### PR TITLE
Fast path scan/keys/total when there's nothing to merge

### DIFF
--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1889,7 +1889,7 @@ impl TransactionInner {
 		let beg = &rng.start.into_bytes();
 		let end = &rng.end.into_bytes();
 		// Calculate how many items to skip
-		let skip = skip.unwrap_or_default();
+		let mut skip = skip.unwrap_or_default();
 		// Check wether we should track range scan reads
 		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 			// Track scans if scanning the latest version
@@ -1897,20 +1897,55 @@ impl TransactionInner {
 				self.track_scan_range(beg, end);
 			}
 		}
-		// Build combined writeset from merge queue entries only.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if self.database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in self.database.transaction_merge_queue.range(..=version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
+		// Fast path: when there are no in-flight committed transactions and no
+		// uncommitted writes in this range, the merge iterator has nothing to
+		// merge — read straight from the datastore range.
+		if self.database.transaction_merge_queue.is_empty()
+			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
+		{
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			macro_rules! consume_fast_path {
+				($iter:expr) => {
+					for entry in $iter {
+						let exists = match entry.value().try_read() {
+							Some(g) => g.exists_version(version),
+							None => entry.value().read().exists_version(version),
+						};
+						if !exists {
+							continue;
+						}
+						if skip > 0 {
+							skip -= 1;
+							continue;
+						}
+						res += 1;
+						if let Some(l) = limit {
+							if res >= l {
+								break;
+							}
+						}
 					}
+				};
+			}
+			match direction {
+				Direction::Forward => consume_fast_path!(datastore_range),
+				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
+			}
+			return Ok(res);
+		}
+		// Build combined writeset from merge queue entries only.
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
+			let mut ws = BTreeMap::new();
+			for entry in self.database.transaction_merge_queue.range(..=version).rev() {
+				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+					ws.entry(k.clone()).or_insert_with(|| v.clone());
 				}
-				ws
-			};
+			}
+			ws
+		};
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
 			self.database
@@ -1962,7 +1997,7 @@ impl TransactionInner {
 		let beg = &rng.start.into_bytes();
 		let end = &rng.end.into_bytes();
 		// Calculate how many items to skip
-		let skip = skip.unwrap_or_default();
+		let mut skip = skip.unwrap_or_default();
 		// Check wether we should track range scan reads
 		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 			// Track scans if scanning the latest version
@@ -1970,20 +2005,54 @@ impl TransactionInner {
 				self.track_scan_range(beg, end);
 			}
 		}
-		// Build combined writeset from merge queue entries only.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if self.database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in self.database.transaction_merge_queue.range(..=version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
+		// Fast path: no merge queue entries and no transaction writes in this
+		// range — read keys straight from the datastore range.
+		if self.database.transaction_merge_queue.is_empty()
+			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
+		{
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			macro_rules! consume_fast_path {
+				($iter:expr) => {
+					for entry in $iter {
+						let exists = match entry.value().try_read() {
+							Some(g) => g.exists_version(version),
+							None => entry.value().read().exists_version(version),
+						};
+						if !exists {
+							continue;
+						}
+						if skip > 0 {
+							skip -= 1;
+							continue;
+						}
+						res.push(entry.key().clone());
+						if let Some(l) = limit {
+							if res.len() >= l {
+								break;
+							}
+						}
 					}
+				};
+			}
+			match direction {
+				Direction::Forward => consume_fast_path!(datastore_range),
+				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
+			}
+			return Ok(res);
+		}
+		// Build combined writeset from merge queue entries only.
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
+			let mut ws = BTreeMap::new();
+			for entry in self.database.transaction_merge_queue.range(..=version).rev() {
+				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+					ws.entry(k.clone()).or_insert_with(|| v.clone());
 				}
-				ws
-			};
+			}
+			ws
+		};
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
 			self.database
@@ -2035,7 +2104,7 @@ impl TransactionInner {
 		let beg = &rng.start.into_bytes();
 		let end = &rng.end.into_bytes();
 		// Calculate how many items to skip
-		let skip = skip.unwrap_or_default();
+		let mut skip = skip.unwrap_or_default();
 		// Check wether we should track range scan reads
 		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 			// Track scans if scanning the latest version
@@ -2043,20 +2112,52 @@ impl TransactionInner {
 				self.track_scan_range(beg, end);
 			}
 		}
