### PR TITLE
Implement database AOL and snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +72,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -204,6 +234,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +348,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,14 +377,19 @@ name = "memodb"
 version = "0.8.0"
 dependencies = [
  "arc-swap",
+ "bincode",
  "criterion",
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-skiplist",
+ "lz4",
  "parking_lot",
  "rand",
+ "serde",
  "smallvec",
+ "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -353,6 +435,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "plotters"
@@ -503,6 +591,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,10 +674,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "syn"
@@ -587,6 +697,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -620,10 +743,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,21 @@ license = "Apache-2.0"
 
 [dependencies]
 arc-swap = "1.7.1"
+bincode = { version = "2.0.1", features = ["serde"] }
 crossbeam-deque = "0.8.5"
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
+lz4 = "1.25"
 parking_lot = "0.12.3"
-smallvec = "1.14.0"
+serde = { version = "1.0.219", features = ["derive", "rc"] }
+smallvec = { version = "1.14.0", features = ["serde"] }
 thiserror = "1.0.58"
+tracing = "0.1.41"
 
 [dev-dependencies]
 rand = "0.9.1"
 criterion = { version = "0.5", features = ["html_reports"] }
+tempfile = "3.10"
 
 [[bench]]
 name = "operations"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,130 @@
+// Copyright © SurrealDB Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module stores the compression logic.
+
+use lz4::{Decoder as Lz4Decoder, EncoderBuilder as Lz4EncoderBuilder};
+use std::io::{self, Read, Write};
+use std::io::{BufRead, BufReader, BufWriter};
+
+/// Compression mode for snapshots
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum CompressionMode {
+	/// No compression (default for backward compatibility)
+	#[default]
+	None,
+	/// LZ4 compression (fast compression/decompression)
+	Lz4,
+}
+
+/// Compressed writer wrapper that handles different compression modes
+pub(crate) struct CompressedWriter {
+	inner: Box<dyn Write>,
+}
+
+impl CompressedWriter {
+	/// Create a new compressed writer based on compression mode
+	pub(crate) fn new<W: Write + 'static>(
+		writer: W,
+		compression_mode: CompressionMode,
+	) -> io::Result<Self> {
+		// Determine the compression mode
+		let inner: Box<dyn Write> = match compression_mode {
+			CompressionMode::None => {
+				// Wrap with BufWriter for efficient writing
+				Box::new(BufWriter::new(writer))
+			}
+			CompressionMode::Lz4 => {
+				// LZ4 encoder does its own buffering, so no need for BufWriter
+				let encoder = Lz4EncoderBuilder::new().level(7).build(writer)?;
+				Box::new(encoder)
+			}
+		};
+		// Return the writer
+		Ok(Self {
+			inner,
+		})
+	}
+
+	/// Finish compression (for LZ4, this finalizes the stream)
+	pub(crate) fn finish(self) -> io::Result<()> {
+		// The encoder will be dropped here, which finalizes the stream
+		Ok(())
+	}
+}
+
+impl Write for CompressedWriter {
+	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+		self.inner.write(buf)
+	}
+
+	fn flush(&mut self) -> io::Result<()> {
+		self.inner.flush()
+	}
+}
+
+/// Compressed reader wrapper that handles different compression modes
+pub(crate) struct CompressedReader {
+	inner: Box<dyn Read>,
+}
+
+impl CompressedReader {
+	/// Create a new compressed reader that auto-detects compression mode
+	pub(crate) fn new<R: Read + 'static>(reader: R) -> io::Result<Self> {
+		// Wrap in BufReader to allow peeking at magic bytes
+		let mut buf_reader = BufReader::new(reader);
+		// Detect compression mode by peeking at magic bytes
+		let compression = {
+			// Fill buffer to ensure we can peek at the magic bytes
+			buf_reader.fill_buf()?;
+			// Try to peek at the first 4 bytes without consuming them
+			let buffer = buf_reader.buffer();
+			if buffer.len() >= 4 {
+				// Check for LZ4 magic number (0x184D2204 in little endian)
+				if buffer[0..4] == [0x04, 0x22, 0x4D, 0x18] {
+					CompressionMode::Lz4
+				} else {
+					CompressionMode::None
+				}
+			} else {
+				// If we can't read 4 bytes, assume uncompressed
+				CompressionMode::None
+			}
+		};
+		//
+		tracing::debug!("Detected snapshot compression: {compression:?}");
+		// Create the appropriate decompressor based on detected mode
+		let inner: Box<dyn Read> = match compression {
+			CompressionMode::None => {
+				// For uncompressed data, use the buffered reader as-is
+				Box::new(buf_reader)
+			}
+			CompressionMode::Lz4 => {
+				// For LZ4, wrap the buffered reader with LZ4 decoder
+				let decoder = Lz4Decoder::new(buf_reader)?;
+				Box::new(decoder)
+			}
+		};
+		// Return the reader
+		Ok(Self {
+			inner,
+		})
+	}
+}
+
+impl Read for CompressedReader {
+	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+		self.inner.read(buf)
+	}
+}

--- a/src/err.rs
+++ b/src/err.rs
@@ -14,29 +14,78 @@
 
 //! This module stores the database error types.
 
+use bincode::error::DecodeError as BincodeDecodeError;
+use bincode::error::EncodeError as BincodeEncodeError;
+use std::io::Error as IoError;
+use std::sync::PoisonError;
 use thiserror::Error;
 
 /// The errors which can be emitted from a database.
 #[derive(Error, Debug)]
 pub enum Error {
+	/// A transaction is closed.
 	#[error("Transaction is closed")]
 	TxClosed,
 
+	/// A transaction is not writable.
 	#[error("Transaction is not writable")]
 	TxNotWritable,
 
+	/// A key being inserted already exists.
 	#[error("Key being inserted already exists")]
 	KeyAlreadyExists,
 
+	/// A value being checked was not correct.
 	#[error("Value being checked was not correct")]
 	ValNotExpectedValue,
 
+	/// A read conflict, retry the transaction.
 	#[error("Read conflict, retry the transaction")]
 	KeyReadConflict,
 
+	/// A write conflict, retry the transaction.
 	#[error("Write conflict, retry the transaction")]
 	KeyWriteConflict,
 
+	/// Can not fetch value at a future version.
 	#[error("Can not fetch value at a future version")]
 	VersionInFuture,
+
+	/// A transaction is not persistent.
+	#[error("Transaction is not persistent")]
+	TxCommitNotPersisted(PersistenceError),
+}
+
+/// The errors that can occur during persistence operations.
+#[derive(Error, Debug)]
+pub enum PersistenceError {
+	/// An IO error occurred.
+	#[error("IO error: {0}")]
+	Io(#[from] IoError),
+
+	/// A serialization error occurred.
+	#[error("Serialization error: {0}")]
+	Serialization(#[from] BincodeEncodeError),
+
+	/// A deserialization error occurred.
+	#[error("Deserialization error: {0}")]
+	Deserialization(#[from] BincodeDecodeError),
+
+	/// A lock acquisition failed.
+	#[error("Lock acquisition failed")]
+	LockFailed(String),
+
+	/// A snapshot creation failed.
+	#[error("Snapshot creation failed: {0}")]
+	SnapshotFailed(String),
+
+	/// An AOL append failed.
+	#[error("AOL append failed: {0}")]
+	AppendFailed(String),
+}
+
+impl<T> From<PoisonError<std::sync::MutexGuard<'_, T>>> for PersistenceError {
+	fn from(error: PoisonError<std::sync::MutexGuard<'_, T>>) -> Self {
+		PersistenceError::LockFailed(error.to_string())
+	}
 }

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -16,6 +16,7 @@
 
 use crate::options::DEFAULT_RESET_THRESHOLD;
 use crate::oracle::Oracle;
+use crate::persistence::Persistence;
 use crate::queue::{Commit, Merge};
 use crate::versions::Versions;
 use crate::DatabaseOptions;
@@ -56,6 +57,8 @@ where
 	pub(crate) transaction_merge_injector: Injector<u64>,
 	/// The epoch duration to determine how long to store versioned data
 	pub(crate) garbage_collection_epoch: RwLock<Option<Duration>>,
+	/// Optional persistence handler
+	pub(crate) persistence: RwLock<Option<Arc<Persistence<K, V>>>>,
 	/// Specifies whether background worker threads are enabled
 	pub(crate) background_threads_enabled: AtomicBool,
 	/// Stores a handle to the current transaction cleanup background thread
@@ -87,6 +90,7 @@ where
 			transaction_merge_queue: SkipMap::new(),
 			transaction_merge_injector: Injector::new(),
 			garbage_collection_epoch: RwLock::new(None),
+			persistence: RwLock::new(None),
 			background_threads_enabled: AtomicBool::new(true),
 			transaction_cleanup_handle: RwLock::new(None),
 			garbage_collection_handle: RwLock::new(None),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![allow(clippy::bool_comparison)]
 
+mod compression;
 mod db;
 mod direction;
 mod err;
@@ -21,6 +22,7 @@ mod inner;
 mod iter;
 mod options;
 mod oracle;
+mod persistence;
 mod pool;
 mod queue;
 mod tx;
@@ -36,5 +38,7 @@ pub use self::db::*;
 pub use self::err::*;
 #[doc(inline)]
 pub use self::options::*;
+#[doc(inline)]
+pub use self::persistence::*;
 #[doc(inline)]
 pub use self::tx::*;

--- a/src/options.rs
+++ b/src/options.rs
@@ -48,3 +48,86 @@ impl Default for DatabaseOptions {
 		}
 	}
 }
