### PR TITLE
Add bloom filter pre-checks, incremental GC, and scan API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build
         run: cargo build --verbose
@@ -34,21 +34,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Check WASM compilation
         run: cargo check --target wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
 
       - name: Run WASM tests
         run: wasm-pack test --node
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
 
@@ -73,15 +73,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -91,13 +91,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Check benchmarks compile
         run: cargo bench --no-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     name: semver
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
 
   release:
     name: Process Release
@@ -21,16 +21,16 @@ jobs:
     permissions:
       contents: write  # required for creating tags and GitHub releases
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install a TOML parser
         run: |
@@ -71,7 +71,7 @@ jobs:
         run: cargo publish
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Release ${{ steps.version.outputs.version }}

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -1107,11 +1107,9 @@ fn bench_readset_bloom_impact(c: &mut Criterion) {
 
 	for readset_size in [100, 1_000, 10_000].iter() {
 		// Committed transaction wrote 10 keys in the high range
-		let writeset_keys: Vec<Bytes> =
-			(90_000..90_010).map(generate_sequential_key).collect();
+		let writeset_keys: Vec<Bytes> = (90_000..90_010).map(generate_sequential_key).collect();
 		// Current transaction read keys in the low range (no overlap)
-		let readset_keys: Vec<Bytes> =
-			(0..*readset_size).map(generate_sequential_key).collect();
+		let readset_keys: Vec<Bytes> = (0..*readset_size).map(generate_sequential_key).collect();
 		// Build the scenario once
 		let scenario = ReadsetConflictScenario::new(&writeset_keys, &readset_keys);
 
@@ -1147,8 +1145,7 @@ fn bench_readset_bloom_conflict_path(c: &mut Criterion) {
 		// Committed transaction wrote 10 keys that overlap the readset
 		let writeset_keys: Vec<Bytes> = (0..10).map(generate_sequential_key).collect();
 		// Current transaction read keys 0..readset_size (overlap on 0..10)
-		let readset_keys: Vec<Bytes> =
-			(0..*readset_size).map(generate_sequential_key).collect();
+		let readset_keys: Vec<Bytes> = (0..*readset_size).map(generate_sequential_key).collect();
 		// Build the scenario once
 		let scenario = ReadsetConflictScenario::new(&writeset_keys, &readset_keys);
 
@@ -1185,8 +1182,7 @@ fn bench_writeset_bloom_impact(c: &mut Criterion) {
 		let committed_keys: Vec<Bytes> =
 			(90_000..(90_000 + *writeset_size)).map(generate_sequential_key).collect();
 		// Current transaction wrote keys in the low range (no overlap)
-		let current_keys: Vec<Bytes> =
-			(0..*writeset_size).map(generate_sequential_key).collect();
+		let current_keys: Vec<Bytes> = (0..*writeset_size).map(generate_sequential_key).collect();
 		// Build the scenario once
 		let scenario = WritesetConflictScenario::new(&committed_keys, &current_keys);
 
@@ -1220,8 +1216,7 @@ fn bench_writeset_bloom_conflict_path(c: &mut Criterion) {
 	for writeset_size in [10, 100, 1_000].iter() {
 		// Both write to overlapping ranges
 		let committed_keys: Vec<Bytes> = (0..10).map(generate_sequential_key).collect();
-		let current_keys: Vec<Bytes> =
-			(0..*writeset_size).map(generate_sequential_key).collect();
+		let current_keys: Vec<Bytes> = (0..*writeset_size).map(generate_sequential_key).collect();
 		// Build the scenario once
 		let scenario = WritesetConflictScenario::new(&committed_keys, &current_keys);
 

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -17,6 +17,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::hint::black_box;
 use std::sync::Arc;
+use surrealmx::bench_internals::{ReadsetConflictScenario, WritesetConflictScenario};
 use surrealmx::{Database, DatabaseOptions};
 
 const SEED: u64 = 42;
@@ -831,6 +832,508 @@ fn bench_database_options(c: &mut Criterion) {
 	group.finish();
 }
 
+// Callback-based scan benchmarks (scan_for_each vs scan)
+fn bench_scan_for_each(c: &mut Criterion) {
+	let mut group = c.benchmark_group("scan_for_each_vs_vec");
+
+	for entry_count in [1000, 10_000, 100_000].iter() {
+		let db = setup_database_with_sequential_data(*entry_count, 100);
+		let mut seen_limits = std::collections::HashSet::new();
+
+		for scan_limit in [100, 1000, 10_000].iter() {
+			let limit = std::cmp::min(*scan_limit, *entry_count);
+			if !seen_limits.insert(limit) {
+				continue;
+			}
+			let id = format!("{}entries_limit{}", entry_count, limit);
+
+			group.throughput(Throughput::Elements(limit as u64));
+
+			group.bench_with_input(BenchmarkId::new("scan_vec", &id), &limit, |b, &limit| {
+				b.iter(|| {
+					let mut tx = db.transaction(false);
+					let start_key = b"".to_vec();
+					let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
+					let result = tx.scan(start_key..end_key, None, Some(limit)).unwrap();
+					black_box(result);
+					tx.cancel().unwrap();
+				})
+			});
+
+			group.bench_with_input(BenchmarkId::new("scan_for_each", &id), &limit, |b, &limit| {
+				b.iter(|| {
+					let tx = db.transaction(false);
+					let start_key = b"".to_vec();
+					let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
+					let mut count = 0usize;
+					tx.scan_for_each(start_key..end_key, None, Some(limit), |k, v| {
+						black_box((k, v));
+						count += 1;
+						true
+					})
+					.unwrap();
+					black_box(count);
+				})
+			});
+
+			group.bench_with_input(
+				BenchmarkId::new("scan_into_reuse", &id),
+				&limit,
+				|b, &limit| {
+					let mut buf = Vec::with_capacity(limit);
+					b.iter(|| {
+						let tx = db.transaction(false);
+						let start_key = b"".to_vec();
+						let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
+						tx.scan_into(start_key..end_key, None, Some(limit), &mut buf).unwrap();
+						black_box(buf.len());
+					})
+				},
+			);
+		}
+	}
+	group.finish();
+}
+
+// Keys callback benchmarks
+fn bench_keys_for_each(c: &mut Criterion) {
+	let mut group = c.benchmark_group("keys_for_each_vs_vec");
+
+	for entry_count in [1000, 10_000, 100_000].iter() {
+		let db = setup_database_with_sequential_data(*entry_count, 100);
+		let mut seen_limits = std::collections::HashSet::new();
+
+		for scan_limit in [100, 1000, 10_000].iter() {
+			let limit = std::cmp::min(*scan_limit, *entry_count);
+			if !seen_limits.insert(limit) {
+				continue;
+			}
+			let id = format!("{}entries_limit{}", entry_count, limit);
+
+			group.throughput(Throughput::Elements(limit as u64));
+
+			group.bench_with_input(BenchmarkId::new("keys_vec", &id), &limit, |b, &limit| {
+				b.iter(|| {
+					let mut tx = db.transaction(false);
+					let start_key = b"".to_vec();
+					let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
+					let result = tx.keys(start_key..end_key, None, Some(limit)).unwrap();
+					black_box(result);
+					tx.cancel().unwrap();
+				})
+			});
+
+			group.bench_with_input(BenchmarkId::new("keys_for_each", &id), &limit, |b, &limit| {
+				b.iter(|| {
+					let tx = db.transaction(false);
+					let start_key = b"".to_vec();
+					let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
+					let mut count = 0usize;
+					tx.keys_for_each(start_key..end_key, None, Some(limit), |k| {
+						black_box(k);
+						count += 1;
+						true
+					})
+					.unwrap();
+					black_box(count);
+				})
+			});
+
+			group.bench_with_input(
+				BenchmarkId::new("keys_into_reuse", &id),
+				&limit,
+				|b, &limit| {
+					let mut buf = Vec::with_capacity(limit);
+					b.iter(|| {
+						let tx = db.transaction(false);
+						let start_key = b"".to_vec();
+						let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
+						tx.keys_into(start_key..end_key, None, Some(limit), &mut buf).unwrap();
+						black_box(buf.len());
+					})
+				},
+			);
+		}
+	}
+	group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// GC benchmarks: incremental dirty-key GC vs full scan
+// ---------------------------------------------------------------------------
+
+// Sparse dirty keys: large datastore, only a small number of keys updated.
+// Dirty-key GC should be much faster than a full scan because it only visits
+// the keys that were modified, while the full scan iterates the entire
+// datastore.
+fn bench_gc_sparse_dirty(c: &mut Criterion) {
+	let mut group = c.benchmark_group("gc_sparse_dirty");
+	// Fixed number of dirty keys
+	let dirty_count = 100;
+
+	for total_keys in [1_000, 10_000, 100_000].iter() {
+		// Setup helper: create datastore, then overwrite a small subset
+		let setup = || {
+			let db =
+				Database::new_with_options(DatabaseOptions::default().with_all_workers_disabled());
+			// Insert initial data
+			{
+				let mut tx = db.transaction(true);
+				for i in 0..*total_keys {
+					let key = generate_sequential_key(i);
+					let value = generate_sequential_value(i, 100);
+					tx.put(key, value).unwrap();
+				}
+				tx.commit().unwrap();
+			}
+			// Overwrite a small fixed number of keys to create stale versions
+			{
+				let mut tx = db.transaction(true);
+				for i in 0..dirty_count {
+					let key = generate_sequential_key(i);
+					let value = Bytes::from(format!("updated_{:08}", i).into_bytes());
+					tx.set(key, value).unwrap();
+				}
+				tx.commit().unwrap();
+			}
+			db
+		};
+
+		// Dirty-key GC: should stay roughly constant regardless of total keys
+		group.bench_function(
+			BenchmarkId::new("dirty_gc", format!("{}total_{}dirty", total_keys, dirty_count)),
+			|b| {
+				b.iter_batched(
+					setup,
+					|db| {
+						db.run_gc_dirty();
+					},
+					criterion::BatchSize::LargeInput,
+				)
+			},
+		);
+
+		// Full-scan GC: should grow linearly with total keys
+		group.bench_function(
+			BenchmarkId::new("full_gc", format!("{}total_{}dirty", total_keys, dirty_count)),
+			|b| {
+				b.iter_batched(
+					setup,
+					|db| {
+						db.run_gc();
+					},
+					criterion::BatchSize::LargeInput,
+				)
+			},
+		);
+	}
+	group.finish();
+}
+
+// Scaling with dirty ratio: fixed datastore size, varying the fraction of
+// keys that have been updated. Dirty-key GC should scale proportionally to
+// the number of dirty keys, while full scan stays constant.
+fn bench_gc_dirty_ratio(c: &mut Criterion) {
+	let mut group = c.benchmark_group("gc_dirty_ratio");
+	// Fixed datastore size
+	let total_keys = 10_000;
+
+	for dirty_pct in [1, 10, 50].iter() {
+		let dirty_count = total_keys * dirty_pct / 100;
+
+		// Setup helper
+		let setup = || {
+			let db =
+				Database::new_with_options(DatabaseOptions::default().with_all_workers_disabled());
+			// Insert initial data
+			{
+				let mut tx = db.transaction(true);
+				for i in 0..total_keys {
+					let key = generate_sequential_key(i);
+					let value = generate_sequential_value(i, 100);
+					tx.put(key, value).unwrap();
+				}
+				tx.commit().unwrap();
+			}
+			// Overwrite a percentage of keys
+			{
+				let mut tx = db.transaction(true);
+				for i in 0..dirty_count {
+					let key = generate_sequential_key(i);
+					let value = Bytes::from(format!("updated_{:08}", i).into_bytes());
+					tx.set(key, value).unwrap();
+				}
+				tx.commit().unwrap();
+			}
+			db
+		};
+
+		// Dirty-key GC
+		group.bench_function(
+			BenchmarkId::new("dirty_gc", format!("{}pct_dirty", dirty_pct)),
+			|b| {
+				b.iter_batched(
+					setup,
+					|db| {
+						db.run_gc_dirty();
+					},
+					criterion::BatchSize::LargeInput,
+				)
+			},
+		);
+
+		// Full-scan GC
+		group.bench_function(BenchmarkId::new("full_gc", format!("{}pct_dirty", dirty_pct)), |b| {
+			b.iter_batched(
+				setup,
+				|db| {
+					db.run_gc();
+				},
+				criterion::BatchSize::LargeInput,
+			)
+		});
+	}
+	group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Bloom filter impact: direct with-bloom vs without-bloom comparison
+// ---------------------------------------------------------------------------
+
+// Readset conflict detection: bloom filter vs exact HashSet intersection.
+// Isolates just the conflict check cost with disjoint keys (no conflict).
+fn bench_readset_bloom_impact(c: &mut Criterion) {
+	let mut group = c.benchmark_group("readset_bloom_impact");
+
+	for readset_size in [100, 1_000, 10_000].iter() {
+		// Committed transaction wrote 10 keys in the high range
+		let writeset_keys: Vec<Bytes> =
+			(90_000..90_010).map(generate_sequential_key).collect();
+		// Current transaction read keys in the low range (no overlap)
+		let readset_keys: Vec<Bytes> =
+			(0..*readset_size).map(generate_sequential_key).collect();
+		// Build the scenario once
+		let scenario = ReadsetConflictScenario::new(&writeset_keys, &readset_keys);
+
+		// With bloom filter pre-check
+		group.bench_function(
+			BenchmarkId::new("with_bloom", format!("{}reads", readset_size)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.check_with_bloom());
+				})
+			},
+		);
+
+		// Without bloom filter (exact HashSet intersection)
+		group.bench_function(
+			BenchmarkId::new("without_bloom", format!("{}reads", readset_size)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.check_without_bloom());
+				})
+			},
+		);
+	}
+	group.finish();
+}
+
+// Readset conflict detection with actual conflict present.
+// The bloom filter says "maybe" and falls through to the exact check.
+fn bench_readset_bloom_conflict_path(c: &mut Criterion) {
+	let mut group = c.benchmark_group("readset_bloom_conflict_path");
+
+	for readset_size in [100, 1_000, 10_000].iter() {
+		// Committed transaction wrote 10 keys that overlap the readset
+		let writeset_keys: Vec<Bytes> = (0..10).map(generate_sequential_key).collect();
+		// Current transaction read keys 0..readset_size (overlap on 0..10)
+		let readset_keys: Vec<Bytes> =
+			(0..*readset_size).map(generate_sequential_key).collect();
+		// Build the scenario once
+		let scenario = ReadsetConflictScenario::new(&writeset_keys, &readset_keys);
+
+		// With bloom (bloom says "maybe", falls through)
+		group.bench_function(
+			BenchmarkId::new("with_bloom", format!("{}reads", readset_size)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.check_with_bloom());
+				})
+			},
+		);
+
+		// Without bloom (exact check directly)
+		group.bench_function(
+			BenchmarkId::new("without_bloom", format!("{}reads", readset_size)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.check_without_bloom());
+				})
+			},
+		);
+	}
+	group.finish();
+}
+
+// Writeset conflict detection: bloom + min/max vs sorted merge.
+// Isolates just the conflict check cost with disjoint keys (no conflict).
+fn bench_writeset_bloom_impact(c: &mut Criterion) {
+	let mut group = c.benchmark_group("writeset_bloom_impact");
+
+	for writeset_size in [10, 100, 1_000].iter() {
+		// Committed transaction wrote keys in the high range
+		let committed_keys: Vec<Bytes> =
+			(90_000..(90_000 + *writeset_size)).map(generate_sequential_key).collect();
+		// Current transaction wrote keys in the low range (no overlap)
+		let current_keys: Vec<Bytes> =
+			(0..*writeset_size).map(generate_sequential_key).collect();
+		// Build the scenario once
+		let scenario = WritesetConflictScenario::new(&committed_keys, &current_keys);
+
+		// With bloom filter + min/max pre-check
+		group.bench_function(
+			BenchmarkId::new("with_bloom", format!("{}writes", writeset_size)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.check_with_bloom());
+				})
+			},
+		);
+
+		// Without bloom (sorted merge only)
+		group.bench_function(
+			BenchmarkId::new("without_bloom", format!("{}writes", writeset_size)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.check_without_bloom());
+				})
+			},
+		);
+	}
+	group.finish();
+}
+
+// Writeset conflict detection with actual conflict present.
+fn bench_writeset_bloom_conflict_path(c: &mut Criterion) {
+	let mut group = c.benchmark_group("writeset_bloom_conflict_path");
+
+	for writeset_size in [10, 100, 1_000].iter() {
+		// Both write to overlapping ranges
+		let committed_keys: Vec<Bytes> = (0..10).map(generate_sequential_key).collect();
+		let current_keys: Vec<Bytes> =
+			(0..*writeset_size).map(generate_sequential_key).collect();
+		// Build the scenario once
+		let scenario = WritesetConflictScenario::new(&committed_keys, &current_keys);
+
+		// With bloom (bloom says "maybe", falls through to sorted merge)
+		group.bench_function(
+			BenchmarkId::new("with_bloom", format!("{}writes", writeset_size)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.check_with_bloom());
+				})
+			},
+		);
+
+		// Without bloom (sorted merge only)
+		group.bench_function(
+			BenchmarkId::new("without_bloom", format!("{}writes", writeset_size)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.check_without_bloom());
+				})
+			},
+		);
+	}
+	group.finish();
+}
+
+// Concurrent SSI throughput: N threads each reading and writing disjoint
+// key ranges, all under SSI. The bloom filter speeds up the conflict-check
+// loop over the commit queue because each thread's writeset is disjoint
+// from every other thread's readset.
+fn bench_bloom_concurrent_throughput(c: &mut Criterion) {
+	let mut group = c.benchmark_group("bloom_concurrent_throughput");
+	// Use a reasonable thread count
+	let cpu_cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+	let thread_counts = [2, 4, cpu_cores.min(8)];
+
+	for &thread_count in thread_counts.iter() {
+		// Each thread gets a disjoint key range of 1000 keys
+		let keys_per_thread = 1000;
+		let total_keys = thread_count * keys_per_thread;
+		let db = Arc::new(setup_database_with_sequential_data(total_keys, 64));
+
+		// SSI mode
+		group.throughput(Throughput::Elements(thread_count as u64));
+		group.bench_function(BenchmarkId::new("ssi", format!("{}threads", thread_count)), |b| {
+			b.iter(|| {
+				let handles: Vec<_> = (0..thread_count)
+					.map(|t| {
+						let db = Arc::clone(&db);
+						std::thread::spawn(move || {
+							let range_start = t * keys_per_thread;
+							let mut tx =
+								db.transaction(true).with_serializable_snapshot_isolation();
+							// Read 100 keys in our range
+							for i in range_start..(range_start + 100) {
+								tx.get(generate_sequential_key(i)).unwrap();
+							}
+							// Write 10 keys in our range
+							for i in range_start..(range_start + 10) {
+								tx.set(
+									generate_sequential_key(i),
+									Bytes::from("updated".as_bytes().to_vec()),
+								)
+								.unwrap();
+							}
+							tx.commit().unwrap();
+						})
+					})
+					.collect();
+				for h in handles {
+					h.join().unwrap();
+				}
+			})
+		});
+
+		// SI baseline for comparison
+		group.bench_function(
+			BenchmarkId::new("si_baseline", format!("{}threads", thread_count)),
+			|b| {
+				b.iter(|| {
+					let handles: Vec<_> = (0..thread_count)
+						.map(|t| {
+							let db = Arc::clone(&db);
+							std::thread::spawn(move || {
+								let range_start = t * keys_per_thread;
+								let mut tx = db.transaction(true).with_snapshot_isolation();
+								// Read 100 keys in our range
+								for i in range_start..(range_start + 100) {
+									tx.get(generate_sequential_key(i)).unwrap();
+								}
+								// Write 10 keys in our range
+								for i in range_start..(range_start + 10) {
+									tx.set(
+										generate_sequential_key(i),
+										Bytes::from("updated".as_bytes().to_vec()),
+									)
+									.unwrap();
+								}
+								tx.commit().unwrap();
+							})
+						})
+						.collect();
+					for h in handles {
+						h.join().unwrap();
+					}
+				})
+			},
+		);
+	}
+	group.finish();
+}
+
 criterion_group!(
 	database_benchmarks,
 	bench_transaction_creation,
@@ -860,9 +1363,23 @@ criterion_group!(
 
 criterion_group!(configuration_benchmarks, bench_database_options);
 
+criterion_group!(
+	optimization_benchmarks,
+	bench_scan_for_each,
+	bench_keys_for_each,
+	bench_gc_sparse_dirty,
+	bench_gc_dirty_ratio,
+	bench_readset_bloom_impact,
+	bench_readset_bloom_conflict_path,
+	bench_writeset_bloom_impact,
+	bench_writeset_bloom_conflict_path,
+	bench_bloom_concurrent_throughput
+);
+
 criterion_main!(
 	database_benchmarks,
 	scan_benchmarks,
 	concurrent_benchmarks,
-	configuration_benchmarks
+	configuration_benchmarks,
+	optimization_benchmarks
 );

--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -1,0 +1,138 @@
+// Copyright © SurrealDB Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Internal helpers for benchmarking conflict detection with and without
+//! bloom filter pre-checks. Not part of the public API.
+
+use crate::bloom::BloomFilter;
+use crate::queue::Commit;
+use bytes::Bytes;
+use papaya::HashSet;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// A prepared readset conflict scenario for benchmarking
+pub struct ReadsetConflictScenario {
+	/// The committed transaction entry
+	commit: Arc<Commit>,
+	/// The transaction readset
+	readset: HashSet<Bytes>,
+	/// The bloom filter over the readset
+	readset_bloom: BloomFilter,
+}
+
+impl ReadsetConflictScenario {
+	/// Build a scenario with the given writeset and readset keys
+	pub fn new(writeset_keys: &[Bytes], readset_keys: &[Bytes]) -> Self {
+		// Build the writeset BTreeMap
+		let mut ws = BTreeMap::new();
+		for k in writeset_keys {
+			ws.insert(k.clone(), Some(Bytes::from_static(b"v")));
+		}
+		// Build the writeset bloom filter
+		let mut writeset_bloom = BloomFilter::new();
+		for k in ws.keys() {
+			writeset_bloom.insert(k);
+		}
+		// Extract min and max keys
+		let min_key = ws.keys().next().cloned().unwrap_or_default();
+		let max_key = ws.keys().next_back().cloned().unwrap_or_default();
+		// Build the commit entry
+		let commit = Arc::new(Commit {
+			id: 1,
+			writeset: Arc::new(ws),
+			writeset_bloom,
+			min_key,
+			max_key,
+		});
+		// Build the readset and bloom filter
+		let readset = HashSet::new();
+		let mut readset_bloom = BloomFilter::new();
+		{
+			let pin = readset.pin();
+			for k in readset_keys {
+				pin.insert(k.clone());
+				readset_bloom.insert(k);
+			}
+		}
+		Self {
+			commit,
+			readset,
+			readset_bloom,
+		}
+	}
+
+	/// Check readset disjointness WITH bloom filter pre-check
+	pub fn check_with_bloom(&self) -> bool {
+		self.commit.is_disjoint_readset_bloom(&self.readset, &self.readset_bloom)
+	}
+
+	/// Check readset disjointness WITHOUT bloom filter (exact check only)
+	pub fn check_without_bloom(&self) -> bool {
+		self.commit.is_disjoint_readset(&self.readset)
+	}
+}
+
+/// A prepared writeset conflict scenario for benchmarking
+pub struct WritesetConflictScenario {
+	/// The committed transaction entry
+	committed: Arc<Commit>,
+	/// The current transaction entry
+	current: Arc<Commit>,
+}
+
+impl WritesetConflictScenario {
+	/// Build a scenario with two writesets
+	pub fn new(committed_keys: &[Bytes], current_keys: &[Bytes]) -> Self {
+		Self {
+			committed: Arc::new(Self::build_commit(committed_keys, 1)),
+			current: Arc::new(Self::build_commit(current_keys, 2)),
+		}
+	}
+
+	/// Check writeset disjointness WITH bloom filter + min/max pre-check
+	pub fn check_with_bloom(&self) -> bool {
+		self.committed.is_disjoint_writeset_bloom(&self.current)
+	}
+
+	/// Check writeset disjointness WITHOUT bloom filter (sorted merge only)
+	pub fn check_without_bloom(&self) -> bool {
+		self.committed.is_disjoint_writeset(&self.current)
+	}
+
+	/// Build a Commit entry from a set of keys
+	fn build_commit(keys: &[Bytes], id: u64) -> Commit {
+		// Build the writeset BTreeMap
+		let mut ws = BTreeMap::new();
+		for k in keys {
+			ws.insert(k.clone(), Some(Bytes::from_static(b"v")));
+		}
+		// Build the writeset bloom filter
+		let mut writeset_bloom = BloomFilter::new();
+		for k in ws.keys() {
+			writeset_bloom.insert(k);
+		}
+		// Extract min and max keys
+		let min_key = ws.keys().next().cloned().unwrap_or_default();
+		let max_key = ws.keys().next_back().cloned().unwrap_or_default();
+		// Build the commit entry
+		Commit {
+			id,
+			writeset: Arc::new(ws),
+			writeset_bloom,
+			min_key,
+			max_key,
+		}
+	}
+}

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -1,0 +1,150 @@
+// Copyright © SurrealDB Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A lightweight bloom filter for probabilistic set membership testing.
+
+const BLOOM_BITS: usize = 4096;
+const BLOOM_BYTES: usize = BLOOM_BITS / 8;
+const NUM_HASHES: u32 = 3;
+
+pub(crate) struct BloomFilter {
+	/// The bit array backing the bloom filter
+	bits: [u8; BLOOM_BYTES],
+	/// The number of keys inserted into the filter
+	count: usize,
+}
+
+impl BloomFilter {
+	/// Create a new empty bloom filter
+	pub fn new() -> Self {
+		BloomFilter {
+			bits: [0; BLOOM_BYTES],
+			count: 0,
+		}
+	}
+
+	/// Insert a key into the bloom filter
+	#[inline]
+	pub fn insert(&mut self, key: &[u8]) {
+		// Compute the dual hash for this key
+		let h = Self::hash(key);
+		// Set all k hash positions in the bit array
+		for i in 0..NUM_HASHES {
+			let bit = Self::nth_hash(h, i) % (BLOOM_BITS as u64);
+			self.bits[(bit / 8) as usize] |= 1 << (bit % 8);
+		}
+		// Increment the insert counter
+		self.count += 1;
+	}
+
+	/// Check whether a key may be present in the filter
+	#[inline]
+	pub fn may_contain(&self, key: &[u8]) -> bool {
+		// Fast path: empty filter contains nothing
+		if self.count == 0 {
+			return false;
+		}
+		// Compute the dual hash for this key
+		let h = Self::hash(key);
+		// Check all k hash positions in the bit array
+		for i in 0..NUM_HASHES {
+			let bit = Self::nth_hash(h, i) % (BLOOM_BITS as u64);
+			if self.bits[(bit / 8) as usize] & (1 << (bit % 8)) == 0 {
+				return false;
+			}
+		}
+		// All bits are set, so the key may be present
+		true
+	}
+
+	/// Check whether the filter is empty
+	pub fn is_empty(&self) -> bool {
+		self.count == 0
+	}
+
+	/// Reset the filter to its initial empty state
+	pub fn clear(&mut self) {
+		self.bits = [0; BLOOM_BYTES];
+		self.count = 0;
+	}
+
+	/// Compute a dual FNV-1a hash for double hashing
+	#[inline]
+	fn hash(key: &[u8]) -> (u64, u64) {
+		// Compute the primary FNV-1a hash
+		let mut h1: u64 = 0xcbf29ce484222325;
+		for &b in key {
+			h1 ^= b as u64;
+			h1 = h1.wrapping_mul(0x100000001b3);
+		}
+		// Derive the secondary hash via multiplication and rotation
+		let h2 = h1.wrapping_mul(0x9e3779b97f4a7c15).rotate_left(31);
+		// Return the dual hash pair
+		(h1, h2)
+	}
+
+	/// Compute the nth hash from the dual hash pair
+	#[inline]
+	fn nth_hash(hashes: (u64, u64), n: u32) -> u64 {
+		hashes.0.wrapping_add((n as u64).wrapping_mul(hashes.1))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn empty_filter_contains_nothing() {
+		let bf = BloomFilter::new();
+		assert!(bf.is_empty());
+		assert!(!bf.may_contain(b"hello"));
+		assert!(!bf.may_contain(b"world"));
+	}
+
+	#[test]
+	fn inserted_keys_are_found() {
+		let mut bf = BloomFilter::new();
+		bf.insert(b"hello");
+		bf.insert(b"world");
+		assert!(!bf.is_empty());
+		assert!(bf.may_contain(b"hello"));
+		assert!(bf.may_contain(b"world"));
+	}
+
+	#[test]
+	fn missing_keys_usually_not_found() {
+		let mut bf = BloomFilter::new();
+		for i in 0..100u32 {
+			bf.insert(&i.to_le_bytes());
+		}
+		let mut false_positives = 0;
+		for i in 1000..2000u32 {
+			if bf.may_contain(&i.to_le_bytes()) {
+				false_positives += 1;
+			}
+		}
+		assert!(false_positives < 100, "too many false positives: {}", false_positives);
+	}
+
+	#[test]
+	fn clear_resets_filter() {
+		let mut bf = BloomFilter::new();
+		bf.insert(b"hello");
+		assert!(bf.may_contain(b"hello"));
+		bf.clear();
+		assert!(bf.is_empty());
+		assert!(!bf.may_contain(b"hello"));
+	}
+}

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -14,6 +14,8 @@
 
 //! This module stores the compression logic.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use lz4::{Decoder as Lz4Decoder, EncoderBuilder as Lz4EncoderBuilder};
 use std::io::{self, Read, Write};
 use std::io::{BufRead, BufReader, BufWriter};

--- a/src/db.rs
+++ b/src/db.rs
@@ -213,12 +213,14 @@ impl Database {
 
 	/// Manually perform garbage collection of stale record versions.
 	///
-	/// This function performs a full datastore scan to clean up old versions
-	/// across all keys. Note that inline garbage collection happens
-	/// automatically during transaction commits, but only for keys being
-	/// modified. This function is useful for cleaning up stale versions on
-	/// keys that haven't been recently modified, or when automatic background
-	/// GC is disabled via [`DatabaseOptions::enable_gc`].
+	/// This function first processes keys that are known to have stale
+	/// versions (tracked during transaction commits), then performs a full
+	/// datastore scan to clean up any remaining old versions. Note that
+	/// inline garbage collection happens automatically during transaction
+	/// commits, but only for keys being modified. This function is useful
+	/// for cleaning up stale versions on keys that haven't been recently
+	/// modified, or when automatic background GC is disabled via
+	/// [`DatabaseOptions::enable_gc`].
 	pub fn run_gc(&self) {
 		// Get the current time in nanoseconds
 		let now = self.oracle.current_time_ns();
@@ -231,11 +233,55 @@ impl Database {
 		// Use the earlier of history cutoff or earliest transaction to protect active
 		// transactions
 		let cleanup_ts = history_cutoff.min(earliest_tx);
-		// Iterate over the entire tree
+		// First, process keys known to have stale versions
+		self.run_gc_dirty_inner(cleanup_ts);
+		// Then perform a full datastore scan for any remaining stale versions
+		self.run_gc_full(cleanup_ts);
+	}
+
+	/// Process only dirty keys that are known to have stale versions.
+	///
+	/// This is a lightweight alternative to a full datastore scan, useful
+	/// for frequent incremental cleanup between full GC passes.
+	pub fn run_gc_dirty(&self) {
+		// Get the current time in nanoseconds
+		let now = self.oracle.current_time_ns();
+		// Get the garbage collection epoch as nanoseconds
+		let history = self.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
+		// Calculate the history cutoff (current time - history duration)
+		let history_cutoff = now.saturating_sub(history as u64);
+		// Get the earliest active transaction version
+		let earliest_tx = self.counter_by_oracle.front().map(|e| *e.key()).unwrap_or(now);
+		// Use the earlier of history cutoff or earliest transaction to protect active
+		// transactions
+		let cleanup_ts = history_cutoff.min(earliest_tx);
+		// Process dirty keys
+		self.run_gc_dirty_inner(cleanup_ts);
+	}
+
+	fn run_gc_dirty_inner(&self, cleanup_ts: u64) {
+		// Drain all keys from the dirty queue
+		while let Some(key) = self.gc_dirty_keys.pop() {
+			// Check if this key still exists in the datastore
+			if let Some(entry) = self.datastore.get(&key) {
+				// Get a mutable reference to the versions list
+				let mut versions = entry.value().write();
+				// Clean up unnecessary older versions
+				if versions.gc_older_versions(cleanup_ts) == 0 {
+					// Drop the version reference
+					drop(versions);
+					// Remove the entry from the datastore
+					self.datastore.remove(&key);
+				}
+			}
+		}
+	}
+
+	fn run_gc_full(&self, cleanup_ts: u64) {
+		// Iterate over the entire datastore
 		for entry in self.datastore.iter() {
-			// Fetch the entry value
+			// Get a mutable reference to the versions list
 			let versions = entry.value();
-			// Modify the version entries
 			let mut versions = versions.write();
 			// Clean up unnecessary older versions
 			if versions.gc_older_versions(cleanup_ts) == 0 {
@@ -333,8 +379,11 @@ impl Database {
 		if db.garbage_collection_handle.read().is_none() {
 			// Get the specified interval
 			let interval = self.gc_interval;
+			// Full scan runs every 4th wake cycle; dirty-key pass runs every cycle
+			const FULL_SCAN_FREQUENCY: u64 = 4;
 			// Spawn a new thread to handle periodic garbage collection
 			let handle = std::thread::spawn(move || {
+				let mut cycle: u64 = 0;
 				// Check whether the garbage collection process is enabled
 				while db.background_threads_enabled.load(Ordering::Relaxed) {
 					// Wait for a specified time interval
@@ -354,18 +403,36 @@ impl Database {
 					// Use the earlier of history cutoff or earliest transaction to protect active
 					// transactions
 					let cleanup_ts = history_cutoff.min(earliest_tx);
-					// Iterate over the entire tree
-					for entry in db.datastore.iter() {
-						// Fetch the entry value
-						let versions = entry.value();
-						// Modify the version entries
-						let mut versions = versions.write();
-						// Clean up unnecessary older versions
-						if versions.gc_older_versions(cleanup_ts) == 0 {
-							// Drop the version reference
-							drop(versions);
-							// Remove the entry from the datastore
-							db.datastore.remove(entry.key());
+					// Drain all keys from the dirty queue (incremental GC)
+					while let Some(key) = db.gc_dirty_keys.pop() {
+						// Check if this key still exists in the datastore
+						if let Some(entry) = db.datastore.get(&key) {
+							// Get a mutable reference to the versions list
+							let mut versions = entry.value().write();
+							// Clean up unnecessary older versions
+							if versions.gc_older_versions(cleanup_ts) == 0 {
+								// Drop the version reference
+								drop(versions);
+								// Remove the entry from the datastore
+								db.datastore.remove(&key);
+							}
+						}
+					}
+					// Periodically do a full datastore scan
+					cycle += 1;
+					if cycle.is_multiple_of(FULL_SCAN_FREQUENCY) {
+						// Iterate over the entire datastore
+						for entry in db.datastore.iter() {
+							// Get a mutable reference to the versions list
+							let versions = entry.value();
+							let mut versions = versions.write();
+							// Clean up unnecessary older versions
+							if versions.gc_older_versions(cleanup_ts) == 0 {
+								// Drop the version reference
+								drop(versions);
+								// Remove the entry from the datastore
+								db.datastore.remove(entry.key());
+							}
 						}
 					}
 				}

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -21,6 +21,7 @@ use crate::queue::{Commit, Merge};
 use crate::versions::Versions;
 use crate::DatabaseOptions;
 use bytes::Bytes;
+use crossbeam_queue::SegQueue;
 use crossbeam_skiplist::SkipMap;
 use parking_lot::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64};
@@ -62,6 +63,8 @@ pub struct Inner {
 	/// Stores a handle to the current garbage collection background thread
 	#[cfg(not(target_arch = "wasm32"))]
 	pub(crate) garbage_collection_handle: RwLock<Option<JoinHandle<()>>>,
+	/// Keys with stale versions pending incremental garbage collection
+	pub(crate) gc_dirty_keys: SegQueue<Bytes>,
 	/// Threshold after which transaction state is reset
 	pub(crate) reset_threshold: usize,
 }
@@ -87,6 +90,7 @@ impl Inner {
 			transaction_cleanup_handle: RwLock::new(None),
 			#[cfg(not(target_arch = "wasm32"))]
 			garbage_collection_handle: RwLock::new(None),
+			gc_dirty_keys: SegQueue::new(),
 			reset_threshold: opts.reset_threshold,
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 pub const LOG_TARGET_CONFLICTS: &str = "surrealmx::conflicts";
 
 mod bloom;
-#[cfg(not(target_arch = "wasm32"))]
 mod compression;
 mod cursor;
 mod db;
@@ -29,7 +28,6 @@ mod iter;
 mod kv;
 mod options;
 mod oracle;
-#[cfg(not(target_arch = "wasm32"))]
 mod persistence;
 mod pool;
 mod queue;
@@ -40,7 +38,6 @@ mod versions;
 #[doc(inline)]
 pub use bytes::Bytes;
 
-#[cfg(not(target_arch = "wasm32"))]
 #[doc(inline)]
 pub use self::compression::*;
 #[doc(inline)]
@@ -55,7 +52,6 @@ pub use self::err::*;
 pub use self::kv::*;
 #[doc(inline)]
 pub use self::options::*;
-#[cfg(not(target_arch = "wasm32"))]
 #[doc(inline)]
 pub use self::persistence::*;
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,6 @@ pub mod bench_internals;
 pub use bytes::Bytes;
 
 #[doc(inline)]
-pub use self::compression::*;
-#[doc(inline)]
 pub use self::cursor::*;
 #[doc(inline)]
 pub use self::db::*;
@@ -56,6 +54,11 @@ pub use self::kv::*;
 #[doc(inline)]
 pub use self::options::*;
 #[doc(inline)]
-pub use self::persistence::*;
-#[doc(inline)]
 pub use self::tx::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(inline)]
+pub use self::compression::*;
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(inline)]
+pub use self::persistence::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 /// Tracing target for transaction conflict diagnostics
 pub const LOG_TARGET_CONFLICTS: &str = "surrealmx::conflicts";
 
+mod bloom;
 #[cfg(not(target_arch = "wasm32"))]
 mod compression;
 mod cursor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ mod tx;
 mod version;
 mod versions;
 
+#[doc(hidden)]
+pub mod bench_internals;
+
 #[doc(inline)]
 pub use bytes::Bytes;
 

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -14,6 +14,8 @@
 
 //! This module stores the database persistence logic.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use crate::compression::CompressedReader;
 use crate::compression::CompressedWriter;
 use crate::compression::CompressionMode;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -14,6 +14,7 @@
 
 //! This module stores the transaction commit and merge queues.
 
+use crate::bloom::BloomFilter;
 use crate::LOG_TARGET_CONFLICTS;
 use bytes::Bytes;
 use papaya::HashSet;
@@ -27,6 +28,12 @@ pub struct Commit {
 	pub(crate) id: u64,
 	/// The local set of updates and deletes
 	pub(crate) writeset: Arc<BTreeMap<Bytes, Option<Bytes>>>,
+	/// Bloom filter over writeset keys for fast conflict pre-checks
+	pub(crate) writeset_bloom: BloomFilter,
+	/// The smallest key in the writeset (for range overlap checks)
+	pub(crate) min_key: Bytes,
+	/// The largest key in the writeset (for range overlap checks)
+	pub(crate) max_key: Bytes,
 }
 
 /// A transaction entry in the transaction merge queue
@@ -38,6 +45,29 @@ pub struct Merge {
 }
 
 impl Commit {
+	/// Returns true if self has no elements in common with other.
+	/// Uses a bloom filter for a fast pre-check before the exact intersection.
+	pub fn is_disjoint_readset_bloom(&self, other: &HashSet<Bytes>, bloom: &BloomFilter) -> bool {
+		// Fast path: if the bloom filter is empty, there are no reads to conflict with
+		if bloom.is_empty() {
+			return true;
+		}
+		// Check writeset keys against the bloom filter first
+		let mut any_possible = false;
+		for key in self.writeset.keys() {
+			if bloom.may_contain(key) {
+				any_possible = true;
+				break;
+			}
+		}
+		// If no writeset key passes the bloom filter, there is definitely no overlap
+		if !any_possible {
+			return true;
+		}
+		// Fall through to exact check
+		self.is_disjoint_readset(other)
+	}
+
 	/// Returns true if self has no elements in common with other
 	pub fn is_disjoint_readset(&self, other: &HashSet<Bytes>) -> bool {
 		// Pin the readset for access
@@ -69,6 +99,38 @@ impl Commit {
 		}
 		// No overlap was found
 		true
+	}
+
+	/// Returns true if self has no elements in common with other.
+	/// Uses bloom filters and key bounds for fast pre-checks before the
+	/// exact sorted merge.
+	pub fn is_disjoint_writeset_bloom(&self, other: &Arc<Commit>) -> bool {
+		// Fast path: check if the key ranges overlap at all
+		if self.max_key < other.min_key || other.max_key < self.min_key {
+			return true;
+		}
+		// Check our writeset keys against the other's bloom filter
+		let mut any_possible = false;
+		for key in self.writeset.keys() {
+			if other.writeset_bloom.may_contain(key) {
+				any_possible = true;
+				break;
+			}
+		}
+		// If no key passes the bloom filter, there is definitely no overlap
+		if !any_possible {
+			return true;
+		}
+		// Fall through to exact check
+		self.is_disjoint_writeset(other)
+	}
+
+	/// Returns true if this commit's writeset may contain keys within the
+	/// given range. Uses the min/max key bounds for a fast range overlap
+	/// check before iterating writeset keys for scan conflict detection.
+	pub fn may_overlap_range(&self, range_start: &Bytes, range_end: &Bytes) -> bool {
+		// Check if the writeset key range overlaps the scan range
+		self.min_key < *range_end && self.max_key >= *range_start
 	}
 
 	/// Returns true if self has no elements in common with other

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -14,6 +14,7 @@
 
 //! This module stores the database transaction logic.
 
+use crate::bloom::BloomFilter;
 use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
@@ -30,6 +31,7 @@ use bytes::Bytes;
 use crossbeam_skiplist::SkipMap;
 use papaya::HashSet;
 use parking_lot::RwLock;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::ops::Range;
@@ -546,6 +548,8 @@ pub(crate) struct TransactionInner {
 	pub(crate) version: u64,
 	/// The local set of key reads
 	pub(crate) readset: HashSet<Bytes>,
+	/// Bloom filter over the readset for fast conflict pre-checks
+	pub(crate) readset_bloom: RefCell<BloomFilter>,
 	/// The local set of key scans
 	pub(crate) scanset: SkipMap<Bytes, ArcSwap<Bytes>>,
 	/// The local set of updates and deletes
@@ -603,6 +607,7 @@ impl TransactionInner {
 			commit,
 			version,
 			readset: HashSet::new(),
+			readset_bloom: RefCell::new(BloomFilter::new()),
 			scanset: SkipMap::new(),
 			writeset: BTreeMap::new(),
 			database: db,
@@ -659,6 +664,8 @@ impl TransactionInner {
 		self.scanset.clear();
 		// Clear the transaction readset
 		self.readset.pin().clear();
+		// Clear the readset bloom filter
+		self.readset_bloom.borrow_mut().clear();
 		// Clear or completely reset the allocated writeset
 		match self.writeset.len() > threshold {
 			true => self.writeset = BTreeMap::new(),
@@ -697,6 +704,7 @@ impl TransactionInner {
 		self.done = true;
 		// Clear the transaction state
 		self.readset.pin().clear();
+		self.readset_bloom.borrow_mut().clear();
 		self.scanset.clear();
 		self.writeset.clear();
 		// Clear savepoint stack
@@ -793,6 +801,7 @@ impl TransactionInner {
 			// Clear the transaction state
 			self.scanset.clear();
 			self.readset.pin().clear();
+			self.readset_bloom.borrow_mut().clear();
 			// Clear savepoint stack
 			self.savepoint_stack.clear();
 			// Continue
@@ -800,22 +809,34 @@ impl TransactionInner {
 		}
 		// Take ownership over the local modifications
 		let writeset = Arc::new(std::mem::take(&mut self.writeset));
+		// Build a bloom filter over the writeset keys
+		let mut writeset_bloom = BloomFilter::new();
+		for key in writeset.keys() {
+			writeset_bloom.insert(key);
+		}
+		// Extract the min and max keys from the writeset
+		let min_key = writeset.keys().next().cloned().unwrap_or_default();
+		let max_key = writeset.keys().next_back().cloned().unwrap_or_default();
 		// Insert this transaction into the commit queue
 		let (version, entry) = self.atomic_commit(Commit {
 			writeset: writeset.clone(),
 			id: self.database.transaction_queue_id.fetch_add(1, Ordering::AcqRel) + 1,
+			writeset_bloom,
+			min_key,
+			max_key,
 		});
 		// Check wether we should check reads conflicts on commit
 		if self.mode >= IsolationLevel::SnapshotIsolation {
 			// Retrieve all transactions committed since we began
 			for tx in self.database.transaction_commit_queue.range(self.commit + 1..version) {
 				// Check if a previous transaction conflicts against writes
-				if !tx.value().is_disjoint_writeset(&entry) {
+				if !tx.value().is_disjoint_writeset_bloom(&entry) {
 					// Remove the transaction from the commit queue
 					self.database.transaction_commit_queue.remove(&version);
 					// Clear the transaction state
 					self.scanset.clear();
 					self.readset.pin().clear();
+					self.readset_bloom.borrow_mut().clear();
 					self.writeset.clear();
 					// Clear savepoint stack
 					self.savepoint_stack.clear();
@@ -825,19 +846,35 @@ impl TransactionInner {
 				// Check if we should check for conflicting read keys
 				if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 					// Check if a previous transaction conflicts against reads
-					if !tx.value().is_disjoint_readset(&self.readset) {
+					if !tx
+						.value()
+						.is_disjoint_readset_bloom(&self.readset, &self.readset_bloom.borrow())
+					{
 						// Remove the transaction from the commit queue
 						self.database.transaction_commit_queue.remove(&version);
 						// Clear the transaction state
 						self.scanset.clear();
 						self.readset.pin().clear();
+						self.readset_bloom.borrow_mut().clear();
 						self.writeset.clear();
 						// Clear savepoint stack
 						self.savepoint_stack.clear();
 						// Return the error for this transaction
 						return Err(Error::KeyReadConflict);
 					}
+					// Check if the committed transaction's key range overlaps any scan range
+					let scan_overlap = if let Some(scan_front) = self.scanset.front() {
+						if let Some(scan_back) = self.scanset.back() {
+							let scan_max_end = Arc::clone(&scan_back.value().load());
+							tx.value().may_overlap_range(scan_front.key(), &scan_max_end)
+						} else {
+							false
+						}
+					} else {
+						false
+					};
 					// A previous transaction has conflicts against scans
+					if scan_overlap {
 					for k in tx.value().writeset.keys() {
 						// Check if this key may be within a scan range
 						if let Some(entry) = self.scanset.range::<Bytes, _>(..=k).next_back() {
@@ -847,6 +884,7 @@ impl TransactionInner {
 								self.database.transaction_commit_queue.remove(&version);
 								// Clear the transaction state
 								self.readset.pin().clear();
+								self.readset_bloom.borrow_mut().clear();
 								self.scanset.clear();
 								self.writeset.clear();
 								// Clear savepoint stack
@@ -858,6 +896,7 @@ impl TransactionInner {
 								return Err(Error::KeyReadConflict);
 							}
 						}
+					}
 					}
 				}
 			}
@@ -919,6 +958,7 @@ impl TransactionInner {
 				// Clear the transaction state
 				self.scanset.clear();
 				self.readset.pin().clear();
+				self.readset_bloom.borrow_mut().clear();
 				self.writeset.clear();
 				// Clear savepoint stack
 				self.savepoint_stack.clear();
@@ -931,6 +971,7 @@ impl TransactionInner {
 		// Clear the transaction state
 		self.scanset.clear();
 		self.readset.pin().clear();
+		self.readset_bloom.borrow_mut().clear();
 		self.writeset.clear();
 		// Clear savepoint stack
 		self.savepoint_stack.clear();
@@ -961,6 +1002,7 @@ impl TransactionInner {
 					let res = self.exists_in_datastore(lookup, self.version);
 					// Check whether we should track key reads
 					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+						self.readset_bloom.borrow_mut().insert(lookup);
 						self.readset.pin().insert(key.into_bytes());
 					}
 					// Return the result
@@ -1020,6 +1062,7 @@ impl TransactionInner {
 					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 						let guard = self.readset.pin();
 						if !guard.contains(lookup) {
+							self.readset_bloom.borrow_mut().insert(lookup);
 							guard.insert(key.into_bytes());
 						}
 					}
@@ -1085,6 +1128,7 @@ impl TransactionInner {
 							if self.mode >= IsolationLevel::SerializableSnapshotIsolation
 								&& !self.readset.pin().contains(lookup)
 							{
+								self.readset_bloom.borrow_mut().insert(lookup);
 								self.readset.pin().insert(key.into_bytes());
 							}
 							// Return the result

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -938,6 +938,10 @@ impl TransactionInner {
 						version,
 						value,
 					});
+					// If stale versions remain, mark this key for background GC
+					if len > 1 {
+						self.database.gc_dirty_keys.push(key.clone());
+					}
 				}
 			} else {
 				self.database.datastore.insert(

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -378,6 +378,70 @@ impl Transaction {
 	}
 
 	// --------------------------------------------------
+	// Callback and buffer-based scan API
+	// --------------------------------------------------
+
+	/// Call a closure for each key-value pair in a range, avoiding intermediate
+	/// Vec allocation. Return `false` from the closure to stop iteration early.
+	pub fn scan_for_each<K, F>(
+		&self,
+		rng: Range<K>,
+		skip: Option<usize>,
+		limit: Option<usize>,
+		f: F,
+	) -> Result<usize, Error>
+	where
+		K: IntoBytes,
+		F: FnMut(&Bytes, &Bytes) -> bool,
+	{
+		self.inner.as_ref().unwrap().scan_for_each(rng, skip, limit, f)
+	}
+
+	/// Call a closure for each key in a range, avoiding intermediate Vec
+	/// allocation. Return `false` from the closure to stop iteration early.
+	pub fn keys_for_each<K, F>(
+		&self,
+		rng: Range<K>,
+		skip: Option<usize>,
+		limit: Option<usize>,
+		f: F,
+	) -> Result<usize, Error>
+	where
+		K: IntoBytes,
+		F: FnMut(&Bytes) -> bool,
+	{
+		self.inner.as_ref().unwrap().keys_for_each(rng, skip, limit, f)
+	}
+
+	/// Scan key-value pairs into a caller-provided Vec, reusing its capacity.
+	pub fn scan_into<K>(
+		&self,
+		rng: Range<K>,
+		skip: Option<usize>,
+		limit: Option<usize>,
+		buf: &mut Vec<(Bytes, Bytes)>,
+	) -> Result<(), Error>
+	where
+		K: IntoBytes,
+	{
+		self.inner.as_ref().unwrap().scan_into(rng, skip, limit, buf)
+	}
+
+	/// Scan keys into a caller-provided Vec, reusing its capacity.
+	pub fn keys_into<K>(
+		&self,
+		rng: Range<K>,
+		skip: Option<usize>,
+		limit: Option<usize>,
+		buf: &mut Vec<Bytes>,
+	) -> Result<(), Error>
+	where
+		K: IntoBytes,
+	{
+		self.inner.as_ref().unwrap().keys_into(rng, skip, limit, buf)
+	}
+
+	// --------------------------------------------------
 	// Cursor and Iterator API
 	// --------------------------------------------------
 
@@ -862,8 +926,9 @@ impl TransactionInner {
 						// Return the error for this transaction
 						return Err(Error::KeyReadConflict);
 					}
-					// Check if the committed transaction's key range overlaps any scan range
+					// Check if the committed writeset may overlap any scan range
 					let scan_overlap = if let Some(scan_front) = self.scanset.front() {
+						// Get the upper bound of the last scan range
 						if let Some(scan_back) = self.scanset.back() {
 							let scan_max_end = Arc::clone(&scan_back.value().load());
 							tx.value().may_overlap_range(scan_front.key(), &scan_max_end)
@@ -873,30 +938,31 @@ impl TransactionInner {
 					} else {
 						false
 					};
-					// A previous transaction has conflicts against scans
+					// Only iterate writeset keys if ranges may overlap
 					if scan_overlap {
-					for k in tx.value().writeset.keys() {
-						// Check if this key may be within a scan range
-						if let Some(entry) = self.scanset.range::<Bytes, _>(..=k).next_back() {
-							// Check if the range includes this key (load from ArcSwap)
-							if **entry.value().load() > *k {
-								// Remove the transaction from the commit queue
-								self.database.transaction_commit_queue.remove(&version);
-								// Clear the transaction state
-								self.readset.pin().clear();
-								self.readset_bloom.borrow_mut().clear();
-								self.scanset.clear();
-								self.writeset.clear();
-								// Clear savepoint stack
-								self.savepoint_stack.clear();
-								// Log the error for debug purposes
-								#[cfg(debug_assertions)]
-								debug!(target: LOG_TARGET_CONFLICTS, "KeyReadConflict involving {:?}", k);
-								// Return the error for this transaction
-								return Err(Error::KeyReadConflict);
+						// A previous transaction has conflicts against scans
+						for k in tx.value().writeset.keys() {
+							// Check if this key may be within a scan range
+							if let Some(entry) = self.scanset.range::<Bytes, _>(..=k).next_back() {
+								// Check if the range includes this key (load from ArcSwap)
+								if **entry.value().load() > *k {
+									// Remove the transaction from the commit queue
+									self.database.transaction_commit_queue.remove(&version);
+									// Clear the transaction state
+									self.readset.pin().clear();
+									self.readset_bloom.borrow_mut().clear();
+									self.scanset.clear();
+									self.writeset.clear();
+									// Clear savepoint stack
+									self.savepoint_stack.clear();
+									// Log the error for debug purposes
+									#[cfg(debug_assertions)]
+									debug!(target: LOG_TARGET_CONFLICTS, "KeyReadConflict involving {:?}", k);
+									// Return the error for this transaction
+									return Err(Error::KeyReadConflict);
+								}
 							}
 						}
-					}
 					}
 				}
 			}
@@ -1496,6 +1562,286 @@ impl TransactionInner {
 		K: IntoBytes,
 	{
 		self.scan_all_versions_any(rng, skip, limit, self.version)
+	}
+
+	/// Call a closure for each key-value pair in a range
+	pub fn scan_for_each<K, F>(
+		&self,
+		rng: Range<K>,
+		skip: Option<usize>,
+		limit: Option<usize>,
+		mut f: F,
+	) -> Result<usize, Error>
+	where
+		K: IntoBytes,
+		F: FnMut(&Bytes, &Bytes) -> bool,
+	{
+		// Check to see if transaction is closed
+		if self.done == true {
+			return Err(Error::TxClosed);
+		}
+		// Initialise the entry counter
+		let mut count = 0;
+		// Compute the range
+		let beg = &rng.start.into_bytes();
+		let end = &rng.end.into_bytes();
+		// Calculate how many items to skip
+		let skip = skip.unwrap_or_default();
+		// Check whether we should track range scan reads
+		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+			self.track_scan_range(beg, end);
+		}
+		// Build combined writeset from merge queue entries only.
+		// Fast path: skip entirely when the merge queue is empty (common case).
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
+			if self.database.transaction_merge_queue.is_empty() {
+				BTreeMap::new()
+			} else {
+				let mut ws = BTreeMap::new();
+				for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
+					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+						ws.entry(k.clone()).or_insert_with(|| v.clone());
+					}
+				}
+				ws
+			};
+		// Create the 3-way merge iterator
+		let iter = MergeIterator::new(
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			combined_writeset,
+			self.writeset.range::<Bytes, _>(beg..end),
+			Direction::Forward,
+			self.version,
+			skip,
+		);
+		// Process entries, calling the closure for each pair
+		for (key, val) in iter {
+			// Only include non-deleted entries
+			if let Some(val) = &val {
+				count += 1;
+				// Call the closure and stop if it returns false
+				if !f(&key, val) {
+					break;
+				}
+				// Check limit
+				if let Some(l) = limit {
+					if count >= l {
+						break;
+					}
+				}
+			}
+		}
+		// Return the number of entries processed
+		Ok(count)
+	}
+
+	/// Call a closure for each key in a range
+	pub fn keys_for_each<K, F>(
+		&self,
+		rng: Range<K>,
+		skip: Option<usize>,
+		limit: Option<usize>,
+		mut f: F,
+	) -> Result<usize, Error>
+	where
+		K: IntoBytes,
+		F: FnMut(&Bytes) -> bool,
+	{
+		// Check to see if transaction is closed
+		if self.done == true {
+			return Err(Error::TxClosed);
+		}
+		// Initialise the entry counter
+		let mut count = 0;
+		// Compute the range
+		let beg = &rng.start.into_bytes();
+		let end = &rng.end.into_bytes();
+		// Calculate how many items to skip
+		let skip = skip.unwrap_or_default();
+		// Check whether we should track range scan reads
+		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+			self.track_scan_range(beg, end);
+		}
+		// Build combined writeset from merge queue entries only.
+		// Fast path: skip entirely when the merge queue is empty (common case).
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
+			if self.database.transaction_merge_queue.is_empty() {
+				BTreeMap::new()
+			} else {
+				let mut ws = BTreeMap::new();
+				for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
+					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+						ws.entry(k.clone()).or_insert_with(|| v.clone());
+					}
+				}
+				ws
+			};
+		// Create the 3-way merge iterator
+		let mut iter = MergeIterator::new(
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			combined_writeset,
+			self.writeset.range::<Bytes, _>(beg..end),
+			Direction::Forward,
+			self.version,
+			skip,
+		);
+		// Process entries, calling the closure for each key
+		while let Some((key, exists)) = iter.next_key() {
+			if exists {
+				count += 1;
+				// Call the closure and stop if it returns false
+				if !f(&key) {
+					break;
+				}
+				// Check limit
+				if let Some(l) = limit {
+					if count >= l {
+						break;
+					}
+				}
+			}
+		}
+		// Return the number of entries processed
+		Ok(count)
+	}
+
+	/// Scan key-value pairs into a caller-provided Vec
+	pub fn scan_into<K>(
+		&self,
+		rng: Range<K>,
+		skip: Option<usize>,
+		limit: Option<usize>,
+		buf: &mut Vec<(Bytes, Bytes)>,
+	) -> Result<(), Error>
+	where
+		K: IntoBytes,
+	{
+		// Clear the output buffer, reusing its capacity
+		buf.clear();
+		// Check to see if transaction is closed
+		if self.done == true {
+			return Err(Error::TxClosed);
+		}
+		// Compute the range
+		let beg = &rng.start.into_bytes();
+		let end = &rng.end.into_bytes();
+		// Calculate how many items to skip
+		let skip = skip.unwrap_or_default();
+		// Check whether we should track range scan reads
+		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+			self.track_scan_range(beg, end);
+		}
+		// Build combined writeset from merge queue entries only.
+		// Fast path: skip entirely when the merge queue is empty (common case).
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
+			if self.database.transaction_merge_queue.is_empty() {
+				BTreeMap::new()
+			} else {
+				let mut ws = BTreeMap::new();
+				for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
+					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+						ws.entry(k.clone()).or_insert_with(|| v.clone());
+					}
+				}
+				ws
+			};
+		// Create the 3-way merge iterator
+		let iter = MergeIterator::new(
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			combined_writeset,
+			self.writeset.range::<Bytes, _>(beg..end),
+			Direction::Forward,
+			self.version,
+			skip,
+		);
+		// Process entries into the output buffer
+		for (key, val) in iter {
+			// Only include non-deleted entries
+			if let Some(val) = val {
+				buf.push((key, val));
+				// Check limit
+				if let Some(l) = limit {
+					if buf.len() >= l {
+						break;
+					}
+				}
+			}
+		}
+		// Continue
+		Ok(())
+	}
+
+	/// Scan keys into a caller-provided Vec
+	pub fn keys_into<K>(
+		&self,
+		rng: Range<K>,
+		skip: Option<usize>,
+		limit: Option<usize>,
+		buf: &mut Vec<Bytes>,
+	) -> Result<(), Error>
+	where
+		K: IntoBytes,
+	{
+		// Clear the output buffer, reusing its capacity
+		buf.clear();
+		// Check to see if transaction is closed
+		if self.done == true {
+			return Err(Error::TxClosed);
+		}
+		// Compute the range
+		let beg = &rng.start.into_bytes();
+		let end = &rng.end.into_bytes();
+		// Calculate how many items to skip
+		let skip = skip.unwrap_or_default();
+		// Check whether we should track range scan reads
+		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+			self.track_scan_range(beg, end);
+		}
+		// Build combined writeset from merge queue entries only.
+		// Fast path: skip entirely when the merge queue is empty (common case).
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
+			if self.database.transaction_merge_queue.is_empty() {
+				BTreeMap::new()
+			} else {
+				let mut ws = BTreeMap::new();
+				for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
+					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+						ws.entry(k.clone()).or_insert_with(|| v.clone());
+					}
+				}
+				ws
+			};
+		// Create the 3-way merge iterator
+		let mut iter = MergeIterator::new(
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			combined_writeset,
+			self.writeset.range::<Bytes, _>(beg..end),
+			Direction::Forward,
+			self.version,
+			skip,
+		);
+		// Process entries into the output buffer
+		while let Some((key, exists)) = iter.next_key() {
+			if exists {
+				buf.push(key);
+				// Check limit
+				if let Some(l) = limit {
+					if buf.len() >= l {
+						break;
+					}
+				}
+			}
+		}
+		// Continue
+		Ok(())
 	}
 
 	/// Helper to track a scan range in the scanset (optimized to minimize


### PR DESCRIPTION
## Summary

- **Bloom filter** (4096-bit, FNV-1a, 3 hash functions) for fast probabilistic disjointness checks on readset, writeset, and scan conflict detection paths
- **Min/max key bounds** on `Commit` entries for O(1) range overlap pre-checks before scan conflict iteration
- **Incremental GC** via dirty-key queue — lightweight per-cycle drain with full datastore scan every 4th cycle
- **Callback/buffer scan API** — `scan_for_each`, `keys_for_each`, `scan_into`, `keys_into` to avoid intermediate `Vec` allocations
- **Wasm cfg cleanup** — move `#[cfg(not(target_arch = "wasm32"))]` from `lib.rs` into `compression.rs`/`persistence.rs` as inner attributes
- **Benchmarks** — with-bloom vs without-bloom conflict detection, scan API comparison, and GC benchmarks

### Benchmark results (bloom filter impact)

**Writeset conflict detection (no conflict, disjoint keys):**

| Writeset size | With bloom | Without bloom | Speedup |
|---|---|---|---|
| 10 keys | 4.6 ns | 28 ns | **6x** |
| 100 keys | 4.6 ns | 271 ns | **59x** |
| 1,000 keys | 4.5 ns | 2,684 ns | **596x** |

**Readset conflict detection (no conflict, disjoint keys):**

| Readset size | With bloom | Without bloom | Speedup |
|---|---|---|---|
| 100 reads | 58 ns | 156 ns | **2.7x** |

Conflict path overhead is a constant ~8–10 ns per check.

## Test plan

- [x] All 128 unit tests + 25 test suites pass
- [x] Clippy clean (`--all-targets --all-features -D warnings`)
- [x] Benchmarks compile and run (`cargo bench --bench operations`)
- [ ] Verify wasm32 target still compiles