-		// Build combined writeset from merge queue entries only.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if self.database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in self.database.transaction_merge_queue.range(..=version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
+		// Fast path: no merge queue entries and no transaction writes in this
+		// range — read key/value pairs straight from the datastore range.
+		if self.database.transaction_merge_queue.is_empty()
+			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
+		{
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			macro_rules! consume_fast_path {
+				($iter:expr) => {
+					for entry in $iter {
+						let value = match entry.value().try_read() {
+							Some(g) => g.fetch_version(version),
+							None => entry.value().read().fetch_version(version),
+						};
+						let Some(value) = value else { continue };
+						if skip > 0 {
+							skip -= 1;
+							continue;
+						}
+						res.push((entry.key().clone(), value));
+						if let Some(l) = limit {
+							if res.len() >= l {
+								break;
+							}
+						}
 					}
+				};
+			}
+			match direction {
+				Direction::Forward => consume_fast_path!(datastore_range),
+				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
+			}
+			return Ok(res);
+		}
+		// Build combined writeset from merge queue entries only.
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
+			let mut ws = BTreeMap::new();
+			for entry in self.database.transaction_merge_queue.range(..=version).rev() {
+				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+					ws.entry(k.clone()).or_insert_with(|| v.clone());
 				}
-				ws
-			};
+			}
+			ws
+		};
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
 			self.database

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1586,25 +1586,52 @@ impl TransactionInner {
 		let beg = &rng.start.into_bytes();
 		let end = &rng.end.into_bytes();
 		// Calculate how many items to skip
-		let skip = skip.unwrap_or_default();
+		let mut skip = skip.unwrap_or_default();
 		// Check whether we should track range scan reads
 		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 			self.track_scan_range(beg, end);
 		}
-		// Build combined writeset from merge queue entries only.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if self.database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
+		// Fast path: no merge queue entries and no transaction writes in this
+		// range — walk the datastore directly.
+		if self.database.transaction_merge_queue.is_empty()
+			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
+		{
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			for entry in datastore_range {
+				let value = match entry.value().try_read() {
+					Some(g) => g.fetch_version(self.version),
+					None => entry.value().read().fetch_version(self.version),
+				};
+				let Some(value) = value else { continue };
+				if skip > 0 {
+					skip -= 1;
+					continue;
+				}
+				count += 1;
+				if !f(entry.key(), &value) {
+					break;
+				}
+				if let Some(l) = limit {
+					if count >= l {
+						break;
 					}
 				}
-				ws
-			};
+			}
+			return Ok(count);
+		}
+		// Build combined writeset from merge queue entries only.
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
+			let mut ws = BTreeMap::new();
+			for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
+				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+					ws.entry(k.clone()).or_insert_with(|| v.clone());
+				}
+			}
+			ws
+		};
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
 			self.database
@@ -1659,25 +1686,54 @@ impl TransactionInner {
 		let beg = &rng.start.into_bytes();
 		let end = &rng.end.into_bytes();
 		// Calculate how many items to skip
-		let skip = skip.unwrap_or_default();
+		let mut skip = skip.unwrap_or_default();
 		// Check whether we should track range scan reads
 		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 			self.track_scan_range(beg, end);
 		}
-		// Build combined writeset from merge queue entries only.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if self.database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
+		// Fast path: no merge queue entries and no transaction writes in this
+		// range — walk the datastore directly.
+		if self.database.transaction_merge_queue.is_empty()
+			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
+		{
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			for entry in datastore_range {
+				let exists = match entry.value().try_read() {
+					Some(g) => g.exists_version(self.version),
+					None => entry.value().read().exists_version(self.version),
+				};
+				if !exists {
+					continue;
+				}
+				if skip > 0 {
+					skip -= 1;
+					continue;
+				}
+				count += 1;
+				if !f(entry.key()) {
+					break;
+				}
+				if let Some(l) = limit {
+					if count >= l {
+						break;
 					}
 				}
-				ws
-			};
+			}
+			return Ok(count);
+		}
+		// Build combined writeset from merge queue entries only.
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
+			let mut ws = BTreeMap::new();
+			for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
+				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+					ws.entry(k.clone()).or_insert_with(|| v.clone());
+				}
+			}
+			ws
+		};
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
 			self.database
@@ -1730,25 +1786,49 @@ impl TransactionInner {
 		let beg = &rng.start.into_bytes();
 		let end = &rng.end.into_bytes();
 		// Calculate how many items to skip
-		let skip = skip.unwrap_or_default();
+		let mut skip = skip.unwrap_or_default();
 		// Check whether we should track range scan reads
 		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 			self.track_scan_range(beg, end);
 		}