+
+impl DatabaseOptions {
+	/// Create a new `DatabaseOptions` instance with default settings.
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	/// Set the maximum number of transactions kept in the pool.
+	pub fn with_pool_size(mut self, pool_size: usize) -> Self {
+		self.pool_size = pool_size;
+		self
+	}
+
+	/// Set whether the garbage collector thread is started automatically.
+	pub fn with_enable_gc(mut self, enable: bool) -> Self {
+		self.enable_gc = enable;
+		self
+	}
+
+	/// Set the interval at which the garbage collector wakes up.
+	pub fn with_gc_interval(mut self, interval: Duration) -> Self {
+		self.gc_interval = interval;
+		self
+	}
+
+	/// Set whether the cleanup worker thread is started automatically.
+	pub fn with_enable_cleanup(mut self, enable: bool) -> Self {
+		self.enable_cleanup = enable;
+		self
+	}
+
+	/// Set the interval at which the cleanup worker wakes up.
+	pub fn with_cleanup_interval(mut self, interval: Duration) -> Self {
+		self.cleanup_interval = interval;
+		self
+	}
+
+	/// Set whether the merge worker thread is started automatically.
+	pub fn with_enable_merge_worker(mut self, enable: bool) -> Self {
+		self.enable_merge_worker = enable;
+		self
+	}
+
+	/// Set the threshold after which transaction state maps are reset.
+	pub fn with_reset_threshold(mut self, threshold: usize) -> Self {
+		self.reset_threshold = threshold;
+		self
+	}
+
+	/// Set the interval at which the timestamp oracle resyncs with the system clock.
+	pub fn with_resync_interval(mut self, interval: Duration) -> Self {
+		self.resync_interval = interval;
+		self
+	}
+
+	/// Disable all background worker threads (gc, cleanup, and merge worker).
+	pub fn with_all_workers_disabled(mut self) -> Self {
+		self.enable_gc = false;
+		self.enable_cleanup = false;
+		self.enable_merge_worker = false;
+		self
+	}
+
+	/// Configure for high-performance scenarios with faster intervals and larger thresholds.
+	pub fn with_high_performance(mut self) -> Self {
+		self.pool_size *= 2;
+		self.gc_interval = Duration::from_secs(30);
+		self.cleanup_interval = Duration::from_millis(100);
+		self.reset_threshold *= 2;
+		self.resync_interval = Duration::from_secs(2);
+		self
+	}
+
+	/// Configure for low-resource scenarios with slower intervals and smaller thresholds.
+	pub fn with_low_resource(mut self) -> Self {
+		self.pool_size /= 2;
+		self.gc_interval = Duration::from_secs(120);
+		self.cleanup_interval = Duration::from_millis(500);
+		self.reset_threshold /= 2;
+		self.resync_interval = Duration::from_secs(10);
+		self
+	}
+}

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,965 @@
+// Copyright © SurrealDB Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module stores the database persistence logic.
+
+use crate::compression::CompressedReader;
+use crate::compression::CompressedWriter;
+use crate::compression::CompressionMode;
+use crate::err::PersistenceError;
+use crate::inner::Inner;
+use crate::version::Version;
+use crate::versions::Versions;
+use bincode::config;
+use crossbeam_deque::{Injector, Steal};
+use parking_lot::RwLock;
+use serde::{de::DeserializeOwned, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::io::{BufReader, BufWriter, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+pub type PersistenceResult<T> = Result<T, PersistenceError>;
+
+/// Represents a pending asynchronous append operation
+#[derive(Debug, Clone)]
+pub struct AsyncAppendOperation<K, V> {
+	pub version: u64,
+	pub writeset: BTreeMap<K, Option<Arc<V>>>,
+}
+
+/// Configuration for AOL (Append-Only Log) behavior
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum AolMode {
+	/// Never use AOL
+	#[default]
+	Never,
+	/// Write immediatelyto AOL on every commit
+	SynchronousOnCommit,
+	/// Write asynchronously to AOL on every commit
+	AsynchronousAfterCommit,
+}
+
+/// Configuration for snapshot behavior
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotMode {
+	/// Never use snapshots
+	#[default]
+	Never,
+	/// Periodically snapshot at the given interval
+	Interval(Duration),
+}
+
+/// Configuration for fsync behavior
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum FsyncMode {
+	/// Never call fsync (fastest, least durable)
+	#[default]
+	Never,
+	/// Call fsync after every append operation (slowest, most durable)
+	EveryAppend,
+	/// Call fsync at most once per interval
+	Interval(Duration),
+}
+
+/// Configuration options for persistence
+#[derive(Debug, Clone)]
+pub struct PersistenceOptions {
+	/// Base path for persistence files
+	pub base_path: PathBuf,
+	/// AOL (append-only log) behavior mode
+	pub aol_mode: AolMode,
+	/// Snapshot behavior mode
+	pub snapshot_mode: SnapshotMode,
+	/// Configuration for fsync behavior
+	pub fsync_mode: FsyncMode,
+	/// Path to the append-only log file (relative to base path or absolute)
+	pub aol_path: Option<PathBuf>,
+	/// Path to the snapshot file (relative to base path or absolute)
+	pub snapshot_path: Option<PathBuf>,
+	/// Compression mode for snapshots
+	pub compression_mode: CompressionMode,
+}
+
+impl Default for PersistenceOptions {
+	fn default() -> Self {
+		Self {
+			base_path: PathBuf::from("./data"),
+			aol_mode: AolMode::default(),
+			snapshot_mode: SnapshotMode::default(),
+			fsync_mode: FsyncMode::default(),
+			aol_path: None,
+			snapshot_path: None,
+			compression_mode: CompressionMode::default(),
+		}
+	}
+}
+
+impl PersistenceOptions {
+	/// Create new persistence options with the given base path
+	pub fn new<P: Into<PathBuf>>(base_path: P) -> Self {
+		Self {
+			base_path: base_path.into(),
+			..Self::default()
+		}
+	}
+
+	/// Set the base path for persistence files
+	pub fn with_base_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+		self.base_path = path.into();
+		self
+	}
+
+	/// Set the AOL (append-only log) behavior mode
+	pub fn with_aol_mode(mut self, mode: AolMode) -> Self {
+		self.aol_mode = mode;
+		self
+	}
+
+	/// Set the snapshot behavior mode
+	pub fn with_snapshot_mode(mut self, mode: SnapshotMode) -> Self {
+		self.snapshot_mode = mode;
+		self
+	}
+
+	/// Set the fsync mode
+	pub fn with_fsync_mode(mut self, mode: FsyncMode) -> Self {
+		self.fsync_mode = mode;
+		self
+	}
+
+	/// Set a custom AOL file path
+	pub fn with_aol_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+		self.aol_path = Some(path.into());
+		self
+	}
+
+	/// Set a custom snapshot file path
+	pub fn with_snapshot_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+		self.snapshot_path = Some(path.into());
+		self
+	}
+
+	/// Set the compression mode for snapshots
+	pub fn with_compression(mut self, mode: CompressionMode) -> Self {
+		self.compression_mode = mode;
+		self
+	}
+}
+
+/// A persistence layer for storing and loading database state
+///
+/// This struct handles the persistence of database state through:
+/// - Append-only log (AOL) for recording changes
+/// - Periodic snapshots for efficient recovery
+/// - Background worker for automatic snapshot creation
+#[derive(Clone)]
+pub struct Persistence<K, V>
+where
+	K: Ord + Clone + Debug + Sync + Send + 'static,
+	V: Eq + Clone + Debug + Sync + Send + 'static,
+{
+	/// Reference to the inner database state
+	pub(crate) inner: Arc<Inner<K, V>>,
+	/// File handle for the append-only log (None if AOL is disabled)
+	pub(crate) aol: Option<Arc<Mutex<File>>>,
+	/// Path to the append-only log file (None if AOL is disabled)
+	pub(crate) aol_path: PathBuf,
+	/// Path to the snapshot file
+	pub(crate) snapshot_path: PathBuf,
+	/// AOL (append-only log) behavior mode
+	pub(crate) aol_mode: AolMode,
+	/// Snapshot behavior mode
+	pub(crate) snapshot_mode: SnapshotMode,
+	/// Fsync configuration mode
+	pub(crate) fsync_mode: FsyncMode,
+	/// Compression mode for snapshots
+	pub(crate) compression_mode: CompressionMode,
+	/// Specifies whether background worker threads are enabled
+	pub(crate) background_threads_enabled: Arc<AtomicBool>,
+	/// Handle to the background fsync worker thread (for interval mode)
+	pub(crate) fsync_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
+	/// Handle to the background snapshot worker thread
+	pub(crate) snapshot_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
+	/// Handle to the background async append worker thread
+	pub(crate) appender_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
+	/// Last fsync timestamp for interval mode
+	pub(crate) last_fsync: Arc<Mutex<Instant>>,
+	/// Counter for AOL appends since last fsync
+	pub(crate) pending_syncs: Arc<AtomicU64>,
+	/// Queue for asynchronous append operations
+	pub(crate) async_append_injector: Arc<Injector<AsyncAppendOperation<K, V>>>,
+}
+
+impl<K, V> Persistence<K, V>
+where
+	K: Ord + Clone + Debug + Sync + Send + 'static + Serialize + DeserializeOwned,
+	V: Eq + Clone + Debug + Sync + Send + 'static + Serialize + DeserializeOwned,
+{
+	/// Creates a new persistence layer with custom options
+	///
+	/// # Arguments
+	/// * `options` - Configuration options for persistence
+	/// * `inner` - Reference to the database state
+	///
+	/// # Returns
+	/// * `PersistenceResult<Self>` - The created persistence layer or an error
+	pub fn new_with_options(
+		options: PersistenceOptions,
+		inner: Arc<Inner<K, V>>,
+	) -> PersistenceResult<Self> {
+		// Get the base path from options
+		let base_path = &options.base_path;
+		// Ensure the directory exists
+		fs::create_dir_all(base_path)?;
+		// Determine the specified AOL file path
+		let aol_path = if let Some(path) = options.aol_path {
+			if path.is_absolute() {
+				path
+			} else {
+				base_path.join(path)
+			}
+		} else {
+			base_path.join("aol.bin")
+		};
+		// Determine the specified snapshot file path
+		let snapshot_path = if let Some(path) = options.snapshot_path {
+			if path.is_absolute() {
+				path
+			} else {
+				base_path.join(path)
+			}
+		} else {
+			base_path.join("snapshot.bin")
+		};
+		// Initialize AOL components if enabled
+		let aol = if !matches!(options.aol_mode, AolMode::Never) {
+			// Ensure parent directories exist for AOL path
+			if let Some(parent) = aol_path.parent() {
+				fs::create_dir_all(parent)?;
+			}
+			// Open the AOL file with append mode
+			let file = OpenOptions::new().create(true).append(true).read(true).open(&aol_path)?;
+			Some(Arc::new(Mutex::new(file)))
+		} else {
+			None
+		};
+		// Ensure parent directories exist for snapshot path
+		if let Some(parent) = snapshot_path.parent() {
+			fs::create_dir_all(parent)?;
+		}
+		// Create the persistence instance
+		let this = Self {
+			inner,
+			aol,
+			aol_path,
+			snapshot_path,
+			aol_mode: options.aol_mode,
+			snapshot_mode: options.snapshot_mode,
+			fsync_mode: options.fsync_mode,
+			compression_mode: options.compression_mode,
+			background_threads_enabled: Arc::new(AtomicBool::new(true)),
+			fsync_handle: Arc::new(RwLock::new(None)),
+			snapshot_handle: Arc::new(RwLock::new(None)),
+			appender_handle: Arc::new(RwLock::new(None)),
+			last_fsync: Arc::new(Mutex::new(Instant::now())),
+			pending_syncs: Arc::new(AtomicU64::new(0)),
+			async_append_injector: Arc::new(Injector::new()),
+		};
+		// Load existing data from disk
+		this.load()?;
+		// Start the background snapshot worker if snapshots are enabled
+		this.spawn_snapshot_worker();
+		// Start the fsync worker if needed (only when AOL is enabled)
+		this.spawn_fsync_worker();
+		// Start the async append worker if asynchronous mode is enabled
+		this.spawn_appender_worker();
+		// Return the persistence layer
+		Ok(this)
+	}
+
+	/// Loads the database state from disk
+	///
+	/// This function:
+	/// 1. Loads the latest snapshot if it exists
+	/// 2. Applies any changes from the append-only log
+	fn load(&self) -> PersistenceResult<()> {
+		// Check if snapshot file exists
+		if self.snapshot_path.exists() {
+			// Read and deserialize the snapshot data
+			let file = File::open(&self.snapshot_path)?;
+			// Get the metadata of the snapshot file
+			let metadata = file.metadata()?;
+			// Check if the snapshot file is empty
+			if metadata.len() > 0 {
+				// Create compressed reader that auto-detects compression mode
+				let mut reader = CompressedReader::new(file)?;
+				// Initialize counters for tracking loaded entries
+				let mut count = 0;
+				// Stream reading the snapshot to reduce memory usage
+				loop {
+					// Increment the counter
+					count += 1;
+					// Trace the loading of the snapshot entry
+					tracing::trace!("Loading snapshot entry: {count}");
+					// Type alias for the entry
+					type Entry<K, V> = (K, Vec<(u64, Option<V>)>);
+					// Attempt to decode the next entry, handling EOF gracefully
+					let result: Result<Entry<K, V>, _> =
+						bincode::serde::decode_from_std_read(&mut reader, config::standard());
+					// Detech any end of file errors
+					match result {
+						Ok((k, versions)) => {
+							// Ensure that there are version entries
+							if !versions.is_empty() {
+								// Create a new versions entry
+								let mut entries = Versions::new();
+								// Add all of the version entries
+								for (version, value) in versions.into_iter() {
+									entries.push(Version {
+										version,
+										value: value.map(Arc::new),
+									});
+								}
+								// Insert the entry into the datastore
+								self.inner.datastore.insert(k, RwLock::new(entries));
+							}
+						}
+						Err(e) => match e {
+							// Handle bincode decode errors that indicate EOF
+							bincode::error::DecodeError::Io {
+								inner,
+								..
+							} if inner.kind() == std::io::ErrorKind::UnexpectedEof => {
+								break;
+							}
+							e => return Err(PersistenceError::Deserialization(e)),
+						},
+					}
+				}
+			}
+		}
+		// Check if append-only file exists
+		if self.aol_path.exists() {
+			// Open and read the AOL file
+			let file = File::open(&self.aol_path)?;
+			// Get the metadata of the append-only file
+			let metadata = file.metadata()?;
+			// Check if the append-only file is empty
+			if metadata.len() > 0 {
+				// Create buffered reader for efficient reading
+				let mut reader = BufReader::new(file);
+				// Initialize counters for tracking loaded entries
+				let mut count = 0;
+				// Read and apply each change from the AOL
+				loop {
+					// Increment the counter
+					count += 1;
+					// Trace the loading of the append-only entry
+					tracing::trace!("Loading AOL entry: {count}");
+					// Type alias for the entry
+					type Entry<K, V> = (K, u64, Option<Arc<V>>);
+					// Explicitly type the result to help type inference
+					let result: Result<Entry<K, V>, _> =
+						bincode::serde::decode_from_std_read(&mut reader, config::standard());
+					// Detech any end of file errors
+					match result {
+						Ok((k, version, val)) => {
+							// Check if the key already exists
+							if let Some(entry) = self.inner.datastore.get(&k) {
+								// Update existing key with stored version
+								entry.value().write().push(Version {
+									version,
+									value: val,
+								});
+							} else {
+								// Insert new key with stored version
+								self.inner.datastore.insert(
+									k.clone(),
+									RwLock::new(Versions::from(Version {
+										version,
+										value: val,
+									})),
+								);
+							}
+						}
+						Err(e) => match e {
+							// Handle bincode decode errors that indicate EOF
+							bincode::error::DecodeError::Io {
+								inner,
+								..
+							} if inner.kind() == std::io::ErrorKind::UnexpectedEof => {
+								break;
+							}
+							e => return Err(PersistenceError::Deserialization(e)),
+						},
+					}
+				}
+			}
+		}
+		// Return success
+		Ok(())
+	}
+
+	/// Creates a new snapshot of the current database state
+	///
+	/// This function:
+	/// 1. Captures the current AOL file position as a cutoff point
+	/// 2. Creates a new snapshot file atomically using a temporary file
+	/// 3. Streams data to reduce memory usage
+	/// 4. Truncates AOL only up to the cutoff position, preserving newer entries
+	///
+	/// # Returns
+	/// * `PersistenceResult<()>` - Success or an error
+	pub fn snapshot(&self) -> PersistenceResult<()> {
+		// Create temporary file for atomic swap
+		let temp_path = self.snapshot_path.with_extension("tmp");
+		// Execute snapshot operation in closure for clean error handling
+		let result = (|| -> PersistenceResult<()> {
+			// Create temporary file
+			let file = File::create(&temp_path)?;
+			// Create compressed writer (handles buffering internally)
+			let mut writer = CompressedWriter::new(file, self.compression_mode)?;
+			// Get the current position in the AOL file (if AOL is enabled)
+			let aol_cutoff_position = if let Some(ref aol) = self.aol {
+				aol.lock()?.metadata()?.len()
+			} else {
+				0
+			};
+			// Stream write each key-value pair to reduce memory usage
+			for entry in self.inner.datastore.iter() {
+				// Get all versions for this key
+				let versions = entry.value().read().all_versions();
+				// Ensure that there are version entries
+				if !versions.is_empty() {
+					// Serialize and write this single entry
+					bincode::serde::encode_into_std_write(
+						&(entry.key().clone(), versions),
+						&mut writer,
+						config::standard(),
+					)?;
+				}
+			}
+			// Flush the compressed writer
+			writer.flush()?;
+			// Finish compression (finalizes LZ4 stream)
+			writer.finish()?;
+			// Atomically rename temporary file to actual snapshot
+			fs::rename(&temp_path, &self.snapshot_path)?;
+			// Sync the renamed file to disk for durability
+			{
+				let final_file = File::open(&self.snapshot_path)?;
+				final_file.sync_all()?;
+			}
+			// Truncate AOL only up to the cutoff position
+			Self::truncate(&self.aol, aol_cutoff_position, &self.pending_syncs)?;
+			// All ok
+			Ok(())
+		})();
+		// Clean up temporary file if operation failed
+		if result.is_err() {
+			// Ignore removal errors
+			let _ = fs::remove_file(&temp_path);
+		}
+		// Return the operation result
+		result
+	}
+
+	/// Truncate the AOL file up to the specified position, preserving any data after.
+	fn truncate(
+		aol: &Option<Arc<Mutex<File>>>,
+		position: u64,
+		pending_syncs: &Arc<AtomicU64>,
+	) -> PersistenceResult<()> {
+		// Check that we have a AOL file handle
+		if let Some(ref aol) = aol {
+			// Lock the AOL file
+			let mut file = aol.lock()?;
+			// Get the current file length
+			let file_len = file.metadata()?.len();
+			// Check if there is remaining data
+			if file_len > position {
+				// Generate a unique name for the temporary file
+				let name = format!("aol_truncate_{}.tmp", std::process::id());
+				// Generate the path for the temporary file
+				let path = std::env::temp_dir().join(name);
+				// Execute truncation in a closure for clean error handling
+				let result = (|| -> PersistenceResult<()> {
+					// Create temporary file and copy remaining data
+					{
+						file.seek(SeekFrom::Start(position))?;
+						// Create the temporary file
+						let mut temp = File::create(&path)?;
+						// Copy the remaining data to the temporary file
+						std::io::copy(&mut *file, &mut temp)?;
+						// Sync the temporary file
+						temp.sync_all()?;
+					}
+					// Go to the beginning of the file
+					file.seek(SeekFrom::Start(0))?;
+					// Truncate the AOL file
+					file.set_len(0)?;
+					// Copy data from temporary file
+					{
+						let mut temp = File::open(&path)?;
+						std::io::copy(&mut temp, &mut *file)?;
+					}
+					// Flush the file contents
+					file.flush()?;
+					// All ok
+					Ok(())
+				})();
+				// Delete the temporary file
+				let _ = fs::remove_file(&path);
+				// Return the result
+				result?;
+			} else {
+				// Truncate the AOL file
+				file.set_len(0)?;
+				// Flush the file contents
+				file.flush()?;
+			}
+			// Reset pending syncs if we truncated to beginning
+			if position == 0 {
+				pending_syncs.store(0, Ordering::Release);
+			}
+		}
+		// All ok
+		Ok(())
+	}
+
+	/// Spawns a background worker thread for periodic fsync
+	fn spawn_fsync_worker(&self) {
+		// Check if AOL is enabled
+		if self.aol_mode == AolMode::Never {
+			return;
+		}
+		// Get the specified fsync interval
+		let FsyncMode::Interval(interval) = self.fsync_mode else {
+			return;
+		};
+		// Check if AOL is enabled
+		if let Some(ref aol) = self.aol {
+			// Check if a background thread is already running
+			if self.fsync_handle.read().is_none() {
+				// Clone necessary fields for the worker thread
+				let aol = aol.clone();
+				let pending_syncs = self.pending_syncs.clone();
+				let enabled = self.background_threads_enabled.clone();
+				// Spawn the background worker thread
+				let handle = thread::spawn(move || {
+					// Check whether the persistence process is enabled
+					while enabled.load(Ordering::Acquire) {
+						// Sleep for the configured interval
+						thread::park_timeout(interval);
+						// Check shutdown flag again after waking
+						if !enabled.load(Ordering::Acquire) {
+							break;
+						}
+						// Check if there are pending syncs
+						if pending_syncs.load(Ordering::Acquire) > 0 {
+							if let Ok(file) = aol.lock() {
+								if let Err(e) = file.sync_all() {
+									tracing::error!("Fsync worker error: {e}");
+								} else {
+									pending_syncs.store(0, Ordering::Release);
+								}
+							}
+						}
+					}
+				});
+				// Store and track the thread handle
+				*self.fsync_handle.write() = Some(handle);
+			}
+		}
+	}
+
+	/// Spawns a background worker thread for periodic snapshots
+	///
+	/// The worker thread:
+	/// 1. Sleeps for the configured interval
+	/// 2. Captures the current AOL file position
+	/// 3. Creates a new snapshot
+	/// 4. Truncates AOL up to the cutoff, preserving newer entries
+	fn spawn_snapshot_worker(&self) {
+		// Check if snapshots are enabled
+		if self.snapshot_mode == SnapshotMode::Never {
+			return;
+		}
+		// Only spawn if snapshot interval is configured
+		let SnapshotMode::Interval(interval) = self.snapshot_mode else {
+			return;
+		};
+		// Check if a background thread is already running
+		if self.snapshot_handle.read().is_none() {
+			// Clone necessary fields for the worker thread
+			let db = self.inner.clone();
+			let aol = self.aol.clone();
+			let snapshot_path = self.snapshot_path.clone();
+			let pending_syncs = self.pending_syncs.clone();
+			let enabled = self.background_threads_enabled.clone();
+			let compression = self.compression_mode;
+			// Spawn the background worker thread
+			let handle = thread::spawn(move || {
+				// Check whether the persistence process is enabled
+				while enabled.load(Ordering::Acquire) {
+					// Sleep for the configured interval
+					thread::park_timeout(interval);
+					// Check shutdown flag again after waking
+					if !enabled.load(Ordering::Acquire) {
+						break;
+					}
+					// Create temporary file for atomic swap
+					let temp_path = snapshot_path.with_extension("tmp");
+					// Ensure clean error handling in closure
+					let result = (|| -> Result<(), PersistenceError> {
+						// Create temporary file
+						let file = File::create(&temp_path)?;
+						// Create compressed writer (handles buffering internally)
+						let mut writer = CompressedWriter::new(file, compression)?;
+						// Get the current position in the AOL file before snapshotting (if AOL enabled)
+						let aol_cutoff_position = if let Some(ref aol) = aol {
+							aol.lock()?.metadata()?.len()
+						} else {
+							0
+						};
+						// Stream write each entry to reduce memory usage
+						for entry in db.datastore.iter() {
+							// Get all versions for this key
+							let versions = entry.value().read().all_versions();
+							// Ensure that there are version entries
+							if !versions.is_empty() {
+								// Serialize and write this single entry
+								bincode::serde::encode_into_std_write(
+									&(entry.key().clone(), versions),
+									&mut writer,
+									config::standard(),
+								)?;
+							}
+						}
+						// Flush the compressed writer
+						writer.flush()?;
+						// Finish compression (finalizes LZ4 stream)
+						writer.finish()?;
+						// Atomically rename temporary file
+						fs::rename(&temp_path, &snapshot_path)?;
+						// Sync the renamed file to disk for durability
+						{
+							let final_file = File::open(&snapshot_path)?;
+							final_file.sync_all()?;
+						}
+						// Truncate AOL to the cutoff position
+						Self::truncate(&aol, aol_cutoff_position, &pending_syncs)?;
+						// All ok
+						Ok(())
+					})();
+					// Check if the snapshot operation failed
+					if let Err(e) = result {
+						// Trace the snapshot worker error
+						tracing::error!("Snapshot worker error: {e}");
+						// Clean up temporary file if it exists
+						let _ = fs::remove_file(&temp_path);
+					}
+				}
+			});
+			// Store the worker thread handle
+			*self.snapshot_handle.write() = Some(handle);
+		}
+	}
+
+	/// Spawn the background worker thread for processing async append operations
+	fn spawn_appender_worker(&self) {
+		// Check if asynchronous append mode is enabled
+		if self.aol_mode != AolMode::AsynchronousAfterCommit {
+			return;
+		}
+		// Check if AOL is enabled
+		if let Some(ref aol) = self.aol {
+			// Check if a background thread is already running
+			if self.appender_handle.read().is_none() {
+				// Clone necessary fields for the worker thread
+				let injector = self.async_append_injector.clone();
+				let aol = aol.clone();
+				let fsync_mode = self.fsync_mode;
+				let enabled = self.background_threads_enabled.clone();
+				let pending_syncs = self.pending_syncs.clone();
+				let last_fsync = self.last_fsync.clone();
+				// Spawn the background worker thread
+				let handle = thread::spawn(move || {
+					// Set the batch size and timeout
+					const BATCH_SIZE: usize = 100;
+					const TIMEOUT_MS: u64 = 10;
+					// Initialize the batch vector
+					let mut batch = Vec::with_capacity(BATCH_SIZE);
+					// Check whether the persistence process is enabled
+					while enabled.load(Ordering::Acquire) {
+						// Check shutdown flag again after waking
+						if !enabled.load(Ordering::Acquire) {
+							break;
+						}
+						// Clear the batch
+						batch.clear();
+						// Collect operations into a batch
+						loop {
+							// Check shutdown flag in the inner loop
+							if !enabled.load(Ordering::Acquire) {
+								break;
+							}
+							match injector.steal() {
+								Steal::Retry => {
+									std::thread::yield_now();
+									continue;
+								}
+								Steal::Success(op) => {
+									batch.push(op);
+									if batch.len() == BATCH_SIZE {
+										break;
+									}
+								}
+								Steal::Empty => {
+									// If we have items to append, break
+									if !batch.is_empty() {
+										break;
+									}
+									// Park the thread to wait for work
+									thread::park_timeout(Duration::from_millis(TIMEOUT_MS));
+								}
+							}
+						}
+						// Process the batch if we have operations
+						if !batch.is_empty() {
+							// Ensure clean error handling in closure
+							let result = (|| -> Result<(), PersistenceError> {
+								// Lock the AOL file for writing
+								if let Ok(mut file) = aol.lock() {
+									// Create a new buffer for the AOL file
+									let mut writer = BufWriter::new(&mut *file);
+									// Write all operations in the batch
+									for op in &batch {
+										for (k, v) in &op.writeset {
+											bincode::serde::encode_into_std_write(
+												(k, op.version, v),
+												&mut writer,
+												config::standard(),
+											)?;
+										}
+									}
+									// Flush the buffer to the file on the operating system
+									writer.flush()?;
+									// Drop the writer to release the mutable borrow
+									drop(writer);
+									// Handle fsync based on mode
+									match fsync_mode {
+										// Let the operating system handle syncing to disk
+										FsyncMode::Never => {
+											// No fsync, just increment pending counter
+											pending_syncs.fetch_add(1, Ordering::Release);
+										}
+										// Sync immediately to diskafter every append
+										FsyncMode::EveryAppend => {
+											// Sync immediately
+											file.sync_all()?;
+										}
+										// Force sync to disk at a specified interval
+										FsyncMode::Interval(duration) => {
+											// Check if we should sync based on time
+											let now = Instant::now();
+											// Check if we should sync based on time
+											let should_sync = {
+												// Get the last fsync time
+												let mut last_fsync = last_fsync.lock()?;
+												// Check if the last fsync time is greater than the duration
+												if now.duration_since(*last_fsync) >= duration {
+													// Update the last fsync time
+													*last_fsync = now;
+													true
+												} else {
+													false
+												}
+											};
+											// Check if we should sync
+											if should_sync {
+												// Force sync the AOL file to disk
+												file.sync_all()?;
+												// Reset the pending syncs counter
+												pending_syncs.store(0, Ordering::Release);
+											} else {
+												// Increment the pending syncs counter
+												pending_syncs.fetch_add(1, Ordering::Release);
+											}
+										}
+									}
+								}
+								// All ok
+								Ok(())
+							})();
+							// Check if the async append operation failed
+							if let Err(e) = result {
+								// Trace the snapshot worker error
+								tracing::error!("Async append worker error: {e}");
+							}
+						}
+					}
+				});
+				// Store the thread handle
+				*self.appender_handle.write() = Some(handle);
+			}
+		}
+	}
+}
+
+impl<K, V> Drop for Persistence<K, V>
+where
+	K: Ord + Clone + Debug + Sync + Send + 'static,
+	V: Eq + Clone + Debug + Sync + Send + 'static,
+{
+	/// Cleans up resources when the persistence layer is dropped
+	fn drop(&mut self) {
+		// Signal shutdown to the worker threads
+		self.background_threads_enabled.store(false, Ordering::Release);
+		// Stop the fsync worker if it exists
+		if let Some(handle) = self.fsync_handle.write().take() {
+			handle.thread().unpark();
+			let _ = handle.join();
+		}
+		// Stop the snapshot worker if it exists
+		if let Some(handle) = self.snapshot_handle.write().take() {
+			handle.thread().unpark();
+			let _ = handle.join();
+		}
+		// Stop the async append worker if it exists
+		if let Some(handle) = self.appender_handle.write().take() {
+			handle.thread().unpark();
+			let _ = handle.join();
+		}
+		// Perform final fsync if there are pending syncs
+		if self.aol_mode != AolMode::Never && self.pending_syncs.load(Ordering::Acquire) > 0 {
+			// Try to acquire lock on AOL file
+			if let Some(ref aol) = self.aol {
+				// Lock the AOL file
+				if let Ok(file) = aol.lock() {
+					// Sync file contents to disk
+					let _ = file.sync_all();
+				}
+			}
+		}
+	}
+}
+
+impl<K, V> Persistence<K, V>
+where
+	K: Ord + Clone + Debug + Sync + Send + 'static + Serialize,
+	V: Eq + Clone + Debug + Sync + Send + 'static + Serialize,
+{
+	/// Appends a set of changes to the append-only log
+	///
+	/// # Arguments
+	/// * `version` - The version (timestamp) for these changes
+	/// * `writeset` - Map of key-value changes to append
+	///
+	/// # Returns
+	/// * `PersistenceResult<()>` - Success or an error
+	pub fn append(
+		&self,
+		version: u64,
+		writeset: &BTreeMap<K, Option<Arc<V>>>,
+	) -> PersistenceResult<()> {
+		// Skip AOL writing if AOL is disabled
+		if self.aol_mode == AolMode::Never {
+			return Ok(());
+		}
+		// AOL is enabled, proceed with append logic
+		if let Some(ref aol) = self.aol {
+			// Handle asynchronous AOL mode by queuing the operation
+			if self.aol_mode == AolMode::AsynchronousAfterCommit {
+				// Queue the append operation
+				self.async_append_injector.push(AsyncAppendOperation {
+					version,
+					writeset: writeset.clone(),
+				});
+				// Wake up the async append worker if available
+				if let Some(handle) = self.appender_handle.read().as_ref() {
+					handle.thread().unpark();
+				}
+			}
+			if self.aol_mode == AolMode::SynchronousOnCommit {
+				// Lock the AOL file for writing
+				let mut file = aol.lock()?;
+				// Create a new buffer for the AOL file
+				let mut writer = BufWriter::new(&mut *file);
+				// Serialize and write each change with version
+				for (k, v) in writeset {
+					bincode::serde::encode_into_std_write(
+						(k, version, v),
+						&mut writer,
+						config::standard(),
+					)?;
+				}
+				// Flush the buffer to the file on the operating system
+				writer.flush()?;
+				// Drop the writer to release the mutable borrow
+				drop(writer);
+				// Handle fsync based on mode
+				match self.fsync_mode {
+					// Let the operating system handle syncing to disk
+					FsyncMode::Never => {
+						// No fsync, just increment pending counter
+						self.pending_syncs.fetch_add(1, Ordering::Release);
+					}
+					// Sync immediately to diskafter every append
+					FsyncMode::EveryAppend => {
+						// Sync immediately
+						file.sync_all()?;
+					}
+					// Force sync to disk at a specified interval
+					FsyncMode::Interval(duration) => {
+						// Check if we should sync based on time
+						let now = Instant::now();
+						// Check if we should sync based on time
+						let should_sync = {
+							// Get the last fsync time
+							let mut last_fsync = self.last_fsync.lock()?;
+							// Check if the last fsync time is greater than the duration
+							if now.duration_since(*last_fsync) >= duration {
+								// Update the last fsync time
+								*last_fsync = now;
+								true
+							} else {
+								false
+							}
+						};
+						// Check if we should sync
+						if should_sync {
+							// Force sync the AOL file to disk
+							file.sync_all()?;
+							// Reset the pending syncs counter
+							self.pending_syncs.store(0, Ordering::Release);
+						} else {
+							// Increment the pending syncs counter
+							self.pending_syncs.fetch_add(1, Ordering::Release);
+						}
+					}
+				}
+			}
+		}
+		// All ok
+		Ok(())
+	}
+}

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -26,6 +26,14 @@ impl<V> Versions<V>
 where
 	V: Eq + Clone + Sync + Send + 'static,
 {
+	/// Create a new versions object.
+	#[inline]
+	pub(crate) fn new() -> Self {
+		Versions {
+			inner: SmallVec::new(),
+		}
+	}
+
 	/// Insert a value into its sorted position
 	#[inline]
 	pub(crate) fn insert(&mut self, value: Version<V>) {
@@ -102,5 +110,11 @@ where
 		} else {
 			false
 		}
+	}
+
+	/// Get all versions as a vector of (version, value) tuples.
+	#[inline]
+	pub(crate) fn all_versions(&self) -> Vec<(u64, Option<Arc<V>>)> {
+		self.inner.iter().map(|v| (v.version, v.value.clone())).collect()
 	}
 }

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -1,0 +1,763 @@
+use memodb::{AolMode, Database, DatabaseOptions, FsyncMode, PersistenceOptions, SnapshotMode};
+use std::time::Duration;
+use tempfile::TempDir;
+
+#[test]
+fn test_aol_synchronous_basic() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	// Create database options
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+
+	// Configure synchronous AOL persistence (no snapshots)
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::SynchronousOnCommit)
+		.with_snapshot_mode(SnapshotMode::Never)
+		.with_fsync_mode(FsyncMode::EveryAppend);
+
+	// Create persistent database with AOL mode
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Add some data
+	{
+		let mut tx = db.transaction(true);
+		tx.set("key1".to_string(), "value1".to_string()).unwrap();
+		tx.set("key2".to_string(), "value2".to_string()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Add more data in a separate transaction
+	{
+		let mut tx = db.transaction(true);
+		tx.set("key3".to_string(), "value3".to_string()).unwrap();
+		tx.del("key1".to_string()).unwrap(); // Delete key1
+		tx.commit().unwrap();
+	}
+
+	// Verify data is accessible in current session
+	{
+		let mut tx = db.transaction(false);
+		assert_eq!(tx.get("key1".to_string()).unwrap(), None); // Should be deleted
+		assert_eq!(tx.get("key2".to_string()).unwrap(), Some("value2".to_string()));
+		assert_eq!(tx.get("key3".to_string()).unwrap(), Some("value3".to_string()));
+		tx.cancel().unwrap();
+	}
+
+	// Verify AOL file exists and snapshot doesn't
+	let aol_path = temp_path.join("aol.bin");
+	let snapshot_path = temp_path.join("snapshot.bin");
+
+	assert!(aol_path.exists(), "AOL file should exist");
+	assert!(!snapshot_path.exists(), "Snapshot file should not exist in AOL-only mode");
+
+	std::thread::sleep(Duration::from_millis(250));
+
+	// Verify the AOL file has content
+	let aol_metadata = std::fs::metadata(&aol_path).unwrap();
+	assert!(aol_metadata.len() > 0, "AOL file should not be empty");
+}
+
+#[test]
+fn test_aol_asynchronous_basic() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	// Create database options
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+
+	// Configure asynchronous AOL persistence (no snapshots)
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::AsynchronousAfterCommit)
+		.with_snapshot_mode(SnapshotMode::Never)
+		.with_fsync_mode(FsyncMode::Never);
+
+	// Create persistent database with AOL mode
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Add some data
+	{
+		let mut tx = db.transaction(true);
+		tx.set("key1".to_string(), "value1".to_string()).unwrap();
+		tx.set("key2".to_string(), "value2".to_string()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Add more data in a separate transaction
+	{
+		let mut tx = db.transaction(true);
+		tx.set("key3".to_string(), "value3".to_string()).unwrap();
+		tx.del("key1".to_string()).unwrap(); // Delete key1
+		tx.commit().unwrap();
+	}
+
+	// Verify data is accessible in current session
+	{
+		let mut tx = db.transaction(false);
+		assert_eq!(tx.get("key1".to_string()).unwrap(), None); // Should be deleted
+		assert_eq!(tx.get("key2".to_string()).unwrap(), Some("value2".to_string()));
+		assert_eq!(tx.get("key3".to_string()).unwrap(), Some("value3".to_string()));
+		tx.cancel().unwrap();
+	}
+
+	// Verify AOL file exists and snapshot doesn't
+	let aol_path = temp_path.join("aol.bin");
+	let snapshot_path = temp_path.join("snapshot.bin");
+
+	assert!(aol_path.exists(), "AOL file should exist");
+	assert!(!snapshot_path.exists(), "Snapshot file should not exist in AOL-only mode");
+
+	std::thread::sleep(Duration::from_millis(250));
+
+	// Verify the AOL file has content
+	let aol_metadata = std::fs::metadata(&aol_path).unwrap();
+	assert!(aol_metadata.len() > 0, "AOL file should not be empty");
+}
+
+#[test]
+fn test_aol_recovery() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	// Create database options
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+
+	// Configure AOL persistence
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::SynchronousOnCommit)
+		.with_snapshot_mode(SnapshotMode::Never)
+		.with_fsync_mode(FsyncMode::EveryAppend);
+
+	// Create first database instance and add data
+	{
+		let db: Database<String, String> =
+			Database::new_with_persistence(db_opts.clone(), persistence_opts.clone()).unwrap();
+
+		let mut tx = db.transaction(true);
+		tx.set("recover_key1".to_string(), "recover_value1".to_string()).unwrap();
+		tx.set("recover_key2".to_string(), "recover_value2".to_string()).unwrap();
+		tx.commit().unwrap();
+
+		// Update a key
+		let mut tx = db.transaction(true);
+		tx.set("recover_key1".to_string(), "updated_value1".to_string()).unwrap();
+		tx.set("recover_key3".to_string(), "recover_value3".to_string()).unwrap();
+		tx.commit().unwrap();
+
+		// Delete a key
+		let mut tx = db.transaction(true);
+		tx.del("recover_key2".to_string()).unwrap();
+		tx.commit().unwrap();
+	} // Database drops here, releasing all resources
+
+	// Create second database instance from the same directory (simulates restart)
+	{
+		let db: Database<String, String> =
+			Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+		// Verify data was recovered from AOL
+		let mut tx = db.transaction(false);
+		assert_eq!(tx.get("recover_key1".to_string()).unwrap(), Some("updated_value1".to_string()));
+		assert_eq!(tx.get("recover_key2".to_string()).unwrap(), None); // Should be deleted
+		assert_eq!(tx.get("recover_key3".to_string()).unwrap(), Some("recover_value3".to_string()));
+		tx.cancel().unwrap();
+	}
+}
+
+#[test]
+fn test_aol_fsync_modes() {
+	// Test FsyncMode::EveryAppend
+	{
+		let temp_dir = TempDir::new().unwrap();
+		let temp_path = temp_dir.path();
+
+		let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+		let persistence_opts = PersistenceOptions::new(temp_path)
+			.with_aol_mode(AolMode::SynchronousOnCommit)
+			.with_fsync_mode(FsyncMode::EveryAppend);
+
+		let db: Database<i32, String> =
+			Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+		let mut tx = db.transaction(true);
+		tx.set(1, "fsync_every_append".to_string()).unwrap();
+		tx.commit().unwrap(); // Should fsync immediately
+	}
+
+	// Test FsyncMode::Interval
+	{
+		let temp_dir = TempDir::new().unwrap();
+		let temp_path = temp_dir.path();
+
+		let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+		let persistence_opts = PersistenceOptions::new(temp_path)
+			.with_aol_mode(AolMode::SynchronousOnCommit)
+			.with_fsync_mode(FsyncMode::Interval(Duration::from_millis(100)));
+
+		let db: Database<i32, String> =
+			Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+		let mut tx = db.transaction(true);
+		tx.set(1, "fsync_interval".to_string()).unwrap();
+		tx.commit().unwrap(); // Should not fsync immediately
+
+		// Wait for interval to pass
+		std::thread::sleep(Duration::from_millis(200));
+	}
+
+	// Test FsyncMode::Never
+	{
+		let temp_dir = TempDir::new().unwrap();
+		let temp_path = temp_dir.path();
+
+		let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+		let persistence_opts = PersistenceOptions::new(temp_path)
+			.with_aol_mode(AolMode::SynchronousOnCommit)
+			.with_fsync_mode(FsyncMode::Never);
+
+		let db: Database<i32, String> =
+			Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+		let mut tx = db.transaction(true);
+		tx.set(1, "fsync_never".to_string()).unwrap();
+		tx.commit().unwrap(); // Should never fsync
+	}
+}
+
+#[test]
+fn test_snapshot_manual_creation() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	// Create database options
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+
+	// Configure manual snapshot persistence (no AOL, no automatic snapshots)
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::Never)
+		.with_snapshot_mode(SnapshotMode::Never);
+
+	// Create persistent database
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Add some data
+	{
+		let mut tx = db.transaction(true);
+		tx.set("snap_key1".to_string(), "snap_value1".to_string()).unwrap();
+		tx.set("snap_key2".to_string(), "snap_value2".to_string()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Manually create a snapshot
+	if let Some(persistence) = db.persistence() {
+		persistence.snapshot().unwrap();
+	}
+
+	// Verify snapshot file exists and AOL doesn't
+	let snapshot_path = temp_path.join("snapshot.bin");
+	let aol_path = temp_path.join("aol.bin");
+
+	assert!(snapshot_path.exists(), "Snapshot file should exist");
+	assert!(!aol_path.exists(), "AOL file should not exist in snapshot-only mode");
+
+	// Verify the snapshot file has content
+	let snapshot_metadata = std::fs::metadata(&snapshot_path).unwrap();
+	assert!(snapshot_metadata.len() > 0, "Snapshot file should not be empty");
+}
+
+#[test]
+fn test_snapshot_only_persistence_basic() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	// Create database options
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+
+	// Configure snapshot-only persistence (no AOL)
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::Never)
+		.with_snapshot_mode(SnapshotMode::Interval(Duration::from_secs(60)));
+
+	// Create persistent database with snapshot-only mode
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Add some data
+	{
+		let mut tx = db.transaction(true);
+		tx.put("key1".to_string(), "value1".to_string()).unwrap();
+		tx.put("key2".to_string(), "value2".to_string()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Verify data is accessible in current session
+	{
+		let mut tx = db.transaction(false);
+		assert_eq!(tx.get("key1".to_string()).unwrap(), Some("value1".to_string()));
+		assert_eq!(tx.get("key2".to_string()).unwrap(), Some("value2".to_string()));
+		tx.cancel().unwrap();
+	}
+
+	// Trigger a manual snapshot
+	if let Some(persistence) = db.persistence() {
+		persistence.snapshot().unwrap();
+	}
+
+	// Verify snapshot file exists but AOL file doesn't
+	let snapshot_path = temp_path.join("snapshot.bin");
+	let aol_path = temp_path.join("aol.bin");
+
+	assert!(snapshot_path.exists(), "Snapshot file should exist");
+	assert!(!aol_path.exists(), "AOL file should not exist in snapshot-only mode");
+
+	// Verify the snapshot file has content
+	let snapshot_metadata = std::fs::metadata(&snapshot_path).unwrap();
+	assert!(snapshot_metadata.len() > 0, "Snapshot file should not be empty");
+
+	println!("Successfully created snapshot file with {} bytes", snapshot_metadata.len());
+}
+
+#[test]
+fn test_snapshot_basic() {
+	// Test basic snapshot creation
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::Never)
+		.with_snapshot_mode(SnapshotMode::Never);
+
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Add test data
+	{
+		let mut tx = db.transaction(true);
+		for i in 0..100 {
+			tx.set(format!("key_{i}"), format!("value_{i}_with_some_data")).unwrap();
+		}
+		tx.commit().unwrap();
+	}
+
+	// Create snapshot
+	if let Some(persistence) = db.persistence() {
+		persistence.snapshot().unwrap();
+	}
+
+	// Verify snapshot file exists and has content
+	let snapshot_path = temp_path.join("snapshot.bin");
+	assert!(snapshot_path.exists(), "Snapshot file should exist");
+
+	let metadata = std::fs::metadata(&snapshot_path).unwrap();
+	assert!(metadata.len() > 0, "Snapshot file should not be empty");
+
+	println!("Snapshot size = {} bytes", metadata.len());
+}
+
+#[test]
+fn test_snapshot_recovery() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::Never)
+		.with_snapshot_mode(SnapshotMode::Never);
+
+	// Create first database instance and add data
+	{
+		let db: Database<String, String> =
+			Database::new_with_persistence(db_opts.clone(), persistence_opts.clone()).unwrap();
+
+		// Add initial data
+		{
+			let mut tx = db.transaction(true);
+			tx.set("snapshot_key1".to_string(), "snapshot_value1".to_string()).unwrap();
+			tx.set("snapshot_key2".to_string(), "snapshot_value2".to_string()).unwrap();
+			tx.commit().unwrap();
+		}
+
+		// Update data
+		{
+			let mut tx = db.transaction(true);
+			tx.set("snapshot_key1".to_string(), "updated_snapshot_value1".to_string()).unwrap();
+			tx.set("snapshot_key3".to_string(), "snapshot_value3".to_string()).unwrap();
+			tx.commit().unwrap();
+		}
+
+		// Delete data
+		{
+			let mut tx = db.transaction(true);
+			tx.del("snapshot_key2".to_string()).unwrap();
+			tx.commit().unwrap();
+		}
+
+		// Create snapshot before closing
+		if let Some(persistence) = db.persistence() {
+			persistence.snapshot().unwrap();
+		}
+	} // Database drops here
+
+	// Create second database instance from the same directory (simulates restart)
+	{
+		let db: Database<String, String> =
+			Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+		// Verify data was recovered from snapshot
+		let mut tx = db.transaction(false);
+		assert_eq!(
+			tx.get("snapshot_key1".to_string()).unwrap(),
+			Some("updated_snapshot_value1".to_string())
+		);
+		assert_eq!(tx.get("snapshot_key2".to_string()).unwrap(), None); // Should be deleted
+		assert_eq!(
+			tx.get("snapshot_key3".to_string()).unwrap(),
+			Some("snapshot_value3".to_string())
+		);
+		tx.cancel().unwrap();
+	}
+}
+
+#[test]
+fn test_snapshot_interval() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::Never)
+		.with_snapshot_mode(SnapshotMode::Interval(Duration::from_millis(100)));
+
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Add some data
+	{
+		let mut tx = db.transaction(true);
+		tx.set("interval_key1".to_string(), "interval_value1".to_string()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Wait for snapshot to be created automatically
+	std::thread::sleep(Duration::from_millis(200));
+
+	// Add more data
+	{
+		let mut tx = db.transaction(true);
+		tx.set("interval_key2".to_string(), "interval_value2".to_string()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Wait for another snapshot
+	std::thread::sleep(Duration::from_millis(200));
+
+	// Verify snapshot file exists
+	let snapshot_path = temp_path.join("snapshot.bin");
+	assert!(snapshot_path.exists(), "Snapshot file should exist with interval snapshots");
+}
+
+#[test]
+fn test_combined_aol_and_snapshot() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::SynchronousOnCommit)
+		.with_snapshot_mode(SnapshotMode::Never) // Manual snapshots
+		.with_fsync_mode(FsyncMode::EveryAppend);
+
+	// Create first database instance
+	{
+		let db: Database<String, String> =
+			Database::new_with_persistence(db_opts.clone(), persistence_opts.clone()).unwrap();
+
+		// Add initial data (will go to AOL)
+		{
+			let mut tx = db.transaction(true);
+			tx.set("combined_key1".to_string(), "combined_value1".to_string()).unwrap();
+			tx.set("combined_key2".to_string(), "combined_value2".to_string()).unwrap();
+			tx.commit().unwrap();
+		}
+
+		// Create a snapshot (should truncate AOL)
+		if let Some(persistence) = db.persistence() {
+			persistence.snapshot().unwrap();
+		}
+
+		// Add more data after snapshot (will go to AOL)
+		{
+			let mut tx = db.transaction(true);
+			tx.set("combined_key3".to_string(), "combined_value3".to_string()).unwrap();
+			tx.set("combined_key1".to_string(), "updated_combined_value1".to_string()).unwrap();
+			tx.commit().unwrap();
+		}
+	} // Database drops here
+
+	// Verify both snapshot and AOL files exist
+	let snapshot_path = temp_path.join("snapshot.bin");
+	let aol_path = temp_path.join("aol.bin");
+
+	assert!(snapshot_path.exists(), "Snapshot file should exist");
+	assert!(aol_path.exists(), "AOL file should exist");
+
+	// Create second database instance (simulates restart)
+	{
+		let db: Database<String, String> =
+			Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+		// Verify data was recovered from both snapshot and AOL
+		let mut tx = db.transaction(false);
+		assert_eq!(
+			tx.get("combined_key1".to_string()).unwrap(),
+			Some("updated_combined_value1".to_string())
+		);
+		assert_eq!(
+			tx.get("combined_key2".to_string()).unwrap(),
+			Some("combined_value2".to_string())
+		);
+		assert_eq!(
+			tx.get("combined_key3".to_string()).unwrap(),
+			Some("combined_value3".to_string())
+		);
+		tx.cancel().unwrap();
+	}
+}
+
+#[test]
+fn test_aol_snapshot_with_truncation() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::SynchronousOnCommit)
+		.with_snapshot_mode(SnapshotMode::Never)
+		.with_fsync_mode(FsyncMode::EveryAppend);
+
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Add data that will go to AOL
+	{
+		let mut tx = db.transaction(true);
+		for i in 0..10 {
+			tx.set(format!("key_{}", i), format!("value_{}", i)).unwrap();
+		}
+		tx.commit().unwrap();
+	}
+
+	// Check AOL file size before snapshot
+	let aol_path = temp_path.join("aol.bin");
+	let aol_size_before = std::fs::metadata(&aol_path).unwrap().len();
+	assert!(aol_size_before > 0, "AOL should have content before snapshot");
+
+	// Create snapshot (should truncate AOL)
+	if let Some(persistence) = db.persistence() {
+		persistence.snapshot().unwrap();
+	}
+
+	// Check AOL file size after snapshot (should be much smaller or empty)
+	let aol_size_after = std::fs::metadata(&aol_path).unwrap().len();
+	assert!(aol_size_after < aol_size_before, "AOL should be truncated after snapshot");
+
+	// Add more data after snapshot
+	{
+		let mut tx = db.transaction(true);
+		tx.set("post_snapshot_key".to_string(), "post_snapshot_value".to_string()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Verify snapshot exists
+	let snapshot_path = temp_path.join("snapshot.bin");
+	assert!(snapshot_path.exists(), "Snapshot file should exist");
+
+	// Verify all data is still accessible
+	{
+		let mut tx = db.transaction(false);
+		for i in 0..10 {
+			assert_eq!(tx.get(format!("key_{}", i)).unwrap(), Some(format!("value_{}", i)));
+		}
+		assert_eq!(
+			tx.get("post_snapshot_key".to_string()).unwrap(),
+			Some("post_snapshot_value".to_string())
+		);
+		tx.cancel().unwrap();
+	}
+}
+
+#[test]
+fn test_combined_recovery_complex() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::SynchronousOnCommit)
+		.with_snapshot_mode(SnapshotMode::Never)
+		.with_fsync_mode(FsyncMode::EveryAppend);
+
+	// First session: Add data, snapshot, add more data
+	{
+		let db: Database<String, String> =
+			Database::new_with_persistence(db_opts.clone(), persistence_opts.clone()).unwrap();
+
+		// Phase 1: Add initial data
+		{
+			let mut tx = db.transaction(true);
+			tx.set("phase1_key1".to_string(), "phase1_value1".to_string()).unwrap();
+			tx.set("phase1_key2".to_string(), "phase1_value2".to_string()).unwrap();
+			tx.commit().unwrap();
+		}
+
+		// Phase 2: Update and delete some data
+		{
+			let mut tx = db.transaction(true);
+			tx.set("phase1_key1".to_string(), "updated_phase1_value1".to_string()).unwrap();
+			tx.del("phase1_key2".to_string()).unwrap();
+			tx.set("phase2_key1".to_string(), "phase2_value1".to_string()).unwrap();
+			tx.commit().unwrap();
+		}
+
+		// Create snapshot
+		if let Some(persistence) = db.persistence() {
+			persistence.snapshot().unwrap();
+		}
+
+		// Phase 3: Add data after snapshot
+		{
+			let mut tx = db.transaction(true);
+			tx.set("phase3_key1".to_string(), "phase3_value1".to_string()).unwrap();
+			tx.set("phase1_key1".to_string(), "final_phase1_value1".to_string()).unwrap();
+			tx.commit().unwrap();
+		}
+	} // First session ends
+
+	// Second session: Verify all data is recovered correctly
+	{
+		let db: Database<String, String> =
+			Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+		let mut tx = db.transaction(false);
+		assert_eq!(
+			tx.get("phase1_key1".to_string()).unwrap(),
+			Some("final_phase1_value1".to_string())
+		);
+		assert_eq!(tx.get("phase1_key2".to_string()).unwrap(), None); // Should be deleted
+		assert_eq!(tx.get("phase2_key1".to_string()).unwrap(), Some("phase2_value1".to_string()));
+		assert_eq!(tx.get("phase3_key1".to_string()).unwrap(), Some("phase3_value1".to_string()));
+		tx.cancel().unwrap();
+	}
+}
+
+#[test]
+fn test_custom_file_paths() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	// Create custom subdirectories
+	let aol_dir = temp_path.join("logs");
+	let snapshot_dir = temp_path.join("snapshots");
+	std::fs::create_dir_all(&aol_dir).unwrap();
+	std::fs::create_dir_all(&snapshot_dir).unwrap();
+
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::SynchronousOnCommit)
+		.with_snapshot_mode(SnapshotMode::Never)
+		.with_aol_path(aol_dir.join("custom.aol"))
+		.with_snapshot_path(snapshot_dir.join("custom.snapshot"));
+
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Add some data
+	{
+		let mut tx = db.transaction(true);
+		tx.set("custom_key".to_string(), "custom_value".to_string()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Create snapshot
+	if let Some(persistence) = db.persistence() {
+		persistence.snapshot().unwrap();
+	}
+
+	// Verify files exist at custom paths
+	let custom_aol_path = aol_dir.join("custom.aol");
+	let custom_snapshot_path = snapshot_dir.join("custom.snapshot");
+
+	assert!(custom_aol_path.exists(), "Custom AOL file should exist");
+	assert!(custom_snapshot_path.exists(), "Custom snapshot file should exist");
+}
+
+#[test]
+fn test_persistence_options_builder() {
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	// Test fluent builder pattern
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::AsynchronousAfterCommit)
+		.with_snapshot_mode(SnapshotMode::Interval(Duration::from_secs(1)))
+		.with_fsync_mode(FsyncMode::Interval(Duration::from_millis(500)));
+
+	// Verify the options were set correctly
+	assert_eq!(persistence_opts.aol_mode, AolMode::AsynchronousAfterCommit);
+	assert_eq!(persistence_opts.snapshot_mode, SnapshotMode::Interval(Duration::from_secs(1)));
+	assert_eq!(persistence_opts.fsync_mode, FsyncMode::Interval(Duration::from_millis(500)));
+
+	// Test that database can be created with these options
+	let db_opts = DatabaseOptions::default().with_enable_merge_worker(false);
+	let _db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+}
+
+#[test]
+fn test_readonly_operations_no_persistence() {
+	// Test that read-only operations work even with persistence configured
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	let db_opts = DatabaseOptions::default();
+	let persistence_opts = PersistenceOptions::new(temp_path)
+		.with_aol_mode(AolMode::SynchronousOnCommit)
+		.with_snapshot_mode(SnapshotMode::Never);
+
+	let db: Database<String, String> =
+		Database::new_with_persistence(db_opts, persistence_opts).unwrap();
+
+	// Perform read-only operations (should not trigger persistence)
+	{
+		let mut tx = db.transaction(false);
+		assert_eq!(tx.get("non_existent_key".to_string()).unwrap(), None);
+		assert!(!tx.exists("non_existent_key".to_string()).unwrap());
+		tx.cancel().unwrap();
+	}
+
+	// Verify no persistence files were created for read-only operations
+	let aol_path = temp_path.join("aol.bin");
+	let snapshot_path = temp_path.join("snapshot.bin");
+
+	// AOL file might exist but should be empty, snapshot should not exist
+	if aol_path.exists() {
+		let metadata = std::fs::metadata(&aol_path).unwrap();
+		assert_eq!(metadata.len(), 0, "AOL file should be empty after read-only operations");
+	}
+	assert!(!snapshot_path.exists(), "Snapshot file should not exist after read-only operations");
+}


### PR DESCRIPTION
### Overview

This PR adds comprehensive persistence functionality to MemoDB, implementing both Append-Only Log (AOL) and snapshot-based data durability with configurable modes for different performance/durability trade-offs.

### Features

#### Persistence
- **Append-Only Log (AOL)** - Synchronous/asynchronous modes for durability
- **Snapshots** - Periodic full database state capture
- **Data Recovery** - Automatic recovery from snapshots + AOL on startup
- **AOL Truncation** - Automatic cleanup after snapshots

#### Configuration
- **Fsync Control** - Never/every-append/interval modes
- **LZ4 Compression** - Optional snapshot compression
- **Custom Paths** - Configurable AOL and snapshot file locations