-		// Build combined writeset from merge queue entries only.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if self.database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
+		// Fast path: no merge queue entries and no transaction writes in this
+		// range — walk the datastore directly into the buffer.
+		if self.database.transaction_merge_queue.is_empty()
+			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
+		{
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			for entry in datastore_range {
+				let value = match entry.value().try_read() {
+					Some(g) => g.fetch_version(self.version),
+					None => entry.value().read().fetch_version(self.version),
+				};
+				let Some(value) = value else { continue };
+				if skip > 0 {
+					skip -= 1;
+					continue;
+				}
+				buf.push((entry.key().clone(), value));
+				if let Some(l) = limit {
+					if buf.len() >= l {
+						break;
 					}
 				}
-				ws
-			};
+			}
+			return Ok(());
+		}
+		// Build combined writeset from merge queue entries only.
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
+			let mut ws = BTreeMap::new();
+			for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
+				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+					ws.entry(k.clone()).or_insert_with(|| v.clone());
+				}
+			}
+			ws
+		};
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
 			self.database
@@ -1798,25 +1878,51 @@ impl TransactionInner {
 		let beg = &rng.start.into_bytes();
 		let end = &rng.end.into_bytes();
 		// Calculate how many items to skip
-		let skip = skip.unwrap_or_default();
+		let mut skip = skip.unwrap_or_default();
 		// Check whether we should track range scan reads
 		if self.write && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 			self.track_scan_range(beg, end);
 		}
-		// Build combined writeset from merge queue entries only.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if self.database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
+		// Fast path: no merge queue entries and no transaction writes in this
+		// range — walk the datastore directly into the buffer.
+		if self.database.transaction_merge_queue.is_empty()
+			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
+		{
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			for entry in datastore_range {
+				let exists = match entry.value().try_read() {
+					Some(g) => g.exists_version(self.version),
+					None => entry.value().read().exists_version(self.version),
+				};
+				if !exists {
+					continue;
+				}
+				if skip > 0 {
+					skip -= 1;
+					continue;
+				}
+				buf.push(entry.key().clone());
+				if let Some(l) = limit {
+					if buf.len() >= l {
+						break;
 					}
 				}
-				ws
-			};
+			}
+			return Ok(());
+		}
+		// Build combined writeset from merge queue entries only.
+		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
+			let mut ws = BTreeMap::new();
+			for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
+				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
+					ws.entry(k.clone()).or_insert_with(|| v.clone());
+				}
+			}
+			ws
+		};
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
 			self.database

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1605,7 +1605,9 @@ impl TransactionInner {
 					Some(g) => g.fetch_version(self.version),
 					None => entry.value().read().fetch_version(self.version),
 				};
-				let Some(value) = value else { continue };
+				let Some(value) = value else {
+					continue;
+				};
 				if skip > 0 {
 					skip -= 1;
 					continue;
@@ -1805,7 +1807,9 @@ impl TransactionInner {
 					Some(g) => g.fetch_version(self.version),
 					None => entry.value().read().fetch_version(self.version),
 				};
-				let Some(value) = value else { continue };
+				let Some(value) = value else {
+					continue;
+				};
 				if skip > 0 {
 					skip -= 1;
 					continue;
@@ -2234,7 +2238,9 @@ impl TransactionInner {
 							Some(g) => g.fetch_version(version),
 							None => entry.value().read().fetch_version(version),
 						};
-						let Some(value) = value else { continue };
+						let Some(value) = value else {
+							continue;
+						};
 						if skip > 0 {
 							skip -= 1;
 							continue;


### PR DESCRIPTION
## Summary

`scan_any`, `keys_any`, `total_any`, `scan_for_each`, `keys_for_each`, `scan_into`, and `keys_into` always build a `MergeIterator` over the tree, the merge queue, and the transaction's writeset. For the overwhelmingly common case where the merge queue is empty and the transaction has no writes in the scanned range, the three-way merge collapses to a single source — the tree — and the state machine is pure overhead.

This adds a fast path before constructing `MergeIterator` when both `transaction_merge_queue` is empty and `self.writeset.range(beg..end)` yields nothing. The fast path walks the datastore range directly, resolving each entry's version under its `try_read`/`read` fallback.

## Bench (`cargo bench --quick`, vs `origin/main`)

| Group | Improvement |
|---|---|
| `scan_operations/*` | −5% to −33% |
| `keys_operations/*` | −9% to −22% |
| `total_operations/*` | −5% to −15% |

## Test plan

- [x] `cargo test` (lib + integration): all 371 tests pass
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets` clean