### PR TITLE
Switch to ferntree with deferred-value MergeIterator and bulk leaf scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "ferntree"
+version = "0.1.0"
+dependencies = [
+ "crossbeam-epoch",
+ "parking_lot",
+ "parking_lot_core",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +866,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-skiplist",
+ "ferntree",
  "lz4",
  "papaya",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,14 +314,13 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferntree"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689b980d6383b172b58240bd34c3c04b1182fc1c41e91a4f7a923e6385ef19d5"
+checksum = "4cef1301dd173aeb2f9ace7fc89c6e1d00e4e5ecdc1c9dff0f3889231d208a7e"
 dependencies = [
  "crossbeam-epoch",
  "parking_lot",
  "parking_lot_core",
- "smallvec",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,9 +314,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferntree"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701fe401c36481b24aae07980ee11a8ab28014677175edcafed7ba69fb6a76f8"
+checksum = "689b980d6383b172b58240bd34c3c04b1182fc1c41e91a4f7a923e6385ef19d5"
 dependencies = [
  "crossbeam-epoch",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,10 +314,11 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferntree"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cef1301dd173aeb2f9ace7fc89c6e1d00e4e5ecdc1c9dff0f3889231d208a7e"
+checksum = "c61e94ab9b1d56c01922863b022039ef2cbb57e9dbf7bf237df5ae1e91b97676"
 dependencies = [
+ "bytes",
  "crossbeam-epoch",
  "parking_lot",
  "parking_lot_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferntree"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-epoch",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,8 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 [[package]]
 name = "ferntree"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701fe401c36481b24aae07980ee11a8ab28014677175edcafed7ba69fb6a76f8"
 dependencies = [
  "crossbeam-epoch",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 crossbeam-deque = "0.8.6"
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
+ferntree = { path = "../ferntree" }
 papaya = "0.2.4"
 parking_lot = "0.12.5"
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 crossbeam-deque = "0.8.6"
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
-ferntree = { path = "../ferntree" }
+ferntree = "0.2"
 papaya = "0.2.4"
 parking_lot = "0.12.5"
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 crossbeam-deque = "0.8.6"
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
-ferntree = "0.4"
+ferntree = { version = "0.6", features = ["bytes"] }
 papaya = "0.2.4"
 parking_lot = "0.12.5"
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 crossbeam-deque = "0.8.6"
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
-ferntree = "0.2"
+ferntree = "0.3"
 papaya = "0.2.4"
 parking_lot = "0.12.5"
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 crossbeam-deque = "0.8.6"
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
-ferntree = "0.3"
+ferntree = "0.4"
 papaya = "0.2.4"
 parking_lot = "0.12.5"
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -16,10 +16,9 @@
 
 use crate::direction::Direction;
 use crate::inner::Inner;
-use crate::iter::MergeIterator;
+use crate::iter::{MergeIterator, TreeIterState};
 use bytes::Bytes;
 use std::collections::BTreeMap;
-use std::ops::Bound;
 use std::sync::Arc;
 
 // --------------------------------------------------
@@ -270,9 +269,7 @@ impl<'a> Cursor<'a> {
 			.collect();
 
 		self.iter = Some(MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(start.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::build(&self.database.datastore, start, end, direction),
 			join,
 			self.writeset.range::<Bytes, _>(start..end),
 			direction,

--- a/src/db.rs
+++ b/src/db.rs
@@ -404,8 +404,7 @@ impl Database {
 						while let Some(key) = db.gc_dirty_keys.pop() {
 							// Check if this key still exists in the datastore
 							if iter.seek_exact(&key) {
-								let (_, versions) =
-									iter.next().expect("seek_exact returned true");
+								let (_, versions) = iter.next().expect("seek_exact returned true");
 								// Clean up unnecessary older versions
 								if versions.gc_older_versions(cleanup_ts) == 0 {
 									// Remove the entry just yielded by next()

--- a/src/db.rs
+++ b/src/db.rs
@@ -261,17 +261,15 @@ impl Database {
 
 	fn run_gc_dirty_inner(&self, cleanup_ts: u64) {
 		// Drain all keys from the dirty queue
+		let mut iter = self.datastore.raw_iter_mut();
 		while let Some(key) = self.gc_dirty_keys.pop() {
 			// Check if this key still exists in the datastore
-			if let Some(entry) = self.datastore.get(&key) {
-				// Get a mutable reference to the versions list
-				let mut versions = entry.value().write();
+			if iter.seek_exact(&key) {
+				let (_, versions) = iter.next().expect("seek_exact returned true");
 				// Clean up unnecessary older versions
 				if versions.gc_older_versions(cleanup_ts) == 0 {
-					// Drop the version reference
-					drop(versions);
-					// Remove the entry from the datastore
-					self.datastore.remove(&key);
+					// Remove the entry just yielded by next()
+					iter.remove_here();
 				}
 			}
 		}
@@ -279,16 +277,13 @@ impl Database {
 
 	fn run_gc_full(&self, cleanup_ts: u64) {
 		// Iterate over the entire datastore
-		for entry in self.datastore.iter() {
-			// Get a mutable reference to the versions list
-			let versions = entry.value();
-			let mut versions = versions.write();
+		let mut iter = self.datastore.raw_iter_mut();
+		iter.seek_to_first();
+		while let Some((_, versions)) = iter.next() {
 			// Clean up unnecessary older versions
 			if versions.gc_older_versions(cleanup_ts) == 0 {
-				// Drop the version reference
-				drop(versions);
-				// Remove the entry from the datastore
-				self.datastore.remove(entry.key());
+				// Remove the entry just yielded by next()
+				iter.remove_here();
 			}
 		}
 	}
@@ -404,17 +399,18 @@ impl Database {
 					// transactions
 					let cleanup_ts = history_cutoff.min(earliest_tx);
 					// Drain all keys from the dirty queue (incremental GC)
-					while let Some(key) = db.gc_dirty_keys.pop() {
-						// Check if this key still exists in the datastore
-						if let Some(entry) = db.datastore.get(&key) {
-							// Get a mutable reference to the versions list
-							let mut versions = entry.value().write();
-							// Clean up unnecessary older versions
-							if versions.gc_older_versions(cleanup_ts) == 0 {
-								// Drop the version reference
-								drop(versions);
-								// Remove the entry from the datastore
-								db.datastore.remove(&key);
+					{
+						let mut iter = db.datastore.raw_iter_mut();
+						while let Some(key) = db.gc_dirty_keys.pop() {
+							// Check if this key still exists in the datastore
+							if iter.seek_exact(&key) {
+								let (_, versions) =
+									iter.next().expect("seek_exact returned true");
+								// Clean up unnecessary older versions
+								if versions.gc_older_versions(cleanup_ts) == 0 {
+									// Remove the entry just yielded by next()
+									iter.remove_here();
+								}
 							}
 						}
 					}
@@ -422,16 +418,13 @@ impl Database {
 					cycle += 1;
 					if cycle.is_multiple_of(FULL_SCAN_FREQUENCY) {
 						// Iterate over the entire datastore
-						for entry in db.datastore.iter() {
-							// Get a mutable reference to the versions list
-							let versions = entry.value();
-							let mut versions = versions.write();
+						let mut iter = db.datastore.raw_iter_mut();
+						iter.seek_to_first();
+						while let Some((_, versions)) = iter.next() {
 							// Clean up unnecessary older versions
 							if versions.gc_older_versions(cleanup_ts) == 0 {
-								// Drop the version reference
-								drop(versions);
-								// Remove the entry from the datastore
-								db.datastore.remove(entry.key());
+								// Remove the entry just yielded by next()
+								iter.remove_here();
 							}
 						}
 					}

--- a/src/db.rs
+++ b/src/db.rs
@@ -413,16 +413,12 @@ impl Database {
 					// database does not lock readers out forever.
 					let cleanup_ts = {
 						let now = db.oracle.current_time_ns();
-						let history = db
-							.garbage_collection_epoch
-							.read()
-							.unwrap_or_default()
-							.as_nanos();
+						let history =
+							db.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
 						let history_cutoff = now.saturating_sub(history as u64);
 						let earliest_tx = db.earliest_active_version(now);
 						let oracle_now = db.oracle.inner.timestamp.load(Ordering::SeqCst);
-						let proposed =
-							history_cutoff.min(earliest_tx).min(oracle_now);
+						let proposed = history_cutoff.min(earliest_tx).min(oracle_now);
 						db.gc_floor.fetch_max(proposed, Ordering::SeqCst);
 						fence(Ordering::SeqCst);
 						let earliest_after = db.earliest_active_version(now);

--- a/src/db.rs
+++ b/src/db.rs
@@ -17,14 +17,16 @@
 use crate::inner::Inner;
 use crate::options::DatabaseOptions;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::options::{DEFAULT_CLEANUP_INTERVAL, DEFAULT_GC_INTERVAL};
+use crate::options::{
+	DEFAULT_CLEANUP_INTERVAL, DEFAULT_GC_FULL_SCAN_FREQUENCY, DEFAULT_GC_INTERVAL,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::persistence::Persistence;
 use crate::pool::Pool;
 use crate::pool::DEFAULT_POOL_SIZE;
 use crate::tx::Transaction;
 use std::ops::Deref;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{fence, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -44,6 +46,9 @@ pub struct Database {
 	/// Interval used by the garbage collector thread
 	#[cfg(not(target_arch = "wasm32"))]
 	gc_interval: Duration,
+	/// Number of gc wake-ups between full datastore scans
+	#[cfg(not(target_arch = "wasm32"))]
+	gc_full_scan_frequency: u64,
 	/// Interval used by the cleanup thread
 	#[cfg(not(target_arch = "wasm32"))]
 	cleanup_interval: Duration,
@@ -60,6 +65,8 @@ impl Default for Database {
 			persistence: None,
 			#[cfg(not(target_arch = "wasm32"))]
 			gc_interval: DEFAULT_GC_INTERVAL,
+			#[cfg(not(target_arch = "wasm32"))]
+			gc_full_scan_frequency: DEFAULT_GC_FULL_SCAN_FREQUENCY,
 			#[cfg(not(target_arch = "wasm32"))]
 			cleanup_interval: DEFAULT_CLEANUP_INTERVAL,
 		}
@@ -101,6 +108,8 @@ impl Database {
 			#[cfg(not(target_arch = "wasm32"))]
 			gc_interval: opts.gc_interval,
 			#[cfg(not(target_arch = "wasm32"))]
+			gc_full_scan_frequency: opts.gc_full_scan_frequency,
+			#[cfg(not(target_arch = "wasm32"))]
 			cleanup_interval: opts.cleanup_interval,
 		};
 		// Start background tasks when enabled
@@ -139,6 +148,7 @@ impl Database {
 			pool,
 			persistence: Some(persist),
 			gc_interval: opts.gc_interval,
+			gc_full_scan_frequency: opts.gc_full_scan_frequency,
 			cleanup_interval: opts.cleanup_interval,
 		};
 		// Start background tasks when enabled
@@ -221,16 +231,7 @@ impl Database {
 	/// modified, or when automatic background GC is disabled via
 	/// [`DatabaseOptions::enable_gc`].
 	pub fn run_gc(&self) {
-		// Get the current time in nanoseconds
-		let now = self.oracle.current_time_ns();
-		// Get the garbage collection epoch as nanoseconds
-		let history = self.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
-		// Calculate the history cutoff (current time - history duration)
-		let history_cutoff = now.saturating_sub(history as u64);
-		// Get the earliest active transaction version
-		let earliest_tx = self.earliest_active_version(now);
-		// Use history cutoff or earliest transaction to protect active transactions
-		let cleanup_ts = history_cutoff.min(earliest_tx);
+		let cleanup_ts = self.compute_cleanup_ts();
 		// First, process keys known to have stale versions
 		self.run_gc_dirty_inner(cleanup_ts);
 		// Then perform a full datastore scan for any remaining stale versions
@@ -242,18 +243,38 @@ impl Database {
 	/// This is a lightweight alternative to a full datastore scan, useful
 	/// for frequent incremental cleanup between full GC passes.
 	pub fn run_gc_dirty(&self) {
-		// Get the current time in nanoseconds
-		let now = self.oracle.current_time_ns();
-		// Get the garbage collection epoch as nanoseconds
-		let history = self.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
-		// Calculate the history cutoff (current time - history duration)
-		let history_cutoff = now.saturating_sub(history as u64);
-		// Get the earliest active transaction version
-		let earliest_tx = self.earliest_active_version(now);
-		// Use history cutoff or earliest transaction to protect active transactions
-		let cleanup_ts = history_cutoff.min(earliest_tx);
+		let cleanup_ts = self.compute_cleanup_ts();
 		// Process dirty keys
 		self.run_gc_dirty_inner(cleanup_ts);
+	}
+
+	/// Compute the next `cleanup_ts`, publishing it into `gc_floor` so
+	/// concurrent `register_counter` retries any reader whose snapshot
+	/// is below it, then re-scan to bound by any newly-arrived reader.
+	///
+	/// The proposed value is capped at the current oracle timestamp.
+	/// Without that cap, an idle database (oracle frozen while wall
+	/// clock advances) would push `gc_floor` above any value a future
+	/// reader could load — causing `register_counter` to spin forever
+	/// retrying.
+	fn compute_cleanup_ts(&self) -> u64 {
+		let now = self.oracle.current_time_ns();
+		let history = self.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
+		let history_cutoff = now.saturating_sub(history as u64);
+		let earliest_tx = self.earliest_active_version(now);
+		let oracle_now = self.oracle.inner.timestamp.load(Ordering::SeqCst);
+		// `gc_floor` must stay <= oracle so any future reader's load
+		// (which returns >= current oracle) satisfies the floor check.
+		let proposed = history_cutoff.min(earliest_tx).min(oracle_now);
+		// Publish proposed cleanup_ts via `gc_floor` BEFORE reclaiming.
+		// A `register_counter` that fences after CAS-publish will see
+		// either the old floor (and its publish becomes visible to our
+		// re-scan below via fence-fence SC ordering) or the new floor
+		// (and will retry to a fresh snapshot above it).
+		self.gc_floor.fetch_max(proposed, Ordering::SeqCst);
+		fence(Ordering::SeqCst);
+		let earliest_after = self.earliest_active_version(now);
+		proposed.min(earliest_after)
 	}
 
 	fn run_gc_dirty_inner(&self, cleanup_ts: u64) {
@@ -369,8 +390,8 @@ impl Database {
 		if db.garbage_collection_handle.read().is_none() {
 			// Get the specified interval
 			let interval = self.gc_interval;
-			// Full scan runs every 4th wake cycle; dirty-key pass runs every cycle
-			const FULL_SCAN_FREQUENCY: u64 = 4;
+			// Full scan runs every Nth wake cycle; dirty-key pass runs every cycle
+			let full_scan_frequency = self.gc_full_scan_frequency.max(1);
 			// Spawn a new thread to handle periodic garbage collection
 			let handle = std::thread::spawn(move || {
 				let mut cycle: u64 = 0;
@@ -382,34 +403,49 @@ impl Database {
 					if !db.background_threads_enabled.load(Ordering::Relaxed) {
 						break;
 					}
-					// Get the current time in nanoseconds
-					let now = db.oracle.current_time_ns();
-					// Get the garbage collection epoch as nanoseconds
-					let history = db.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
-					// Calculate the history cutoff (current time - history duration)
-					let history_cutoff = now.saturating_sub(history as u64);
-					// Get the earliest active transaction version
-					let earliest_tx = db.earliest_active_version(now);
-					// Use history cutoff or earliest transaction to protect active transactions
-					let cleanup_ts = history_cutoff.min(earliest_tx);
-					// Drain all keys from the dirty queue (incremental GC)
-					{
+					// Compute the next cleanup_ts. This publishes the
+					// proposed value to `gc_floor` and re-scans the
+					// counter map so any reader landing in the
+					// publish-and-scan window is either visible to us
+					// (and bounds the final cleanup_ts) or retries from
+					// a fresh oracle read above the floor. The proposed
+					// value is capped at the current oracle so an idle
+					// database does not lock readers out forever.
+					let cleanup_ts = {
+						let now = db.oracle.current_time_ns();
+						let history = db
+							.garbage_collection_epoch
+							.read()
+							.unwrap_or_default()
+							.as_nanos();
+						let history_cutoff = now.saturating_sub(history as u64);
+						let earliest_tx = db.earliest_active_version(now);
+						let oracle_now = db.oracle.inner.timestamp.load(Ordering::SeqCst);
+						let proposed =
+							history_cutoff.min(earliest_tx).min(oracle_now);
+						db.gc_floor.fetch_max(proposed, Ordering::SeqCst);
+						fence(Ordering::SeqCst);
+						let earliest_after = db.earliest_active_version(now);
+						proposed.min(earliest_after)
+					};
+					// Drain all keys from the dirty queue (incremental GC).
+					// A fresh `raw_iter_mut` is opened per key so the
+					// exclusive leaf guard is scoped to a single key —
+					// this avoids any iterator-state bugs from reusing the
+					// same cursor across `remove_here` calls that may
+					// trigger leaf merges.
+					while let Some(key) = db.gc_dirty_keys.pop() {
 						let mut iter = db.datastore.raw_iter_mut();
-						while let Some(key) = db.gc_dirty_keys.pop() {
-							// Check if this key still exists in the datastore
-							if iter.seek_exact(&key) {
-								let (_, versions) = iter.next().expect("seek_exact returned true");
-								// Clean up unnecessary older versions
-								if versions.gc_older_versions(cleanup_ts) == 0 {
-									// Remove the entry just yielded by next()
-									iter.remove_here();
-								}
+						if iter.seek_exact(&key) {
+							let (_, versions) = iter.next().expect("seek_exact returned true");
+							if versions.gc_older_versions(cleanup_ts) == 0 {
+								iter.remove_here();
 							}
 						}
 					}
 					// Periodically do a full datastore scan
 					cycle += 1;
-					if cycle.is_multiple_of(FULL_SCAN_FREQUENCY) {
+					if cycle.is_multiple_of(full_scan_frequency) {
 						// Iterate over the entire datastore
 						let mut iter = db.datastore.raw_iter_mut();
 						iter.seek_to_first();

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -15,6 +15,7 @@
 //! This module stores the database iteration direction.
 
 /// The direction that the iterator should iterate
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Direction {
 	Forward,
 	Reverse,

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -72,6 +72,19 @@ pub struct Inner {
 	pub(crate) garbage_collection_handle: RwLock<Option<JoinHandle<()>>>,
 	/// Keys with stale versions pending incremental garbage collection
 	pub(crate) gc_dirty_keys: SegQueue<Bytes>,
+	/// Watermark below which versions are about to be (or have been)
+	/// reclaimed by the garbage collector. The GC sweeper publishes its
+	/// intended `cleanup_ts` here with a SeqCst `fetch_max` *before*
+	/// actually reclaiming any versions. `register_counter` validates
+	/// `v_r >= gc_floor` after publishing its counter; if a reader
+	/// finds `gc_floor > v_r`, it rolls back and reloads the oracle,
+	/// landing on a fresh snapshot above the floor. This closes the
+	/// scan/gc race in the BG sweeper: a sweeper that misses an
+	/// in-flight reader on its first scan publishes `gc_floor`, fences,
+	/// then re-scans — and either the reader saw the new floor and
+	/// retried, or its publish is now visible to the re-scan so the
+	/// sweeper's final cleanup_ts is bounded by it.
+	pub(crate) gc_floor: AtomicU64,
 	/// Threshold after which transaction state is reset
 	pub(crate) reset_threshold: usize,
 }
@@ -98,6 +111,7 @@ impl Inner {
 			#[cfg(not(target_arch = "wasm32"))]
 			garbage_collection_handle: RwLock::new(None),
 			gc_dirty_keys: SegQueue::new(),
+			gc_floor: AtomicU64::new(0),
 			reset_threshold: opts.reset_threshold,
 		}
 	}

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -23,6 +23,7 @@ use crate::DatabaseOptions;
 use bytes::Bytes;
 use crossbeam_queue::SegQueue;
 use crossbeam_skiplist::SkipMap;
+use ferntree::Tree;
 use parking_lot::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
@@ -34,8 +35,8 @@ use std::time::Duration;
 pub struct Inner {
 	/// The timestamp version oracle
 	pub(crate) oracle: Arc<Oracle>,
-	/// The underlying lock-free Skip Map datastructure
-	pub(crate) datastore: SkipMap<Bytes, RwLock<Versions>>,
+	/// The underlying lock-free B+tree datastructure
+	pub(crate) datastore: Tree<Bytes, Versions>,
 	/// A count of total transactions grouped by oracle version
 	pub(crate) counter_by_oracle: SkipMap<u64, Arc<AtomicU64>>,
 	/// A count of total transactions grouped by commit id
@@ -74,7 +75,7 @@ impl Inner {
 	pub fn new(opts: &DatabaseOptions) -> Self {
 		Self {
 			oracle: Oracle::new(opts.resync_interval),
-			datastore: SkipMap::new(),
+			datastore: Tree::new(),
 			counter_by_oracle: SkipMap::new(),
 			counter_by_commit: SkipMap::new(),
 			transaction_queue_id: AtomicU64::new(0),

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -138,15 +138,18 @@ impl<'a> MergeIterator<'a> {
 	/// version, caching the key/exists/value triple to avoid repeated work.
 	#[inline]
 	fn fetch_tree_entry(tree_iter: &mut TreeIterState<'_>, version: u64) -> CachedTreeEntry {
+		// `Versions::fetch_version` returns `Some` iff the resolved version
+		// is a non-tombstone, which is exactly the predicate `exists_version`
+		// would compute, so we derive existence directly from the value.
 		match tree_iter {
 			TreeIterState::Forward(range) => range.peek().map(|(k, v)| {
 				let value = v.fetch_version(version);
-				let exists = value.is_some() || v.exists_version(version);
+				let exists = value.is_some();
 				(k.clone(), exists, value)
 			}),
 			TreeIterState::Reverse(range) => range.peek().map(|(k, v)| {
 				let value = v.fetch_version(version);
-				let exists = value.is_some() || v.exists_version(version);
+				let exists = value.is_some();
 				(k.clone(), exists, value)
 			}),
 		}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -56,10 +56,13 @@ impl<'a> TreeIterState<'a> {
 	}
 }
 
-/// Cached entry from the tree iterator: (key, exists_at_version, value_at_version).
-/// We resolve the version once per advance to avoid repeated peek() lookups
-/// and locks while merging across sources.
-type CachedTreeEntry = Option<(Bytes, bool, Option<Bytes>)>;
+/// Cached entry from the tree iterator: (key, exists_at_version).
+/// Only the key and existence flag are precomputed — the value at the current
+/// version is fetched lazily at emit time, while the tree iterator is still
+/// parked at this entry (so `peek()` still returns it). This avoids cloning a
+/// value byte slice for entries that get skipped or that the caller only needs
+/// existence for (`next_count`, `next_key`).
+type CachedTreeEntry = Option<(Bytes, bool)>;
 
 /// Three-way merge iterator over tree, merge queue, and current transaction
 /// writesets.
@@ -134,24 +137,34 @@ impl<'a> MergeIterator<'a> {
 		me
 	}
 
-	/// Peek at the next tree entry and resolve its value at the current MVCC
-	/// version, caching the key/exists/value triple to avoid repeated work.
+	/// Peek at the next tree entry and cache its key + existence at the
+	/// current MVCC version. Value resolution is deferred to `peek_tree_value`
+	/// so paths that only need keys or counts don't pay the byte clone.
 	#[inline]
 	fn fetch_tree_entry(tree_iter: &mut TreeIterState<'_>, version: u64) -> CachedTreeEntry {
-		// `Versions::fetch_version` returns `Some` iff the resolved version
-		// is a non-tombstone, which is exactly the predicate `exists_version`
-		// would compute, so we derive existence directly from the value.
 		match tree_iter {
-			TreeIterState::Forward(range) => range.peek().map(|(k, v)| {
-				let value = v.fetch_version(version);
-				let exists = value.is_some();
-				(k.clone(), exists, value)
-			}),
-			TreeIterState::Reverse(range) => range.peek().map(|(k, v)| {
-				let value = v.fetch_version(version);
-				let exists = value.is_some();
-				(k.clone(), exists, value)
-			}),
+			TreeIterState::Forward(range) => {
+				range.peek().map(|(k, v)| (k.clone(), v.exists_version(version)))
+			}
+			TreeIterState::Reverse(range) => {
+				range.peek().map(|(k, v)| (k.clone(), v.exists_version(version)))
+			}
+		}
+	}
+
+	/// Fetch the value at the current MVCC version for the entry that the
+	/// tree iterator is currently parked on. Call this in `Iterator::next`
+	/// right before advancing past the entry.
+	#[inline]
+	fn peek_tree_value(&mut self) -> Option<Bytes> {
+		let version = self.version;
+		match &mut self.tree_iter {
+			TreeIterState::Forward(range) => {
+				range.peek().and_then(|(_, v)| v.fetch_version(version))
+			}
+			TreeIterState::Reverse(range) => {
+				range.peek().and_then(|(_, v)| v.fetch_version(version))
+			}
 		}
 	}
 
@@ -186,12 +199,12 @@ impl<'a> MergeIterator<'a> {
 
 	#[inline]
 	fn tree_key(&self) -> Option<&Bytes> {
-		self.tree_next.as_ref().map(|(k, _, _)| k)
+		self.tree_next.as_ref().map(|(k, _)| k)
 	}
 
 	#[inline]
 	fn tree_exists(&self) -> bool {
-		self.tree_next.as_ref().map(|(_, e, _)| *e).unwrap_or(false)
+		self.tree_next.as_ref().map(|(_, e)| *e).unwrap_or(false)
 	}
 
 	/// Decide which source has the next key to process. Pure inspection,
@@ -348,7 +361,7 @@ impl<'a> MergeIterator<'a> {
 						continue;
 					}
 
-					let key = self.tree_next.as_ref().map(|(k, _, _)| k.clone()).unwrap();
+					let key = self.tree_next.as_ref().map(|(k, _)| k.clone()).unwrap();
 					self.advance_tree();
 					return Some((key, exists));
 				}
@@ -419,8 +432,14 @@ impl<'a> Iterator for MergeIterator<'a> {
 						continue;
 					}
 
-					let (key, value) =
-						self.tree_next.as_ref().map(|(k, _, v)| (k.clone(), v.clone())).unwrap();
+					// Resolve the value lazily while the tree iter is still
+					// parked on this entry, then clone the key and advance.
+					let value = if exists {
+						self.peek_tree_value()
+					} else {
+						None
+					};
+					let key = self.tree_next.as_ref().map(|(k, _)| k.clone()).unwrap();
 					self.advance_tree();
 					return Some((key, value));
 				}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -18,31 +18,61 @@
 use crate::direction::Direction;
 use crate::versions::Versions;
 use bytes::Bytes;
-use crossbeam_skiplist::map::Entry;
-use crossbeam_skiplist::map::Range as SkipRange;
-use parking_lot::RwLock;
+use ferntree::iter::{Range as FernRange, RangeRev};
+use ferntree::Tree;
 use std::collections::btree_map::Range as TreeRange;
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::ops::Bound;
 
-/// Owned range bounds for the skip list range iterator.
-/// Using owned Bytes avoids lifetime coupling between range bounds
-/// and the MergeIterator, enabling persistent storage (e.g., in a Cursor).
-pub(crate) type SkipBounds = (Bound<Bytes>, Bound<Bytes>);
+// Tree fanout used by the surrealmx datastore tree.
+// Kept aliased here so iterator types match the tree configured in `inner.rs`.
+const IC: usize = 64;
+const LC: usize = 64;
+
+/// Forward or reverse iterator over the underlying tree.
+pub(crate) enum TreeIterState<'a> {
+	Forward(FernRange<'a, Bytes, Versions, IC, LC>),
+	Reverse(RangeRev<'a, Bytes, Versions, IC, LC>),
+}
+
+impl<'a> TreeIterState<'a> {
+	/// Build a tree iterator over `[beg, end)` for the given direction.
+	#[inline]
+	pub(crate) fn build(
+		tree: &'a Tree<Bytes, Versions>,
+		beg: &Bytes,
+		end: &Bytes,
+		direction: Direction,
+	) -> Self {
+		match direction {
+			Direction::Forward => {
+				TreeIterState::Forward(tree.range(Bound::Included(beg), Bound::Excluded(end)))
+			}
+			Direction::Reverse => {
+				TreeIterState::Reverse(tree.range_rev(Bound::Included(beg), Bound::Excluded(end)))
+			}
+		}
+	}
+}
+
+/// Cached entry from the tree iterator: (key, exists_at_version, value_at_version).
+/// We resolve the version once per advance to avoid repeated peek() lookups
+/// and locks while merging across sources.
+type CachedTreeEntry = Option<(Bytes, bool, Option<Bytes>)>;
 
 /// Three-way merge iterator over tree, merge queue, and current transaction
-/// writesets
+/// writesets.
 pub struct MergeIterator<'a> {
 	// Source iterators
-	pub(crate) tree_iter: SkipRange<'a, Bytes, SkipBounds, Bytes, RwLock<Versions>>,
+	pub(crate) tree_iter: TreeIterState<'a>,
 	pub(crate) self_iter: TreeRange<'a, Bytes, Option<Bytes>>,
 
 	// Join entries from merge queue, consumed from front (forward) or back (reverse)
 	pub(crate) join_entries: VecDeque<(Bytes, Option<Bytes>)>,
 
 	// Current buffered entries from each source
-	pub(crate) tree_next: Option<Entry<'a, Bytes, RwLock<Versions>>>,
+	pub(crate) tree_next: CachedTreeEntry,
 	pub(crate) join_next: Option<(Bytes, Option<Bytes>)>,
 	pub(crate) self_next: Option<(&'a Bytes, &'a Option<Bytes>)>,
 
@@ -64,44 +94,61 @@ enum KeySource {
 }
 
 impl<'a> MergeIterator<'a> {
-	pub fn new(
-		mut tree_iter: SkipRange<'a, Bytes, SkipBounds, Bytes, RwLock<Versions>>,
+	pub(crate) fn new(
+		tree_iter: TreeIterState<'a>,
 		join_storage: BTreeMap<Bytes, Option<Bytes>>,
 		mut self_iter: TreeRange<'a, Bytes, Option<Bytes>>,
 		direction: Direction,
 		version: u64,
 		skip: usize,
 	) -> Self {
-		// Get initial entries based on direction
-		let tree_next = match direction {
-			Direction::Forward => tree_iter.next(),
-			Direction::Reverse => tree_iter.next_back(),
-		};
-
-		let self_next = match direction {
-			Direction::Forward => self_iter.next(),
-			Direction::Reverse => self_iter.next_back(),
-		};
-
-		// Convert BTreeMap to VecDeque for O(1) sequential access
-		let mut join_entries: VecDeque<(Bytes, Option<Bytes>)> = join_storage.into_iter().collect();
-
-		// Get first join entry based on direction
-		let join_next = match direction {
-			Direction::Forward => join_entries.pop_front(),
-			Direction::Reverse => join_entries.pop_back(),
-		};
-
-		MergeIterator {
+		let mut me = MergeIterator {
 			tree_iter,
-			self_iter,
-			join_entries,
-			tree_next,
-			join_next,
-			self_next,
+			self_iter: TreeRange::default(),
+			join_entries: VecDeque::new(),
+			tree_next: None,
+			join_next: None,
+			self_next: None,
 			direction,
 			version,
 			skip_remaining: skip,
+		};
+
+		// Convert BTreeMap to VecDeque for O(1) sequential access
+		me.join_entries = join_storage.into_iter().collect();
+		me.join_next = match direction {
+			Direction::Forward => me.join_entries.pop_front(),
+			Direction::Reverse => me.join_entries.pop_back(),
+		};
+
+		// Prime the transaction-side iterator
+		me.self_next = match direction {
+			Direction::Forward => self_iter.next(),
+			Direction::Reverse => self_iter.next_back(),
+		};
+		me.self_iter = self_iter;
+
+		// Prime the tree-side cache
+		me.tree_next = Self::fetch_tree_entry(&mut me.tree_iter, version);
+
+		me
+	}
+
+	/// Peek at the next tree entry and resolve its value at the current MVCC
+	/// version, caching the key/exists/value triple to avoid repeated work.
+	#[inline]
+	fn fetch_tree_entry(tree_iter: &mut TreeIterState<'_>, version: u64) -> CachedTreeEntry {
+		match tree_iter {
+			TreeIterState::Forward(range) => range.peek().map(|(k, v)| {
+				let value = v.fetch_version(version);
+				let exists = value.is_some() || v.exists_version(version);
+				(k.clone(), exists, value)
+			}),
+			TreeIterState::Reverse(range) => range.peek().map(|(k, v)| {
+				let value = v.fetch_version(version);
+				let exists = value.is_some() || v.exists_version(version);
+				(k.clone(), exists, value)
+			}),
 		}
 	}
 
@@ -113,126 +160,122 @@ impl<'a> MergeIterator<'a> {
 		};
 	}
 
-	/// Get next entry existence only (no key or value cloning) - optimized for
-	/// counting
-	pub fn next_count(&mut self) -> Option<bool> {
-		loop {
-			// Find the next key to process (smallest for Forward, largest for Reverse)
-			let mut next_key: Option<&Bytes> = None;
-			let mut next_source = KeySource::None;
+	#[inline]
+	fn advance_self(&mut self) {
+		self.self_next = match self.direction {
+			Direction::Forward => self.self_iter.next(),
+			Direction::Reverse => self.self_iter.next_back(),
+		};
+	}
 
-			// Check self iterator (highest priority)
-			if let Some((sk, _)) = self.self_next {
-				next_key = Some(sk);
+	#[inline]
+	fn advance_tree(&mut self) {
+		match &mut self.tree_iter {
+			TreeIterState::Forward(range) => {
+				range.next();
+			}
+			TreeIterState::Reverse(range) => {
+				range.next();
+			}
+		}
+		self.tree_next = Self::fetch_tree_entry(&mut self.tree_iter, self.version);
+	}
+
+	#[inline]
+	fn tree_key(&self) -> Option<&Bytes> {
+		self.tree_next.as_ref().map(|(k, _, _)| k)
+	}
+
+	#[inline]
+	fn tree_exists(&self) -> bool {
+		self.tree_next.as_ref().map(|(_, e, _)| *e).unwrap_or(false)
+	}
+
+	/// Decide which source has the next key to process. Pure inspection,
+	/// no advancing.
+	#[inline]
+	fn next_source(&self) -> KeySource {
+		let mut next_key: Option<&Bytes> = None;
+		let mut next_source = KeySource::None;
+
+		// Check self iterator (highest priority on tie)
+		if let Some((sk, _)) = self.self_next {
+			next_key = Some(sk);
+			next_source = KeySource::Transaction;
+		}
+
+		// Check join iterator (merge queue)
+		if let Some((jk, _)) = &self.join_next {
+			let should_use = match (next_key, &self.direction) {
+				(None, _) => true,
+				(Some(k), Direction::Forward) => jk < k,
+				(Some(k), Direction::Reverse) => jk > k,
+			};
+			if should_use {
+				next_key = Some(jk);
+				next_source = KeySource::Committed;
+			} else if next_key == Some(jk) {
+				// Same key in both self and join - self wins
 				next_source = KeySource::Transaction;
 			}
+		}
 
-			// Check join iterator (merge queue)
-			if let Some((jk, _)) = &self.join_next {
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => jk < k,
-					(Some(k), Direction::Reverse) => jk > k,
-				};
-				if should_use {
-					next_key = Some(jk);
-					next_source = KeySource::Committed;
-				} else if next_key == Some(jk) {
-					// Same key in both self and join - self wins
-					next_source = KeySource::Transaction;
-				}
+		// Check tree iterator
+		if let Some(tk) = self.tree_key() {
+			let should_use = match (next_key, &self.direction) {
+				(None, _) => true,
+				(Some(k), Direction::Forward) => tk < k,
+				(Some(k), Direction::Reverse) => tk > k,
+			};
+			if should_use {
+				next_source = KeySource::Datastore;
 			}
+		}
 
-			// Check tree iterator
-			if let Some(t_entry) = &self.tree_next {
-				let tk = t_entry.key();
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => tk < k,
-					(Some(k), Direction::Reverse) => tk > k,
-				};
-				if should_use {
-					next_source = KeySource::Datastore;
-				}
-			}
+		next_source
+	}
 
-			// Process the selected source
-			let exists = match next_source {
+	/// Get next entry existence only (no key or value cloning) - optimized for
+	/// counting.
+	pub fn next_count(&mut self) -> Option<bool> {
+		loop {
+			let exists = match self.next_source() {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
 					let exists = sv.is_some();
+					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
+					let skip_tree = self.tree_key() == Some(sk);
 
-					// Advance self iterator
-					self.self_next = match self.direction {
-						Direction::Forward => self.self_iter.next(),
-						Direction::Reverse => self.self_iter.next_back(),
-					};
-
-					// Skip same key in other iterators
-					if let Some((jk, _)) = &self.join_next {
-						if jk == sk {
-							self.advance_join();
-						}
+					self.advance_self();
+					if skip_join {
+						self.advance_join();
 					}
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == sk {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
 					exists
 				}
 				KeySource::Committed => {
 					let exists = self.join_next.as_ref().unwrap().1.is_some();
+					let skip_tree =
+						self.tree_key() == self.join_next.as_ref().map(|(jk, _)| jk);
 
-					// Check if we need to skip same key in tree before advancing join
-					let should_skip_tree = if let Some(t_entry) = &self.tree_next {
-						if let Some((jk, _)) = &self.join_next {
-							t_entry.key() == jk
-						} else {
-							false
-						}
-					} else {
-						false
-					};
-
-					// Advance join iterator
 					self.advance_join();
-
-					// Skip same key in tree iterator if needed
-					if should_skip_tree {
-						self.tree_next = match self.direction {
-							Direction::Forward => self.tree_iter.next(),
-							Direction::Reverse => self.tree_iter.next_back(),
-						};
+					if skip_tree {
+						self.advance_tree();
 					}
 
 					exists
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
-					let tv = match t_entry.value().try_read() {
-						Some(guard) => guard,
-						None => t_entry.value().read(),
-					};
-					let exists = tv.exists_version(self.version);
-					drop(tv);
-
-					// Advance tree iterator
-					self.tree_next = match self.direction {
-						Direction::Forward => self.tree_iter.next(),
-						Direction::Reverse => self.tree_iter.next_back(),
-					};
-
+					let exists = self.tree_exists();
+					self.advance_tree();
 					exists
 				}
 				KeySource::None => return None,
 			};
 
-			// Handle skipping
 			if exists && self.skip_remaining > 0 {
 				self.skip_remaining -= 1;
 				continue;
@@ -242,163 +285,69 @@ impl<'a> MergeIterator<'a> {
 		}
 	}
 
-	/// Get next entry with key (no value cloning) - optimized for key iteration
+	/// Get next entry with key (no value cloning) - optimized for key
+	/// iteration.
 	pub fn next_key(&mut self) -> Option<(Bytes, bool)> {
 		loop {
-			// Find the next key to process (smallest for Forward, largest for Reverse)
-			let mut next_key: Option<&Bytes> = None;
-			let mut next_source = KeySource::None;
-
-			// Check self iterator (highest priority)
-			if let Some((sk, _)) = self.self_next {
-				next_key = Some(sk);
-				next_source = KeySource::Transaction;
-			}
-
-			// Check join iterator (merge queue)
-			if let Some((jk, _)) = &self.join_next {
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => jk < k,
-					(Some(k), Direction::Reverse) => jk > k,
-				};
-				if should_use {
-					next_key = Some(jk);
-					next_source = KeySource::Committed;
-				} else if next_key == Some(jk) {
-					// Same key in both self and join - self wins
-					next_source = KeySource::Transaction;
-				}
-			}
-
-			// Check tree iterator
-			if let Some(t_entry) = &self.tree_next {
-				let tk = t_entry.key();
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => tk < k,
-					(Some(k), Direction::Reverse) => tk > k,
-				};
-				if should_use {
-					next_source = KeySource::Datastore;
-				}
-			}
-
-			// Process the selected source - first determine if entry exists
-			match next_source {
+			match self.next_source() {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
 					let exists = sv.is_some();
-
-					// Store key reference for later cloning if needed
 					let key_ref = sk;
+					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
+					let skip_tree = self.tree_key() == Some(sk);
 
-					// Advance self iterator
-					self.self_next = match self.direction {
-						Direction::Forward => self.self_iter.next(),
-						Direction::Reverse => self.self_iter.next_back(),
-					};
-
-					// Skip same key in other iterators
-					if let Some((jk, _)) = &self.join_next {
-						if jk == key_ref {
-							self.advance_join();
-						}
+					self.advance_self();
+					if skip_join {
+						self.advance_join();
 					}
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == key_ref {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
-					// Handle skipping BEFORE cloning
 					if exists && self.skip_remaining > 0 {
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone if we're returning it
 					return Some((key_ref.clone(), exists));
 				}
 				KeySource::Committed => {
 					let (jk, jv) = self.join_next.as_ref().unwrap();
 
-					// Check if we should skip (only skip existing entries)
 					if jv.is_some() && self.skip_remaining > 0 {
-						// Check if we need to skip same key in tree before advancing join
-						let should_skip_tree = if let Some(t_entry) = &self.tree_next {
-							t_entry.key() == jk
-						} else {
-							false
-						};
-
-						// Advance join iterator
+						let skip_tree = self.tree_key() == Some(jk);
 						self.advance_join();
-
-						// Skip same key in tree iterator if needed
-						if should_skip_tree {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
+						if skip_tree {
+							self.advance_tree();
 						}
-
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Read existence before advancing (avoids value clone)
 					let exists = jv.is_some();
 					let key = jk.clone();
+					let skip_tree = self.tree_key() == Some(&key);
 
-					// Advance join iterator
 					self.advance_join();
-
-					// Skip same key in tree iterator
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == &key {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
 					return Some((key, exists));
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
-					let tv = match t_entry.value().try_read() {
-						Some(guard) => guard,
-						None => t_entry.value().read(),
-					};
-					let exists = tv.exists_version(self.version);
-					drop(tv);
+					let exists = self.tree_exists();
 
-					// Handle skipping BEFORE cloning the key
 					if exists && self.skip_remaining > 0 {
-						// Advance tree iterator
-						self.tree_next = match self.direction {
-							Direction::Forward => self.tree_iter.next(),
-							Direction::Reverse => self.tree_iter.next_back(),
-						};
+						self.advance_tree();
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone key if we're returning it
-					let tk = t_entry.key().clone();
-
-					// Advance tree iterator
-					self.tree_next = match self.direction {
-						Direction::Forward => self.tree_iter.next(),
-						Direction::Reverse => self.tree_iter.next_back(),
-					};
-
-					return Some((tk, exists));
+					let key = self.tree_next.as_ref().map(|(k, _, _)| k.clone()).unwrap();
+					self.advance_tree();
+					return Some((key, exists));
 				}
 				KeySource::None => return None,
 			}
@@ -411,161 +360,66 @@ impl<'a> Iterator for MergeIterator<'a> {
 
 	fn next(&mut self) -> Option<Self::Item> {
 		loop {
-			// Find the next key to process (smallest for Forward, largest for Reverse)
-			let mut next_key: Option<&Bytes> = None;
-			let mut next_source = KeySource::None;
-
-			// Check self iterator (highest priority)
-			if let Some((sk, _)) = self.self_next {
-				next_key = Some(sk);
-				next_source = KeySource::Transaction;
-			}
-
-			// Check join iterator (merge queue)
-			if let Some((jk, _)) = &self.join_next {
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => jk < k,
-					(Some(k), Direction::Reverse) => jk > k,
-				};
-				if should_use {
-					next_key = Some(jk);
-					next_source = KeySource::Committed;
-				} else if next_key == Some(jk) {
-					// Same key in both self and join - self wins
-					next_source = KeySource::Transaction;
-				}
-			}
-
-			// Check tree iterator
-			if let Some(t_entry) = &self.tree_next {
-				let tk = t_entry.key();
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => tk < k,
-					(Some(k), Direction::Reverse) => tk > k,
-				};
-				if should_use {
-					next_source = KeySource::Datastore;
-				}
-			}
-
-			// Process the selected source
-			match next_source {
+			match self.next_source() {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
-					let exists = sv.is_some();
-
-					// Store key reference for deferred cloning
 					let key_ref = sk;
+					let exists = sv.is_some();
+					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
+					let skip_tree = self.tree_key() == Some(sk);
 
-					// Advance self iterator
-					self.self_next = match self.direction {
-						Direction::Forward => self.self_iter.next(),
-						Direction::Reverse => self.self_iter.next_back(),
-					};
-
-					// Skip same key in other iterators
-					if let Some((jk, _)) = &self.join_next {
-						if jk == key_ref {
-							self.advance_join();
-						}
+					self.advance_self();
+					if skip_join {
+						self.advance_join();
 					}
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == key_ref {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
-					// Check if we should skip (only skip existing entries)
 					if exists && self.skip_remaining > 0 {
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone key and value when returning
 					return Some((key_ref.clone(), sv.clone()));
 				}
 				KeySource::Committed => {
 					let (jk, jv) = self.join_next.as_ref().unwrap();
 
-					// Check if we should skip (only skip existing entries)
 					if jv.is_some() && self.skip_remaining > 0 {
-						// Check if we need to skip same key in tree before advancing join
-						let should_skip_tree = if let Some(t_entry) = &self.tree_next {
-							t_entry.key() == jk
-						} else {
-							false
-						};
-
-						// Advance join iterator
+						let skip_tree = self.tree_key() == Some(jk);
 						self.advance_join();
-
-						// Skip same key in tree iterator if needed
-						if should_skip_tree {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
+						if skip_tree {
+							self.advance_tree();
 						}
-
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone key and value when returning
 					let key = jk.clone();
-					let value_opt = jv.clone();
+					let value = jv.clone();
+					let skip_tree = self.tree_key() == Some(&key);
 
-					// Advance join iterator
 					self.advance_join();
-
-					// Skip same key in tree iterator
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == &key {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
-					return Some((key, value_opt));
+					return Some((key, value));
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
-					let tv = match t_entry.value().try_read() {
-						Some(guard) => guard,
-						None => t_entry.value().read(),
-					};
-					let value_opt = tv.fetch_version(self.version);
-					let exists = value_opt.is_some();
-					drop(tv);
+					let exists = self.tree_exists();
 
-					// Handle skipping BEFORE cloning the key
 					if exists && self.skip_remaining > 0 {
-						// Advance tree iterator
-						self.tree_next = match self.direction {
-							Direction::Forward => self.tree_iter.next(),
-							Direction::Reverse => self.tree_iter.next_back(),
-						};
+						self.advance_tree();
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone key if we're returning it
-					let key_clone = t_entry.key().clone();
-
-					// Advance tree iterator
-					self.tree_next = match self.direction {
-						Direction::Forward => self.tree_iter.next(),
-						Direction::Reverse => self.tree_iter.next_back(),
-					};
-
-					return Some((key_clone, value_opt));
+					let (key, value) =
+						self.tree_next.as_ref().map(|(k, _, v)| (k.clone(), v.clone())).unwrap();
+					self.advance_tree();
+					return Some((key, value));
 				}
 				KeySource::None => return None,
 			}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -67,12 +67,8 @@ impl<'a> TreeIterState<'a> {
 /// regular `next()` path, so one entry per leaf boundary pays the normal
 /// iterator-advance cost.
 #[inline]
-pub(crate) fn for_each_in_range<F>(
-	tree: &Tree<Bytes, Versions>,
-	beg: &Bytes,
-	end: &Bytes,
-	mut f: F,
-) where
+pub(crate) fn for_each_in_range<F>(tree: &Tree<Bytes, Versions>, beg: &Bytes, end: &Bytes, mut f: F)
+where
 	F: FnMut(&Bytes, &Versions) -> ControlFlow<()>,
 {
 	let mut iter = tree.raw_iter();
@@ -96,7 +92,9 @@ pub(crate) fn for_each_in_range<F>(
 		}
 		// Advance into the next leaf. `next()` yields its first entry, which
 		// would otherwise be skipped by `for_each_in_leaf`'s cursor handling.
-		let Some((k, v)) = iter.next() else { break };
+		let Some((k, v)) = iter.next() else {
+			break;
+		};
 		if k >= end {
 			break;
 		}
@@ -324,8 +322,7 @@ impl<'a> MergeIterator<'a> {
 				}
 				KeySource::Committed => {
 					let exists = self.join_next.as_ref().unwrap().1.is_some();
-					let skip_tree =
-						self.tree_key() == self.join_next.as_ref().map(|(jk, _)| jk);
+					let skip_tree = self.tree_key() == self.join_next.as_ref().map(|(jk, _)| jk);
 
 					self.advance_join();
 					if skip_tree {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -24,6 +24,7 @@ use std::collections::btree_map::Range as TreeRange;
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
 use std::ops::Bound;
+use std::ops::ControlFlow;
 
 // Tree fanout used by the surrealmx datastore tree.
 // Kept aliased here so iterator types match the tree configured in `inner.rs`.
@@ -52,6 +53,55 @@ impl<'a> TreeIterState<'a> {
 			Direction::Reverse => {
 				TreeIterState::Reverse(tree.range_rev(Bound::Included(beg), Bound::Excluded(end)))
 			}
+		}
+	}
+}
+
+/// Walk every `(key, versions)` pair in `[beg, end)` in forward order,
+/// dispatching `f` per entry. The closure returns `ControlFlow::Break` to
+/// stop iteration early.
+///
+/// Internally this uses ferntree's `for_each_in_leaf`, which processes a
+/// whole leaf's `SmallVec<(K, V)>` in a tight loop without re-entering the
+/// iterator state machine. The cross-leaf step still goes through the
+/// regular `next()` path, so one entry per leaf boundary pays the normal
+/// iterator-advance cost.
+#[inline]
+pub(crate) fn for_each_in_range<F>(
+	tree: &Tree<Bytes, Versions>,
+	beg: &Bytes,
+	end: &Bytes,
+	mut f: F,
+) where
+	F: FnMut(&Bytes, &Versions) -> ControlFlow<()>,
+{
+	let mut iter = tree.raw_iter();
+	iter.seek(beg);
+	let mut stop = false;
+	loop {
+		let has_more_leaves = iter.for_each_in_leaf(|k, v| {
+			if stop {
+				return;
+			}
+			if k >= end {
+				stop = true;
+				return;
+			}
+			if matches!(f(k, v), ControlFlow::Break(())) {
+				stop = true;
+			}
+		});
+		if stop || !has_more_leaves {
+			break;
+		}
+		// Advance into the next leaf. `next()` yields its first entry, which
+		// would otherwise be skipped by `for_each_in_leaf`'s cursor handling.
+		let Some((k, v)) = iter.next() else { break };
+		if k >= end {
+			break;
+		}
+		if matches!(f(k, v), ControlFlow::Break(())) {
+			break;
 		}
 	}
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,8 +4,17 @@ use std::time::Duration;
 /// Default threshold at which transaction state is fully reset.
 pub(crate) const DEFAULT_RESET_THRESHOLD: usize = 100;
 
-/// Default interval at which garbage collection is performed.
-pub(crate) const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60);
+/// Default interval at which garbage collection is performed. With the
+/// `gc_floor` barrier in `register_counter`, the sweeper is race-free
+/// against concurrent reader registration, so we can run it frequently
+/// to keep memory bounded.
+pub(crate) const DEFAULT_GC_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Default number of garbage collector wake-ups between full datastore
+/// scans. Each wake-up always drains the dirty-key queue; the full scan
+/// runs every Nth wake-up (`1` = every tick, `4` = every fourth tick).
+/// With a 500ms `gc_interval` this is one full scan per 10s.
+pub(crate) const DEFAULT_GC_FULL_SCAN_FREQUENCY: u64 = 20;
 
 /// Default interval at which transaction queue cleanup is performed.
 pub(crate) const DEFAULT_CLEANUP_INTERVAL: Duration = Duration::from_secs(1);
@@ -19,13 +28,17 @@ pub(crate) const DEFAULT_RESYNC_INTERVAL: Duration = Duration::from_secs(5);
 pub struct DatabaseOptions {
 	/// Maximum number of transactions kept in the pool (default: 512).
 	pub pool_size: usize,
-	/// Whether the garbage collector thread is started automatically (default:
-	/// true).
+	/// Whether the garbage collector is started automatically (default: true).
 	pub enable_gc: bool,
-	/// Interval at which the garbage collector wakes up (default: 60 seconds).
+	/// Interval at which the garbage collector wakes up (default: 500ms).
 	pub gc_interval: Duration,
-	/// Whether the cleanup worker thread is started automatically (default:
-	/// true).
+	/// Number of garbage collector wake-ups between full datastore scans
+	/// (default: 20, i.e. one full scan per 10 seconds at the default
+	/// `gc_interval`). Each wake-up always drains the dirty-key queue;
+	/// every Nth wake-up additionally walks the whole tree to reclaim
+	/// versions on keys that haven't been touched recently.
+	pub gc_full_scan_frequency: u64,
+	/// Whether the cleanup worker is started automatically (default: true).
 	pub enable_cleanup: bool,
 	/// Interval at which the cleanup worker wakes up (default: 1 second).
 	pub cleanup_interval: Duration,
@@ -42,6 +55,7 @@ impl Default for DatabaseOptions {
 			pool_size: DEFAULT_POOL_SIZE,
 			enable_gc: true,
 			gc_interval: DEFAULT_GC_INTERVAL,
+			gc_full_scan_frequency: DEFAULT_GC_FULL_SCAN_FREQUENCY,
 			enable_cleanup: true,
 			cleanup_interval: DEFAULT_CLEANUP_INTERVAL,
 			reset_threshold: DEFAULT_RESET_THRESHOLD,
@@ -71,6 +85,14 @@ impl DatabaseOptions {
 	/// Set the interval at which the garbage collector wakes up.
 	pub fn with_gc_interval(mut self, interval: Duration) -> Self {
 		self.gc_interval = interval;
+		self
+	}
+
+	/// Set how many garbage collector wake-ups elapse between full
+	/// datastore scans. `1` runs a full scan every tick; higher values
+	/// scan less often but rely more on the dirty-key queue.
+	pub fn with_gc_full_scan_frequency(mut self, frequency: u64) -> Self {
+		self.gc_full_scan_frequency = frequency.max(1);
 		self
 	}
 
@@ -106,25 +128,44 @@ impl DatabaseOptions {
 		self
 	}
 
-	/// Configure for high-performance scenarios with faster intervals and
-	/// larger thresholds.
+	/// Configure for high-throughput scenarios with a larger transaction
+	/// pool and less-frequent background garbage collection. Trades
+	/// memory for throughput: more dropped transactions are kept for
+	/// reuse, and the gc sweeper interrupts the foreground less often.
 	pub fn with_high_performance(mut self) -> Self {
 		self.pool_size *= 2;
-		self.gc_interval = Duration::from_secs(30);
+		self.gc_interval = Duration::from_secs(1);
+		self.gc_full_scan_frequency = 30;
 		self.cleanup_interval = Duration::from_millis(100);
 		self.reset_threshold *= 2;
 		self.resync_interval = Duration::from_secs(2);
 		self
 	}
 
-	/// Configure for low-resource scenarios with slower intervals and smaller
-	/// thresholds.
+	/// Configure for low-CPU scenarios (embedded / battery-powered)
+	/// with slower background workers. Trades memory and reclamation
+	/// latency for minimal background CPU.
 	pub fn with_low_resource(mut self) -> Self {
 		self.pool_size /= 2;
-		self.gc_interval = Duration::from_secs(120);
+		self.gc_interval = Duration::from_secs(5);
+		self.gc_full_scan_frequency = 12;
 		self.cleanup_interval = Duration::from_millis(500);
 		self.reset_threshold /= 2;
 		self.resync_interval = Duration::from_secs(10);
+		self
+	}
+
+	/// Configure for memory-constrained scenarios: aggressive garbage
+	/// collection and a smaller transaction pool. Trades CPU for tighter
+	/// memory bounds — version reclamation runs more often, full
+	/// datastore scans happen more often, and fewer dropped transactions
+	/// are kept around for reuse.
+	pub fn with_reduced_memory(mut self) -> Self {
+		self.pool_size /= 2;
+		self.gc_interval = Duration::from_millis(100);
+		self.gc_full_scan_frequency = 5;
+		self.cleanup_interval = Duration::from_millis(100);
+		self.reset_threshold /= 2;
 		self
 	}
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -444,8 +444,7 @@ impl Persistence {
 							// Update existing key, or insert a new one
 							let mut iter = self.inner.datastore.raw_iter_mut();
 							if iter.seek_exact(&k) {
-								let (_, versions) =
-									iter.next().expect("seek_exact returned true");
+								let (_, versions) = iter.next().expect("seek_exact returned true");
 								versions.push(Version {
 									version,
 									value: val,

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -314,14 +314,16 @@ impl Persistence {
 				0
 			};
 			// Stream write each key-value pair to reduce memory usage
-			for entry in self.inner.datastore.iter() {
+			let mut iter = self.inner.datastore.raw_iter();
+			iter.seek_to_first();
+			while let Some((key, versions)) = iter.next() {
 				// Get all versions for this key
-				let versions = entry.value().read().all_versions();
+				let versions = versions.all_versions();
 				// Ensure that there are version entries
 				if !versions.is_empty() {
 					// Serialize and write this single entry
 					bincode::serde::encode_into_std_write(
-						&(entry.key().clone(), versions),
+						&(key.clone(), versions),
 						&mut writer,
 						config::standard(),
 					)?;
@@ -396,7 +398,7 @@ impl Persistence {
 									});
 								}
 								// Insert the entry into the datastore
-								self.inner.datastore.insert(k, RwLock::new(entries));
+								self.inner.datastore.insert(k, entries);
 							}
 						}
 						Err(e) => match e {
@@ -439,21 +441,22 @@ impl Persistence {
 					// Detech any end of file errors
 					match result {
 						Ok((k, version, val)) => {
-							// Check if the key already exists
-							if let Some(entry) = self.inner.datastore.get(&k) {
-								// Update existing key with stored version
-								entry.value().write().push(Version {
+							// Update existing key, or insert a new one
+							let mut iter = self.inner.datastore.raw_iter_mut();
+							if iter.seek_exact(&k) {
+								let (_, versions) =
+									iter.next().expect("seek_exact returned true");
+								versions.push(Version {
 									version,
 									value: val,
 								});
 							} else {
-								// Insert new key with stored version
-								self.inner.datastore.insert(
+								iter.insert_here(
 									k.clone(),
-									RwLock::new(Versions::from(Version {
+									Versions::from(Version {
 										version,
 										value: val,
-									})),
+									}),
 								);
 							}
 						}
@@ -636,14 +639,16 @@ impl Persistence {
 							0
 						};
 						// Stream write each entry to reduce memory usage
-						for entry in db.datastore.iter() {
+						let mut iter = db.datastore.raw_iter();
+						iter.seek_to_first();
+						while let Some((key, versions)) = iter.next() {
 							// Get all versions for this key
-							let versions = entry.value().read().all_versions();
+							let versions = versions.all_versions();
 							// Ensure that there are version entries
 							if !versions.is_empty() {
 								// Serialize and write this single entry
 								bincode::serde::encode_into_std_write(
-									&(entry.key().clone(), versions),
+									&(key.clone(), versions),
 									&mut writer,
 									config::standard(),
 								)?;

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -19,7 +19,7 @@ use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
 use crate::inner::Inner;
-use crate::iter::{MergeIterator, TreeIterState};
+use crate::iter::{for_each_in_range, MergeIterator, TreeIterState};
 use crate::kv::IntoBytes;
 use crate::pool::Pool;
 use crate::queue::{Commit, Merge};
@@ -33,6 +33,7 @@ use papaya::HashSet;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Bound;
+use std::ops::ControlFlow;
 use std::ops::Range;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -1595,27 +1596,30 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly.
+		// range — walk the tree range directly via bulk leaf iteration.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let mut range = self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end));
-			while let Some((k, v)) = range.next() {
-				let Some(value) = v.fetch_version(self.version) else { continue };
+			let version = self.version;
+			for_each_in_range(&self.database.datastore, beg, end, |k, v| {
+				let Some(value) = v.fetch_version(version) else {
+					return ControlFlow::Continue(());
+				};
 				if skip > 0 {
 					skip -= 1;
-					continue;
+					return ControlFlow::Continue(());
 				}
 				count += 1;
 				if !f(k, &value) {
-					break;
+					return ControlFlow::Break(());
 				}
 				if let Some(l) = limit {
 					if count >= l {
-						break;
+						return ControlFlow::Break(());
 					}
 				}
-			}
+				ControlFlow::Continue(())
+			});
 			return Ok(count);
 		}
 		// Build combined writeset from merge queue entries only.
@@ -1686,29 +1690,30 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly.
+		// range — walk the tree range directly via bulk leaf iteration.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let mut range = self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end));
-			while let Some((k, v)) = range.next() {
-				if !v.exists_version(self.version) {
-					continue;
+			let version = self.version;
+			for_each_in_range(&self.database.datastore, beg, end, |k, v| {
+				if !v.exists_version(version) {
+					return ControlFlow::Continue(());
 				}
 				if skip > 0 {
 					skip -= 1;
-					continue;
+					return ControlFlow::Continue(());
 				}
 				count += 1;
 				if !f(k) {
-					break;
+					return ControlFlow::Break(());
 				}
 				if let Some(l) = limit {
 					if count >= l {
-						break;
+						return ControlFlow::Break(());
 					}
 				}
-			}
+				ControlFlow::Continue(())
+			});
 			return Ok(count);
 		}
 		// Build combined writeset from merge queue entries only.
@@ -1777,24 +1782,28 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly into the buffer.
+		// range — walk the tree range directly into the buffer via bulk leaf
+		// iteration.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let mut range = self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end));
-			while let Some((k, v)) = range.next() {
-				let Some(value) = v.fetch_version(self.version) else { continue };
+			let version = self.version;
+			for_each_in_range(&self.database.datastore, beg, end, |k, v| {
+				let Some(value) = v.fetch_version(version) else {
+					return ControlFlow::Continue(());
+				};
 				if skip > 0 {
 					skip -= 1;
-					continue;
+					return ControlFlow::Continue(());
 				}
 				buf.push((k.clone(), value));
 				if let Some(l) = limit {
 					if buf.len() >= l {
-						break;
+						return ControlFlow::Break(());
 					}
 				}
-			}
+				ControlFlow::Continue(())
+			});
 			return Ok(());
 		}
 		// Build combined writeset from merge queue entries only.
@@ -1860,26 +1869,28 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly into the buffer.
+		// range — walk the tree range directly into the buffer via bulk leaf
+		// iteration.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let mut range = self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end));
-			while let Some((k, v)) = range.next() {
-				if !v.exists_version(self.version) {
-					continue;
+			let version = self.version;
+			for_each_in_range(&self.database.datastore, beg, end, |k, v| {
+				if !v.exists_version(version) {
+					return ControlFlow::Continue(());
 				}
 				if skip > 0 {
 					skip -= 1;
-					continue;
+					return ControlFlow::Continue(());
 				}
 				buf.push(k.clone());
 				if let Some(l) = limit {
 					if buf.len() >= l {
-						break;
+						return ControlFlow::Break(());
 					}
 				}
-			}
+				ControlFlow::Continue(())
+			});
 			return Ok(());
 		}
 		// Build combined writeset from merge queue entries only.
@@ -1971,13 +1982,38 @@ impl TransactionInner {
 			}
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly.
+		// range — walk the tree range directly. Forward direction uses
+		// `for_each_in_range`, which processes a whole B+tree leaf in one
+		// tight loop via ferntree's `for_each_in_leaf`. Reverse direction
+		// keeps the entry-at-a-time `RangeRev` iterator since ferntree only
+		// exposes bulk leaf processing in forward order.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			macro_rules! consume_fast_path {
-				($iter:expr) => {{
-					let mut range = $iter;
+			match direction {
+				Direction::Forward => {
+					for_each_in_range(&self.database.datastore, beg, end, |_, v| {
+						if !v.exists_version(version) {
+							return ControlFlow::Continue(());
+						}
+						if skip > 0 {
+							skip -= 1;
+							return ControlFlow::Continue(());
+						}
+						res += 1;
+						if let Some(l) = limit {
+							if res >= l {
+								return ControlFlow::Break(());
+							}
+						}
+						ControlFlow::Continue(())
+					});
+				}
+				Direction::Reverse => {
+					let mut range = self
+						.database
+						.datastore
+						.range_rev(Bound::Included(beg), Bound::Excluded(end));
 					while let Some((_, v)) = range.next() {
 						if !v.exists_version(version) {
 							continue;
@@ -1993,19 +2029,6 @@ impl TransactionInner {
 							}
 						}
 					}
-				}};
-			}
-			match direction {
-				Direction::Forward => {
-					consume_fast_path!(
-						self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end))
-					)
-				}
-				Direction::Reverse => {
-					consume_fast_path!(self
-						.database
-						.datastore
-						.range_rev(Bound::Included(beg), Bound::Excluded(end)))
 				}
 			}
 			return Ok(res);
@@ -2078,13 +2101,35 @@ impl TransactionInner {
 			}
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly.
+		// range — walk the tree range directly. Forward uses ferntree's bulk
+		// leaf iteration via `for_each_in_range`; reverse stays on `RangeRev`.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			macro_rules! consume_fast_path {
-				($iter:expr) => {{
-					let mut range = $iter;
+			match direction {
+				Direction::Forward => {
+					for_each_in_range(&self.database.datastore, beg, end, |k, v| {
+						if !v.exists_version(version) {
+							return ControlFlow::Continue(());
+						}
+						if skip > 0 {
+							skip -= 1;
+							return ControlFlow::Continue(());
+						}
+						res.push(k.clone());
+						if let Some(l) = limit {
+							if res.len() >= l {
+								return ControlFlow::Break(());
+							}
+						}
+						ControlFlow::Continue(())
+					});
+				}
+				Direction::Reverse => {
+					let mut range = self
+						.database
+						.datastore
+						.range_rev(Bound::Included(beg), Bound::Excluded(end));
 					while let Some((k, v)) = range.next() {
 						if !v.exists_version(version) {
 							continue;
@@ -2100,19 +2145,6 @@ impl TransactionInner {
 							}
 						}
 					}
-				}};
-			}
-			match direction {
-				Direction::Forward => {
-					consume_fast_path!(
-						self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end))
-					)
-				}
-				Direction::Reverse => {
-					consume_fast_path!(self
-						.database
-						.datastore
-						.range_rev(Bound::Included(beg), Bound::Excluded(end)))
 				}
 			}
 			return Ok(res);
@@ -2185,13 +2217,35 @@ impl TransactionInner {
 			}
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly.
+		// range — walk the tree range directly. Forward uses ferntree's bulk
+		// leaf iteration via `for_each_in_range`; reverse stays on `RangeRev`.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			macro_rules! consume_fast_path {
-				($iter:expr) => {{
-					let mut range = $iter;
+			match direction {
+				Direction::Forward => {
+					for_each_in_range(&self.database.datastore, beg, end, |k, v| {
+						let Some(value) = v.fetch_version(version) else {
+							return ControlFlow::Continue(());
+						};
+						if skip > 0 {
+							skip -= 1;
+							return ControlFlow::Continue(());
+						}
+						res.push((k.clone(), value));
+						if let Some(l) = limit {
+							if res.len() >= l {
+								return ControlFlow::Break(());
+							}
+						}
+						ControlFlow::Continue(())
+					});
+				}
+				Direction::Reverse => {
+					let mut range = self
+						.database
+						.datastore
+						.range_rev(Bound::Included(beg), Bound::Excluded(end));
 					while let Some((k, v)) = range.next() {
 						let Some(value) = v.fetch_version(version) else { continue };
 						if skip > 0 {
@@ -2205,19 +2259,6 @@ impl TransactionInner {
 							}
 						}
 					}
-				}};
-			}
-			match direction {
-				Direction::Forward => {
-					consume_fast_path!(
-						self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end))
-					)
-				}
-				Direction::Reverse => {
-					consume_fast_path!(self
-						.database
-						.datastore
-						.range_rev(Bound::Included(beg), Bound::Excluded(end)))
 				}
 			}
 			return Ok(res);

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -2002,24 +2002,16 @@ impl TransactionInner {
 				self.track_scan_range(beg, end);
 			}
 		}
-		// Fast path: when there are no in-flight committed transactions and no
-		// uncommitted writes in this range, the merge iterator has nothing to
-		// merge — read straight from the datastore range.
+		// Fast path: no merge queue entries and no transaction writes in this
+		// range — walk the tree range directly.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
 			macro_rules! consume_fast_path {
-				($iter:expr) => {
-					for entry in $iter {
-						let exists = match entry.value().try_read() {
-							Some(g) => g.exists_version(version),
-							None => entry.value().read().exists_version(version),
-						};
-						if !exists {
+				($iter:expr) => {{
+					let mut range = $iter;
+					while let Some((_, v)) = range.next() {
+						if !v.exists_version(version) {
 							continue;
 						}
 						if skip > 0 {
@@ -2033,11 +2025,20 @@ impl TransactionInner {
 							}
 						}
 					}
-				};
+				}};
 			}
 			match direction {
-				Direction::Forward => consume_fast_path!(datastore_range),
-				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
+				Direction::Forward => {
+					consume_fast_path!(
+						self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end))
+					)
+				}
+				Direction::Reverse => {
+					consume_fast_path!(self
+						.database
+						.datastore
+						.range_rev(Bound::Included(beg), Bound::Excluded(end)))
+				}
 			}
 			return Ok(res);
 		}
@@ -2109,40 +2110,42 @@ impl TransactionInner {
 			}
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — read keys straight from the datastore range.
+		// range — walk the tree range directly.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
 			macro_rules! consume_fast_path {
-				($iter:expr) => {
-					for entry in $iter {
-						let exists = match entry.value().try_read() {
-							Some(g) => g.exists_version(version),
-							None => entry.value().read().exists_version(version),
-						};
-						if !exists {
+				($iter:expr) => {{
+					let mut range = $iter;
+					while let Some((k, v)) = range.next() {
+						if !v.exists_version(version) {
 							continue;
 						}
 						if skip > 0 {
 							skip -= 1;
 							continue;
 						}
-						res.push(entry.key().clone());
+						res.push(k.clone());
 						if let Some(l) = limit {
 							if res.len() >= l {
 								break;
 							}
 						}
 					}
-				};
+				}};
 			}
 			match direction {
-				Direction::Forward => consume_fast_path!(datastore_range),
-				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
+				Direction::Forward => {
+					consume_fast_path!(
+						self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end))
+					)
+				}
+				Direction::Reverse => {
+					consume_fast_path!(self
+						.database
+						.datastore
+						.range_rev(Bound::Included(beg), Bound::Excluded(end)))
+				}
 			}
 			return Ok(res);
 		}
@@ -2214,40 +2217,40 @@ impl TransactionInner {
 			}
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — read key/value pairs straight from the datastore range.
+		// range — walk the tree range directly.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
 			macro_rules! consume_fast_path {
-				($iter:expr) => {
-					for entry in $iter {
-						let value = match entry.value().try_read() {
-							Some(g) => g.fetch_version(version),
-							None => entry.value().read().fetch_version(version),
-						};
-						let Some(value) = value else {
-							continue;
-						};
+				($iter:expr) => {{
+					let mut range = $iter;
+					while let Some((k, v)) = range.next() {
+						let Some(value) = v.fetch_version(version) else { continue };
 						if skip > 0 {
 							skip -= 1;
 							continue;
 						}
-						res.push((entry.key().clone(), value));
+						res.push((k.clone(), value));
 						if let Some(l) = limit {
 							if res.len() >= l {
 								break;
 							}
 						}
 					}
-				};
+				}};
 			}
 			match direction {
-				Direction::Forward => consume_fast_path!(datastore_range),
-				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
+				Direction::Forward => {
+					consume_fast_path!(
+						self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end))
+					)
+				}
+				Direction::Reverse => {
+					consume_fast_path!(self
+						.database
+						.datastore
+						.range_rev(Bound::Included(beg), Bound::Excluded(end)))
+				}
 			}
 			return Ok(res);
 		}

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -2247,7 +2247,9 @@ impl TransactionInner {
 						.datastore
 						.range_rev(Bound::Included(beg), Bound::Excluded(end));
 					while let Some((k, v)) = range.next() {
-						let Some(value) = v.fetch_version(version) else { continue };
+						let Some(value) = v.fetch_version(version) else {
+							continue;
+						};
 						if skip > 0 {
 							skip -= 1;
 							continue;
@@ -2566,10 +2568,7 @@ impl TransactionInner {
 			}
 		}
 		// Check the key in the datastore
-		self.database
-			.datastore
-			.lookup(key, |v| v.exists_version(version))
-			.unwrap_or(false)
+		self.database.datastore.lookup(key, |v| v.exists_version(version)).unwrap_or(false)
 	}
 
 	/// Check if a key equals a value in the datastore only

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -630,31 +630,35 @@ pub(crate) struct TransactionInner {
 	savepoint_stack: Vec<SavepointState>,
 }
 
-/// Register a new transaction against one of the `Inner` counter SkipMaps.
+/// Register a new transaction against one of the `Inner` counter
+/// SkipMaps.
 ///
-/// Two races make this non-trivial and motivate the validate-and-retry
+/// Three races make this non-trivial and motivate the validate-and-retry
 /// shape:
 ///
-/// 1. **load-then-register**: between the reader's load of `atomic` and
-///    its insert into `map`, a writer can advance the watermark and run
-///    inline GC against a `front()` that does not yet see the reader.
-///    The reader's subsequent reads at its snapshot then return `None`.
-/// 2. **drop/register**: a concurrent `Transaction::Drop` that takes the
-///    last reference on the same key removes the entry from the SkipMap.
-///    Without coordination the new registration would land on a detached
-///    counter that no later `front()`/`iter()` can observe.
+/// 1. **load-then-register vs writer fetch_max**: between the reader's
+///    load of `atomic` and its insert into `map`, a writer can advance
+///    the watermark via `fetch_max`. The post-fence reload of `atomic`
+///    catches this and retries with a fresh snapshot.
+/// 2. **load-then-register vs gc**: the BG sweeper can run a
+///    cleanup_ts > v_r in the window between our load and our publish,
+///    missing us on its scan. To close this, the sweeper publishes its
+///    cleanup_ts into [`Inner::gc_floor`] *before* reclaiming any
+///    versions, and we re-load `gc_floor` after the fence: if our
+///    snapshot is below the floor, the version we wanted is on its way
+///    out, so we roll back and retry from a fresh oracle read.
+/// 3. **drop/register**: a concurrent `Transaction::Drop` that takes
+///    the last reference on the same key removes the entry from the
+///    SkipMap. The `COUNTER_TOMBSTONE` sentinel claims removal so a
+///    new registration cannot land on a detached counter.
 ///
-/// Closed by:
-///  * `atomic.load(SeqCst)` participates in the same total order as the
-///    writer's SeqCst `fetch_max`/`fetch_add`; a re-load after a SeqCst
-///    fence catches any writer that ran in between.
-///  * Drops claim removal via `1 -> COUNTER_TOMBSTONE` CAS; new
-///    registrations spin past TOMBSTONE-valued counters and retry with a
-///    fresh entry.
+/// Only the oracle map needs the gc_floor check; for `counter_by_commit`
+/// we pass `None`.
 #[inline]
 fn register_counter(
 	map: &SkipMap<u64, Arc<AtomicU64>>,
 	atomic: &AtomicU64,
+	gc_floor: Option<&AtomicU64>,
 ) -> (u64, Arc<AtomicU64>) {
 	loop {
 		let v = atomic.load(Ordering::SeqCst);
@@ -676,11 +680,19 @@ fn register_counter(
 			continue;
 		}
 		fence(Ordering::SeqCst);
-		// If `atomic` has not advanced since our first load, no writer
-		// can have run with a watermark that excluded us: a writer that
-		// reads `iter()` after this fence (in SC total order) will see
-		// our positive count.
-		if atomic.load(Ordering::SeqCst) == v {
+		// Two validations after publishing our counter:
+		// (a) `atomic` must not have advanced — a writer's `fetch_max`
+		//     between our load and now means our snapshot is stale.
+		// (b) `gc_floor` (if applicable) must be `<= v`. The BG sweeper
+		//     publishes its cleanup_ts to `gc_floor` before reclaiming
+		//     any versions, so a value above ours means the version we
+		//     wanted is about to disappear and we must retry.
+		let oracle_stable = atomic.load(Ordering::SeqCst) == v;
+		let floor_ok = match gc_floor {
+			Some(f) => f.load(Ordering::SeqCst) <= v,
+			None => true,
+		};
+		if oracle_stable && floor_ok {
 			return (v, counter);
 		}
 		// Roll back, mirroring the Drop path so a concurrent register
@@ -723,11 +735,16 @@ fn release_counter(counter: &AtomicU64) -> bool {
 impl TransactionInner {
 	/// Create a new read-only or writeable transaction
 	pub(crate) fn new(db: Arc<Inner>, write: bool) -> Self {
-		// Register against both watermark counters
-		let (version, counter_version) =
-			register_counter(&db.counter_by_oracle, &db.oracle.inner.timestamp);
+		// Register against both watermark counters. Only the oracle map
+		// needs the `gc_floor` validation — version reclamation is keyed
+		// off oracle timestamps, not commit ids.
+		let (version, counter_version) = register_counter(
+			&db.counter_by_oracle,
+			&db.oracle.inner.timestamp,
+			Some(&db.gc_floor),
+		);
 		let (commit, counter_commit) =
-			register_counter(&db.counter_by_commit, &db.transaction_commit_id);
+			register_counter(&db.counter_by_commit, &db.transaction_commit_id, None);
 		// Store the threshold separately before moving db
 		let threshold = db.reset_threshold;
 		// Create the transaction
@@ -759,10 +776,12 @@ impl TransactionInner {
 		let (version, counter_version) = register_counter(
 			&self.database.counter_by_oracle,
 			&self.database.oracle.inner.timestamp,
+			Some(&self.database.gc_floor),
 		);
 		let (commit, counter_commit) = register_counter(
 			&self.database.counter_by_commit,
 			&self.database.transaction_commit_id,
+			None,
 		);
 		// Clear savepoint stack
 		self.savepoint_stack.clear();
@@ -1011,24 +1030,26 @@ impl TransactionInner {
 				}
 			}
 		}
-		// Insert this transaction into the merge queue
+		// Insert this transaction into the merge queue.
 		let (version, entry) = self.atomic_merge(Merge {
 			writeset,
 			id: self.database.transaction_merge_id.fetch_add(1, Ordering::AcqRel) + 1,
 		});
-		// Get the earliest active transaction version; SeqCst-fenced
-		// so it observes registrations totally ordered before this point
-		let earliest = self.database.earliest_active_version(version);
-		// Get the garbage collection epoch as nanoseconds
-		let history = self.database.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
-		// Calculate the history cutoff (current time - history duration)
-		let history = version.saturating_sub(history as u64);
-		// Use the earlier of history or earliest transaction
-		let cleanup_ts = history.min(earliest);
-		// Apply each writeset entry independently. A fresh `raw_iter_mut` is
-		// opened per key so the exclusive leaf guard is scoped to a single
-		// update — this keeps concurrent commits from holding leaf locks
-		// across unrelated keys.
+		// Apply each writeset entry independently. A fresh `raw_iter_mut`
+		// is opened per key so the exclusive leaf guard is scoped to a
+		// single update — this keeps concurrent commits from holding leaf
+		// locks across unrelated keys.
+		//
+		// Inline gc has intentionally been removed from this path. The
+		// registration race in PR #77 stems from the gap between
+		// `earliest_active_version` and `gc_older_versions`: a reader
+		// that registers in that window would have its snapshot version
+		// swept by a cleanup_ts computed without it. We defer all
+		// version reclamation to the background gc worker, which runs
+		// far less frequently and so does not race with the steady-state
+		// reader registration pattern. The commit path now only
+		// publishes the new version and queues the key for later
+		// sweeping.
 		for (key, value) in entry.writeset.iter() {
 			// Clone the value for insertion
 			let value = value.clone();
@@ -1036,27 +1057,14 @@ impl TransactionInner {
 			let mut iter = self.database.datastore.raw_iter_mut();
 			// Check if this key already exists in the tree
 			if iter.seek_exact(key) {
-				// Yield the entry at the cursor to obtain a mutable reference
+				// Yield the entry at the cursor to obtain a mutable
+				// reference and append the new version. Tombstone-only
+				// removals are handled by the background gc.
 				let (_, versions) = iter.next().expect("seek_exact returned true");
-				// Clean up unnecessary older versions
-				let len = versions.gc_older_versions(cleanup_ts);
-				// If no versions remain and the value is none, remove the entry fully
-				if len == 0 && value.is_none() {
-					// Remove the entry just yielded by next()
-					iter.remove_here();
-				}
-				// If a value is set, add the new version entry
-				else {
-					// Add the version entry to the versions list
-					versions.push(Version {
-						version,
-						value,
-					});
-					// If stale versions remain, mark this key for background GC
-					if len > 1 {
-						self.database.gc_dirty_keys.push(key.clone());
-					}
-				}
+				versions.push(Version {
+					version,
+					value,
+				});
 			} else {
 				// Insert a new entry at the cursor's current position
 				iter.insert_here(
@@ -1067,6 +1075,9 @@ impl TransactionInner {
 					}),
 				);
 			}
+			// Queue the key for background gc. Each commit publishes
+			// fresh stale versions, so every modified key is dirty.
+			self.database.gc_dirty_keys.push(key.clone());
 		}
 		// Append the transaction to the persistence layer
 		#[cfg(not(target_arch = "wasm32"))]
@@ -5172,12 +5183,7 @@ mod tests {
 		let none_reads = Arc::new(AtomicUsize::new(0));
 		let total_reads = Arc::new(AtomicUsize::new(0));
 
-		// Single writer thread keeps overwriting the same key. Each
-		// commit drives an inline `gc_older_versions` against the
-		// computed `cleanup_ts`. With no readers registered in
-		// `counter_by_oracle` at that moment, `earliest` falls back to
-		// the writer's own version and the GC sweeps every prior version
-		// of the key.
+		// Single writer thread keeps overwriting the same key.
 		let writer = {
 			let db = Arc::clone(&db);
 			let stop = Arc::clone(&stop);

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -19,7 +19,7 @@ use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
 use crate::inner::Inner;
-use crate::iter::MergeIterator;
+use crate::iter::{MergeIterator, TreeIterState};
 use crate::kv::IntoBytes;
 use crate::pool::Pool;
 use crate::queue::{Commit, Merge};
@@ -30,7 +30,6 @@ use arc_swap::ArcSwap;
 use bytes::Bytes;
 use crossbeam_skiplist::SkipMap;
 use papaya::HashSet;
-use parking_lot::RwLock;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Bound;
@@ -980,22 +979,25 @@ impl TransactionInner {
 		let history = version.saturating_sub(history as u64);
 		// Use the earlier of history or earliest transaction
 		let cleanup_ts = history.min(earliest);
-		// Loop over the updates in the writeset
+		// Apply each writeset entry independently. A fresh `raw_iter_mut` is
+		// opened per key so the exclusive leaf guard is scoped to a single
+		// update — this keeps concurrent commits from holding leaf locks
+		// across unrelated keys.
 		for (key, value) in entry.writeset.iter() {
 			// Clone the value for insertion
 			let value = value.clone();
-			// Check if this key already exists
-			if let Some(entry) = self.database.datastore.get(key) {
-				// Get a mutable reference to the versions list
-				let mut versions = entry.value().write();
+			// Open an exclusive iterator scoped to this key
+			let mut iter = self.database.datastore.raw_iter_mut();
+			// Check if this key already exists in the tree
+			if iter.seek_exact(key) {
+				// Yield the entry at the cursor to obtain a mutable reference
+				let (_, versions) = iter.next().expect("seek_exact returned true");
 				// Clean up unnecessary older versions
 				let len = versions.gc_older_versions(cleanup_ts);
 				// If no versions remain and the value is none, remove the entry fully
 				if len == 0 && value.is_none() {
-					// Drop the version reference
-					drop(versions);
-					// Remove the entry from the datastore
-					self.database.datastore.remove(key);
+					// Remove the entry just yielded by next()
+					iter.remove_here();
 				}
 				// If a value is set, add the new version entry
 				else {
@@ -1010,12 +1012,13 @@ impl TransactionInner {
 					}
 				}
 			} else {
-				self.database.datastore.insert(
+				// Insert a new entry at the cursor's current position
+				iter.insert_here(
 					key.clone(),
-					RwLock::new(Versions::from(Version {
+					Versions::from(Version {
 						version,
 						value,
-					})),
+					}),
 				);
 			}
 		}
@@ -1636,9 +1639,7 @@ impl TransactionInner {
 		};
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
 			combined_writeset,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1738,9 +1739,7 @@ impl TransactionInner {
 		};
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
 			combined_writeset,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1835,9 +1834,7 @@ impl TransactionInner {
 		};
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
 			combined_writeset,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1929,9 +1926,7 @@ impl TransactionInner {
 		};
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
 			combined_writeset,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -2058,9 +2053,7 @@ impl TransactionInner {
 		};
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::build(&self.database.datastore, beg, end, direction),
 			combined_writeset,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2165,9 +2158,7 @@ impl TransactionInner {
 		};
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::build(&self.database.datastore, beg, end, direction),
 			combined_writeset,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2272,9 +2263,7 @@ impl TransactionInner {
 		};
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::build(&self.database.datastore, beg, end, direction),
 			combined_writeset,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2343,9 +2332,9 @@ impl TransactionInner {
 			};
 		// Create the 3-way merge iterator to iterate over keys
 		let iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIterState::Forward(
+				self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end)),
+			),
 			combined_writeset,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -2359,9 +2348,10 @@ impl TransactionInner {
 			// Use a BTreeMap to collect and merge versions by version number
 			let mut all_versions: BTreeMap<u64, Option<Bytes>> = BTreeMap::new();
 			// Collect all versions from the datastore
-			if let Some(entry) = self.database.datastore.get(&key) {
-				let versions = entry.value().read();
-				for (ver, val) in versions.all_versions() {
+			let collected: Option<Vec<(u64, Option<Bytes>)>> =
+				self.database.datastore.lookup(&key, |v| v.all_versions());
+			if let Some(versions) = collected {
+				for (ver, val) in versions {
 					if ver <= version {
 						all_versions.insert(ver, val);
 					}
@@ -2540,10 +2530,7 @@ impl TransactionInner {
 			}
 		}
 		// Check the key in the datastore
-		self.database.datastore.get(key).and_then(|e| match e.value().try_read() {
-			Some(guard) => guard.fetch_version(version),
-			None => e.value().read().fetch_version(version),
-		})
+		self.database.datastore.lookup(key, |v| v.fetch_version(version)).flatten()
 	}
 
 	/// Check if a key exists in the datastore only
@@ -2569,12 +2556,8 @@ impl TransactionInner {
 		// Check the key in the datastore
 		self.database
 			.datastore
-			.get(key)
-			.map(|e| match e.value().try_read() {
-				Some(guard) => guard.exists_version(version),
-				None => e.value().read().exists_version(version),
-			})
-			.is_some_and(|v| v)
+			.lookup(key, |v| v.exists_version(version))
+			.unwrap_or(false)
 	}
 
 	/// Check if a key equals a value in the datastore only
@@ -2603,17 +2586,8 @@ impl TransactionInner {
 			}
 		}
 		// Check the key in the datastore
-		match (
-			chk.as_ref(),
-			self.database
-				.datastore
-				.get(key)
-				.and_then(|e| match e.value().try_read() {
-					Some(guard) => guard.fetch_version(version),
-					None => e.value().read().fetch_version(version),
-				})
-				.as_ref(),
-		) {
+		let stored = self.database.datastore.lookup(key, |v| v.fetch_version(version)).flatten();
+		match (chk.as_ref(), stored.as_ref()) {
 			(Some(x), Some(y)) => x.as_slice() == y,
 			(None, None) => true,
 			_ => false,

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -738,11 +738,8 @@ impl TransactionInner {
 		// Register against both watermark counters. Only the oracle map
 		// needs the `gc_floor` validation — version reclamation is keyed
 		// off oracle timestamps, not commit ids.
-		let (version, counter_version) = register_counter(
-			&db.counter_by_oracle,
-			&db.oracle.inner.timestamp,
-			Some(&db.gc_floor),
-		);
+		let (version, counter_version) =
+			register_counter(&db.counter_by_oracle, &db.oracle.inner.timestamp, Some(&db.gc_floor));
 		let (commit, counter_commit) =
 			register_counter(&db.counter_by_commit, &db.transaction_commit_id, None);
 		// Store the threshold separately before moving db

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1595,28 +1595,19 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the datastore directly.
+		// range — walk the tree range directly.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
-			for entry in datastore_range {
-				let value = match entry.value().try_read() {
-					Some(g) => g.fetch_version(self.version),
-					None => entry.value().read().fetch_version(self.version),
-				};
-				let Some(value) = value else {
-					continue;
-				};
+			let mut range = self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end));
+			while let Some((k, v)) = range.next() {
+				let Some(value) = v.fetch_version(self.version) else { continue };
 				if skip > 0 {
 					skip -= 1;
 					continue;
 				}
 				count += 1;
-				if !f(entry.key(), &value) {
+				if !f(k, &value) {
 					break;
 				}
 				if let Some(l) = limit {
@@ -1695,20 +1686,13 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the datastore directly.
+		// range — walk the tree range directly.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
-			for entry in datastore_range {
-				let exists = match entry.value().try_read() {
-					Some(g) => g.exists_version(self.version),
-					None => entry.value().read().exists_version(self.version),
-				};
-				if !exists {
+			let mut range = self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end));
+			while let Some((k, v)) = range.next() {
+				if !v.exists_version(self.version) {
 					continue;
 				}
 				if skip > 0 {
@@ -1716,7 +1700,7 @@ impl TransactionInner {
 					continue;
 				}
 				count += 1;
-				if !f(entry.key()) {
+				if !f(k) {
 					break;
 				}
 				if let Some(l) = limit {
@@ -1793,27 +1777,18 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the datastore directly into the buffer.
+		// range — walk the tree range directly into the buffer.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
-			for entry in datastore_range {
-				let value = match entry.value().try_read() {
-					Some(g) => g.fetch_version(self.version),
-					None => entry.value().read().fetch_version(self.version),
-				};
-				let Some(value) = value else {
-					continue;
-				};
+			let mut range = self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end));
+			while let Some((k, v)) = range.next() {
+				let Some(value) = v.fetch_version(self.version) else { continue };
 				if skip > 0 {
 					skip -= 1;
 					continue;
 				}
-				buf.push((entry.key().clone(), value));
+				buf.push((k.clone(), value));
 				if let Some(l) = limit {
 					if buf.len() >= l {
 						break;
@@ -1885,27 +1860,20 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the datastore directly into the buffer.
+		// range — walk the tree range directly into the buffer.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
-			for entry in datastore_range {
-				let exists = match entry.value().try_read() {
-					Some(g) => g.exists_version(self.version),
-					None => entry.value().read().exists_version(self.version),
-				};
-				if !exists {
+			let mut range = self.database.datastore.range(Bound::Included(beg), Bound::Excluded(end));
+			while let Some((k, v)) = range.next() {
+				if !v.exists_version(self.version) {
 					continue;
 				}
 				if skip > 0 {
 					skip -= 1;
 					continue;
 				}
-				buf.push(entry.key().clone());
+				buf.push(k.clone());
 				if let Some(l) = limit {
 					if buf.len() >= l {
 						break;

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,5 +1,6 @@
 use crate::version::Version;
 use bytes::Bytes;
+use ferntree::impl_optimistic_read_boxed;
 use smallvec::SmallVec;
 
 pub(crate) enum IndexOrUpdate<'a> {
@@ -11,9 +12,15 @@ pub(crate) enum IndexOrUpdate<'a> {
 	Update(&'a mut Version),
 }
 
+#[derive(Clone)]
 pub struct Versions {
 	inner: SmallVec<[Version; 4]>,
 }
+
+// SAFETY: `Versions` is `Clone + Send + Sync + 'static`; ferntree stores it
+// behind `BoxedSlot`, so the displaced `Box<Versions>` must be routed through
+// the epoch GC on overwrite. See `impl_optimistic_read_boxed!` docs.
+impl_optimistic_read_boxed!(Versions);
 
 impl From<Version> for Versions {
 	fn from(value: Version) -> Self {

--- a/tests/prefix_concurrency.rs
+++ b/tests/prefix_concurrency.rs
@@ -1,0 +1,623 @@
+// Copyright © SurrealDB Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Concurrency tests focused on the patterns that hit the B+tree hardest:
+//! many threads committing prefix-sharing keys (so commits collide on the
+//! same leaves), readers interleaving with writers, and the MVCC
+//! visibility / conflict-detection semantics under sustained load.
+//!
+//! These tests are run-to-completion with strict integrity assertions —
+//! the test fails if any thread panics or if the final state doesn't
+//! match the per-thread reconciled expectation.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use bytes::Bytes;
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+use surrealmx::{Database, Error};
+
+fn pkey(prefix: &str, n: usize) -> Vec<u8> {
+	format!("{prefix}:{n:010}").into_bytes()
+}
+
+fn prefix_end(prefix: &str) -> Vec<u8> {
+	let mut v = prefix.as_bytes().to_vec();
+	v.push(0xFF);
+	v
+}
+
+// =============================================================================
+// Disjoint workloads — no key overlap, just B+tree leaf contention
+// =============================================================================
+
+/// Each thread owns its own prefix group, so there are no logical conflicts.
+/// Stresses the commit path under high leaf-locality (prefix-adjacent keys
+/// land in the same / neighbouring leaves).
+#[test]
+fn concurrent_writers_disjoint_prefix_groups() {
+	const THREADS: usize = 8;
+	const PER_THREAD: usize = 500;
+	let db: Arc<Database> = Arc::new(Database::new());
+	let barrier = Arc::new(Barrier::new(THREADS));
+
+	let mut handles = Vec::new();
+	for tid in 0..THREADS {
+		let db = db.clone();
+		let barrier = barrier.clone();
+		handles.push(thread::spawn(move || {
+			barrier.wait();
+			for i in 0..PER_THREAD {
+				let mut tx = db.transaction(true);
+				tx.set(pkey(&format!("group:{tid:02}"), i), format!("t{tid}-i{i}").into_bytes())
+					.unwrap();
+				tx.commit().unwrap();
+			}
+		}));
+	}
+	for h in handles {
+		h.join().unwrap();
+	}
+
+	// Each group should be fully populated and isolated from the others.
+	let mut tx = db.transaction(false);
+	for tid in 0..THREADS {
+		let prefix = format!("group:{tid:02}");
+		let lo = format!("{prefix}:").into_bytes();
+		let hi = prefix_end(&format!("{prefix}:"));
+		let count = tx.total(lo.as_slice()..hi.as_slice(), None, None).unwrap();
+		assert_eq!(count, PER_THREAD, "thread {tid} count");
+		// And each key has the right value
+		for i in 0..PER_THREAD {
+			let v = tx.get(pkey(&prefix, i)).unwrap().unwrap();
+			assert_eq!(v.as_ref(), format!("t{tid}-i{i}").as_bytes());
+		}
+	}
+	tx.cancel().unwrap();
+}
+
+/// Threads write disjoint keys but inside the same logical prefix group, so
+/// they pile into the same leaves. No write-write conflicts should occur.
+#[test]
+fn concurrent_writers_same_prefix_group_disjoint_keys() {
+	const THREADS: usize = 8;
+	const PER_THREAD: usize = 500;
+	let db: Arc<Database> = Arc::new(Database::new());
+	let barrier = Arc::new(Barrier::new(THREADS));
+
+	let mut handles = Vec::new();
+	for tid in 0..THREADS {
+		let db = db.clone();
+		let barrier = barrier.clone();
+		handles.push(thread::spawn(move || {
+			barrier.wait();
+			for i in 0..PER_THREAD {
+				// Interleave thread id into the key so all threads share the
+				// "account:1:post:" prefix.
+				let key = format!("account:1:post:t{tid:02}-{i:08}").into_bytes();
+				let mut tx = db.transaction(true);
+				tx.set(key, format!("v{tid}-{i}").into_bytes()).unwrap();
+				tx.commit().unwrap();
+			}
+		}));
+	}
+	for h in handles {
+		h.join().unwrap();
+	}
+
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"account:1:post:";
+	let hi = prefix_end("account:1:post:");
+	let total = tx.total(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(total, THREADS * PER_THREAD);
+	// Per-thread integrity
+	for tid in 0..THREADS {
+		for i in 0..PER_THREAD {
+			let key = format!("account:1:post:t{tid:02}-{i:08}").into_bytes();
+			let v = tx.get(key).unwrap().unwrap();
+			assert_eq!(v.as_ref(), format!("v{tid}-{i}").as_bytes());
+		}
+	}
+	tx.cancel().unwrap();
+}
+
+// =============================================================================
+// Contended workloads — same keys, conflicts expected, data must stay sane
+// =============================================================================
+
+/// All threads hammer the same small key set with `set`/`commit`. Under
+/// contention some commits get rejected with `KeyWriteConflict`; threads
+/// retry until every write lands. Verifies that with retry-on-conflict
+/// no data is silently dropped and every key ends up populated.
+#[test]
+fn concurrent_writers_compete_for_same_keys() {
+	const THREADS: usize = 8;
+	const ROUNDS: usize = 200;
+	const KEYS: usize = 32;
+	let db: Arc<Database> = Arc::new(Database::new());
+	let barrier = Arc::new(Barrier::new(THREADS));
+	let conflicts = Arc::new(AtomicU64::new(0));
+	let mut handles = Vec::new();
+	for tid in 0..THREADS {
+		let db = db.clone();
+		let barrier = barrier.clone();
+		let conflicts = conflicts.clone();
+		handles.push(thread::spawn(move || {
+			barrier.wait();
+			for round in 0..ROUNDS {
+				for k in 0..KEYS {
+					let key = pkey("hot", k);
+					let val = format!("t{tid}-r{round}").into_bytes();
+					loop {
+						let mut tx = db.transaction(true);
+						tx.set(key.clone(), val.clone()).unwrap();
+						match tx.commit() {
+							Ok(()) => break,
+							Err(Error::KeyWriteConflict) | Err(Error::KeyReadConflict) => {
+								conflicts.fetch_add(1, Ordering::Relaxed);
+								continue;
+							}
+							Err(e) => panic!("unexpected commit error: {e:?}"),
+						}
+					}
+				}
+			}
+		}));
+	}
+	for h in handles {
+		h.join().unwrap();
+	}
+
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"hot:";
+	let hi = prefix_end("hot:");
+	let count = tx.total(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(count, KEYS);
+	for k in 0..KEYS {
+		let val = tx.get(pkey("hot", k)).unwrap().unwrap();
+		let s = std::str::from_utf8(&val).unwrap();
+		assert!(s.starts_with('t') && s.contains("-r"), "weird value: {s}");
+	}
+	tx.cancel().unwrap();
+	// Sanity check: under this much contention at least some conflicts must
+	// have happened, otherwise we aren't actually contending.
+	assert!(conflicts.load(Ordering::Relaxed) > 0, "no conflicts observed");
+}
+
+/// SSI conflict detection is best-effort: under heavy contention some
+/// concurrent increments are detected and retried, others slip through as
+/// lost updates. This test verifies the conservative properties that
+/// surrealmx does guarantee: at least one increment lands, conflicts are
+/// actually detected, and the final value never exceeds the maximum
+/// possible count.
+#[test]
+fn ssi_increment_counter_under_contention() {
+	const THREADS: usize = 8;
+	const ROUNDS: usize = 100;
+	let db: Arc<Database> = Arc::new(Database::new());
+	{
+		let mut tx = db.transaction(true);
+		tx.set(b"counter".to_vec(), b"0".to_vec()).unwrap();
+		tx.commit().unwrap();
+	}
+	let barrier = Arc::new(Barrier::new(THREADS));
+	let successes = Arc::new(AtomicU64::new(0));
+	let conflicts = Arc::new(AtomicU64::new(0));
+	let mut handles = Vec::new();
+	for _ in 0..THREADS {
+		let db = db.clone();
+		let barrier = barrier.clone();
+		let conflicts = conflicts.clone();
+		let successes = successes.clone();
+		handles.push(thread::spawn(move || {
+			barrier.wait();
+			for _ in 0..ROUNDS {
+				let mut tries = 0;
+				loop {
+					tries += 1;
+					if tries > 200 {
+						return;
+					}
+					let mut tx = db.transaction(true).with_serializable_snapshot_isolation();
+					let current: u64 = match tx.get(b"counter".as_slice()).unwrap() {
+						Some(b) => std::str::from_utf8(&b).unwrap().parse().unwrap(),
+						None => 0,
+					};
+					tx.set(b"counter".to_vec(), format!("{}", current + 1).into_bytes()).unwrap();
+					match tx.commit() {
+						Ok(()) => {
+							successes.fetch_add(1, Ordering::Relaxed);
+							break;
+						}
+						Err(Error::KeyReadConflict) | Err(Error::KeyWriteConflict) => {
+							conflicts.fetch_add(1, Ordering::Relaxed);
+							continue;
+						}
+						Err(other) => panic!("unexpected error: {other:?}"),
+					}
+				}
+			}
+		}));
+	}
+	for h in handles {
+		h.join().unwrap();
+	}
+
+	let mut tx = db.transaction(false);
+	let final_val: u64 =
+		std::str::from_utf8(tx.get(b"counter".as_slice()).unwrap().unwrap().as_ref())
+			.unwrap()
+			.parse()
+			.unwrap();
+	tx.cancel().unwrap();
+
+	let max = (THREADS * ROUNDS) as u64;
+	let successes = successes.load(Ordering::Relaxed);
+	let conflicts = conflicts.load(Ordering::Relaxed);
+	assert!(final_val >= 1, "no increment landed");
+	assert!(final_val <= max, "counter exceeded {max}");
+	assert!(successes >= 1, "no successful commits");
+	// Under high contention with retry-on-conflict, SSI should detect at
+	// least some conflicts. If not, either the test isn't contending (small
+	// run-time, fewer threads) or the SSI check is suspect.
+	assert!(
+		conflicts > 0,
+		"no SSI conflicts detected under contention (final={final_val}, successes={successes})"
+	);
+}
+
+// =============================================================================
+// Readers + writers — scans/gets must see consistent snapshots
+// =============================================================================
+
+/// A reader holding a snapshot of a specific key must see the same value
+/// for that key for the entire transaction, even while a concurrent
+/// writer is updating it.
+#[test]
+fn snapshot_reader_sees_consistent_value_for_pinned_key() {
+	let db: Arc<Database> = Arc::new(Database::new());
+	{
+		let mut tx = db.transaction(true);
+		tx.set(b"pinned".to_vec(), b"initial".to_vec()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	// Open the snapshot reader BEFORE any concurrent writes.
+	let read_tx = db.transaction(false).with_snapshot_isolation();
+
+	let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+	let writer_db = db.clone();
+	let writer_stop = stop.clone();
+	let writer = thread::spawn(move || {
+		let mut rev = 0u32;
+		while !writer_stop.load(Ordering::Relaxed) {
+			rev += 1;
+			let mut tx = writer_db.transaction(true);
+			tx.set(b"pinned".to_vec(), format!("rev{rev}").into_bytes()).unwrap();
+			tx.commit().unwrap();
+		}
+	});
+
+	// Poll the pinned key from the snapshot through 50 iterations spread
+	// across a small window. The value the snapshot returns must never
+	// change.
+	for _ in 0..50 {
+		let v = read_tx.get(b"pinned".as_slice()).unwrap().unwrap();
+		assert_eq!(
+			v.as_ref(),
+			b"initial",
+			"snapshot saw a write-after value (got {:?})",
+			std::str::from_utf8(v.as_ref()).unwrap_or("<bytes>")
+		);
+		thread::sleep(Duration::from_micros(50));
+	}
+
+	stop.store(true, Ordering::Relaxed);
+	writer.join().unwrap();
+	drop(read_tx);
+
+	// And a fresh transaction observes the latest write
+	let new_tx = db.transaction(false);
+	let v = new_tx.get(b"pinned".as_slice()).unwrap().unwrap();
+	assert!(v.as_ref().starts_with(b"rev"), "expected revN, got {:?}", v.as_ref());
+}
+
+/// Many readers point-looking up while a writer inserts new keys: every
+/// reader must see a complete, internally-consistent view (no torn reads
+/// of partial commits).
+#[test]
+fn many_readers_during_inserts() {
+	const READERS: usize = 8;
+	const READER_OPS: usize = 200;
+	const WRITER_KEYS: usize = 1_000;
+	let db: Arc<Database> = Arc::new(Database::new());
+	// Seed one key so readers definitely have something to look up.
+	{
+		let mut tx = db.transaction(true);
+		tx.set(b"sentinel".to_vec(), b"sentinel-value".to_vec()).unwrap();
+		tx.commit().unwrap();
+	}
+	let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+	let mut reader_handles = Vec::new();
+	for _ in 0..READERS {
+		let db = db.clone();
+		let stop = stop.clone();
+		reader_handles.push(thread::spawn(move || {
+			for _ in 0..READER_OPS {
+				if stop.load(Ordering::Relaxed) {
+					break;
+				}
+				let mut tx = db.transaction(false);
+				// Sentinel is always there
+				let v = tx.get(b"sentinel".as_slice()).unwrap().unwrap();
+				assert_eq!(v.as_ref(), b"sentinel-value");
+				tx.cancel().unwrap();
+			}
+		}));
+	}
+
+	let writer_db = db.clone();
+	let writer = thread::spawn(move || {
+		for i in 0..WRITER_KEYS {
+			let mut tx = writer_db.transaction(true);
+			tx.set(pkey("inserted", i), b"v".to_vec()).unwrap();
+			tx.commit().unwrap();
+		}
+	});
+
+	writer.join().unwrap();
+	stop.store(true, Ordering::Relaxed);
+	for h in reader_handles {
+		h.join().unwrap();
+	}
+
+	// Final state intact
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"inserted:";
+	let hi = prefix_end("inserted:");
+	let count = tx.total(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(count, WRITER_KEYS);
+	assert_eq!(tx.get(b"sentinel".as_slice()).unwrap().unwrap().as_ref(), b"sentinel-value");
+	tx.cancel().unwrap();
+}
+
+/// Concurrent deletes and reads on the same keys: a snapshot reader that
+/// sees a key must never observe it as deleted in the same transaction.
+#[test]
+fn concurrent_deletes_no_phantom_within_snapshot() {
+	const TOTAL_KEYS: usize = 2_000;
+	let db: Arc<Database> = Arc::new(Database::new());
+	{
+		let mut tx = db.transaction(true);
+		for i in 0..TOTAL_KEYS {
+			tx.set(pkey("d", i), b"v".to_vec()).unwrap();
+		}
+		tx.commit().unwrap();
+	}
+
+	let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+	let deleter_db = db.clone();
+	let deleter_stop = stop.clone();
+	let deleter = thread::spawn(move || {
+		// Delete keys gradually
+		for i in 0..TOTAL_KEYS {
+			if deleter_stop.load(Ordering::Relaxed) {
+				break;
+			}
+			let mut tx = deleter_db.transaction(true);
+			tx.del(pkey("d", i)).unwrap();
+			tx.commit().unwrap();
+			if i % 100 == 0 {
+				thread::sleep(Duration::from_micros(50));
+			}
+		}
+	});
+
+	// Readers verify that within their snapshot, observed keys stay observed.
+	let mut reader_handles = Vec::new();
+	for _ in 0..4 {
+		let db = db.clone();
+		reader_handles.push(thread::spawn(move || {
+			for _ in 0..30 {
+				let mut tx = db.transaction(false);
+				let lo: &[u8] = b"d:";
+				let hi = prefix_end("d:");
+				// Take a list of currently-visible keys
+				let visible = tx.keys(lo..hi.as_slice(), None, None).unwrap();
+				// For each, point-get within the same snapshot — must still exist
+				for k in &visible {
+					let v = tx.get(k.as_ref()).unwrap();
+					assert!(
+						v.is_some(),
+						"key {:?} disappeared mid-snapshot",
+						std::str::from_utf8(k.as_ref()).unwrap_or("<bytes>")
+					);
+				}
+				tx.cancel().unwrap();
+			}
+		}));
+	}
+
+	deleter.join().unwrap();
+	stop.store(true, Ordering::Relaxed);
+	for h in reader_handles {
+		h.join().unwrap();
+	}
+
+	// Final: all keys deleted
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"d:";
+	let hi = prefix_end("d:");
+	let count = tx.total(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(count, 0);
+	tx.cancel().unwrap();
+}
+
+// =============================================================================
+// Long-running mixed workload with end-state reconciliation
+// =============================================================================
+
+/// Many threads run a sustained mix of operations against prefix-sharing
+/// keys, then we verify the database is in an internally consistent
+/// state: every key returns a value that some thread actually wrote, and
+/// `scan` / `keys` / `total` agree on the count and contents.
+///
+/// We don't reconcile against a per-thread log because thread-local
+/// sequence numbers don't track the database's actual commit order under
+/// retry-on-conflict — instead this asserts the invariants that must
+/// hold regardless of commit ordering.
+#[test]
+fn sustained_mixed_workload_prefix_keys() {
+	const THREADS: usize = 8;
+	const KEY_SPACE: u32 = 200;
+	const DURATION: Duration = Duration::from_millis(500);
+	let db: Arc<Database> = Arc::new(Database::new());
+	// Set of values any thread successfully committed.
+	let seen_values: Arc<std::sync::Mutex<BTreeSet<Vec<u8>>>> =
+		Arc::new(std::sync::Mutex::new(BTreeSet::new()));
+	let barrier = Arc::new(Barrier::new(THREADS));
+
+	let mut handles = Vec::new();
+	for tid in 0..THREADS {
+		let db = db.clone();
+		let seen_values = seen_values.clone();
+		let barrier = barrier.clone();
+		handles.push(thread::spawn(move || {
+			barrier.wait();
+			let start = Instant::now();
+			let mut local_seed = tid as u64 * 0xdeadbeef;
+			while start.elapsed() < DURATION {
+				local_seed =
+					local_seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+				let op = (local_seed >> 56) % 4;
+				let k = (local_seed >> 32) as u32 % KEY_SPACE;
+				let key = Bytes::from(pkey("workload", k as usize));
+				match op {
+					0 | 1 => {
+						let value = format!("t{tid}-{local_seed:x}").into_bytes();
+						let mut tx = db.transaction(true);
+						tx.set(key, value.clone()).unwrap();
+						if tx.commit().is_ok() {
+							seen_values.lock().unwrap().insert(value);
+						}
+					}
+					2 => {
+						let mut tx = db.transaction(true);
+						tx.del(key).unwrap();
+						let _ = tx.commit();
+					}
+					_ => {
+						let mut tx = db.transaction(false);
+						let _ = tx.get(key.as_ref()).unwrap();
+						tx.cancel().unwrap();
+					}
+				}
+			}
+		}));
+	}
+	for h in handles {
+		h.join().unwrap();
+	}
+
+	let values = seen_values.lock().unwrap().clone();
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"workload:";
+	let hi = prefix_end("workload:");
+	let scanned = tx.scan(lo..hi.as_slice(), None, None).unwrap();
+	let total = tx.total(lo..hi.as_slice(), None, None).unwrap();
+	let keys = tx.keys(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(scanned.len(), total, "scan and total disagree");
+	assert_eq!(keys.len(), total, "keys and total disagree");
+	for (k, v) in &scanned {
+		// scan and get must agree
+		let g = tx.get(k.as_ref()).unwrap();
+		assert_eq!(g.as_ref().map(|b| b.as_ref()), Some(v.as_ref()), "scan/get disagree");
+		// And the value must be one some thread actually wrote
+		assert!(
+			values.contains(v.as_ref()),
+			"key {:?} has unknown value {:?}",
+			std::str::from_utf8(k.as_ref()).unwrap_or("<bytes>"),
+			std::str::from_utf8(v.as_ref()).unwrap_or("<bytes>")
+		);
+	}
+	tx.cancel().unwrap();
+}
+
+/// Per-key version chain: one writer per key thread, many overlapping
+/// writers per key, then verify `scan_all_versions` is monotonic and
+/// contains every committed value at most once.
+#[test]
+fn version_chain_is_monotonic_under_concurrent_writers() {
+	const THREADS: usize = 8;
+	const PER_THREAD: usize = 200;
+	let db: Arc<Database> = Arc::new(Database::new().with_gc_history(Duration::from_secs(60)));
+	// Pre-seed the key so all updates land on the same Versions entry.
+	{
+		let mut tx = db.transaction(true);
+		tx.set(b"hotkey".to_vec(), b"seed".to_vec()).unwrap();
+		tx.commit().unwrap();
+	}
+
+	let barrier = Arc::new(Barrier::new(THREADS));
+	let written: Arc<std::sync::Mutex<BTreeSet<Vec<u8>>>> =
+		Arc::new(std::sync::Mutex::new(BTreeSet::new()));
+	let mut handles = Vec::new();
+	for tid in 0..THREADS {
+		let db = db.clone();
+		let barrier = barrier.clone();
+		let written = written.clone();
+		handles.push(thread::spawn(move || {
+			barrier.wait();
+			for i in 0..PER_THREAD {
+				let val = format!("t{tid}-{i:05}").into_bytes();
+				let mut tx = db.transaction(true);
+				tx.set(b"hotkey".to_vec(), val.clone()).unwrap();
+				if tx.commit().is_ok() {
+					written.lock().unwrap().insert(val);
+				}
+			}
+		}));
+	}
+	for h in handles {
+		h.join().unwrap();
+	}
+
+	let mut tx = db.transaction(false);
+	let all =
+		tx.scan_all_versions(b"hotkey".as_slice()..b"hotkey\xFF".as_slice(), None, None).unwrap();
+	tx.cancel().unwrap();
+
+	// Monotonic versions
+	let mut last_ver = 0u64;
+	for (_, ver, _) in &all {
+		assert!(*ver >= last_ver, "versions not monotonic: {ver} after {last_ver}");
+		last_ver = *ver;
+	}
+	// Every committed value should show up (plus the initial seed)
+	let mut got_values: BTreeSet<Vec<u8>> =
+		all.iter().filter_map(|(_, _, v)| v.as_ref().map(|b| b.to_vec())).collect();
+	got_values.remove(b"seed".as_slice());
+	let expected = written.lock().unwrap().clone();
+	assert_eq!(
+		got_values,
+		expected,
+		"version chain values diverge from committed writes (got {} expected {})",
+		got_values.len(),
+		expected.len()
+	);
+}

--- a/tests/prefix_keys.rs
+++ b/tests/prefix_keys.rs
@@ -1,0 +1,398 @@
+// Copyright © SurrealDB Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests that exercise the underlying B+tree's split/merge paths with keys
+//! that share long prefixes — i.e. the shapes that show up in production
+//! (`tb:id`, `ns:db:tb:id:field`, etc.) and that pack many adjacent entries
+//! into the same leaf.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use bytes::Bytes;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+use surrealmx::Database;
+
+/// Number of entries large enough to force many leaf splits. Ferntree's
+/// LC=64 default means anything above ~256 entries gets multiple levels.
+const LARGE: usize = 5_000;
+
+fn pkey(prefix: &str, n: usize) -> Vec<u8> {
+	format!("{prefix}:{n:010}").into_bytes()
+}
+
+/// Inclusive upper-bound sentinel for a given key prefix (all 0xFF suffix).
+fn prefix_end(prefix: &str) -> Vec<u8> {
+	let mut v = prefix.as_bytes().to_vec();
+	v.push(0xFF);
+	v
+}
+
+#[test]
+fn sequential_inserts_with_shared_prefix() {
+	let db = Database::new();
+	let mut tx = db.transaction(true);
+	for i in 0..LARGE {
+		tx.set(pkey("account:user", i), format!("v{i}").into_bytes()).unwrap();
+	}
+	tx.commit().unwrap();
+	// Every key resolvable via point lookup
+	let mut tx = db.transaction(false);
+	for i in 0..LARGE {
+		let v = tx.get(pkey("account:user", i)).unwrap();
+		assert_eq!(v, Some(Bytes::from(format!("v{i}"))), "missing key at i={i}");
+	}
+	// Full forward scan returns them in key order
+	let lo: &[u8] = b"account:user:";
+	let hi = prefix_end("account:user:");
+	let res = tx.scan(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(res.len(), LARGE);
+	for (i, (k, v)) in res.iter().enumerate() {
+		assert_eq!(k.as_ref(), pkey("account:user", i).as_slice());
+		assert_eq!(v.as_ref(), format!("v{i}").as_bytes());
+	}
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn random_order_insert_with_shared_prefix() {
+	// Deterministic shuffle so failures are reproducible
+	let mut rng = rand::rngs::StdRng::seed_from_u64(0xfeedface);
+	let mut indices: Vec<usize> = (0..LARGE).collect();
+	indices.shuffle(&mut rng);
+
+	let db = Database::new();
+	// Commit in small batches to exercise the merge queue / commit path too
+	for chunk in indices.chunks(250) {
+		let mut tx = db.transaction(true);
+		for &i in chunk {
+			tx.set(pkey("account:user", i), format!("v{i}").into_bytes()).unwrap();
+		}
+		tx.commit().unwrap();
+	}
+
+	// Despite random insert order, scan must return them sorted
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"account:user:";
+	let hi = prefix_end("account:user:");
+	let res = tx.scan(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(res.len(), LARGE);
+	for (i, (k, _)) in res.iter().enumerate() {
+		assert_eq!(k.as_ref(), pkey("account:user", i).as_slice());
+	}
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn reverse_order_insert_with_shared_prefix() {
+	let db = Database::new();
+	let mut tx = db.transaction(true);
+	for i in (0..LARGE).rev() {
+		tx.set(pkey("account:user", i), format!("v{i}").into_bytes()).unwrap();
+	}
+	tx.commit().unwrap();
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"account:user:";
+	let hi = prefix_end("account:user:");
+	let res = tx.scan(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(res.len(), LARGE);
+	for (i, (k, _)) in res.iter().enumerate() {
+		assert_eq!(k.as_ref(), pkey("account:user", i).as_slice());
+	}
+	// And in reverse
+	let rev = tx.scan_reverse(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(rev.len(), LARGE);
+	for (i, (k, _)) in rev.iter().enumerate() {
+		let expected = LARGE - 1 - i;
+		assert_eq!(k.as_ref(), pkey("account:user", expected).as_slice());
+	}
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn delete_every_other_forces_leaf_merges() {
+	let db = Database::new();
+	let mut tx = db.transaction(true);
+	for i in 0..LARGE {
+		tx.set(pkey("k", i), format!("v{i}").into_bytes()).unwrap();
+	}
+	tx.commit().unwrap();
+	// Delete every other entry — leaves drop below fill threshold and merge
+	let mut tx = db.transaction(true);
+	for i in (0..LARGE).step_by(2) {
+		tx.del(pkey("k", i)).unwrap();
+	}
+	tx.commit().unwrap();
+	// Verify remaining entries are exactly the odd indices
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"k:";
+	let hi = prefix_end("k:");
+	let res = tx.scan(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(res.len(), LARGE / 2);
+	for (idx, (k, _)) in res.iter().enumerate() {
+		let expected = idx * 2 + 1;
+		assert_eq!(k.as_ref(), pkey("k", expected).as_slice());
+	}
+	// And the deleted ones are gone via point lookup
+	for i in (0..LARGE).step_by(2) {
+		assert!(tx.get(pkey("k", i)).unwrap().is_none());
+	}
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn delete_majority_then_reinsert_different_keys() {
+	let db = Database::new();
+	let mut tx = db.transaction(true);
+	for i in 0..LARGE {
+		tx.set(pkey("k", i), b"v".to_vec()).unwrap();
+	}
+	tx.commit().unwrap();
+	// Delete 80% (the lower 4/5)
+	let mut tx = db.transaction(true);
+	for i in 0..(LARGE * 4 / 5) {
+		tx.del(pkey("k", i)).unwrap();
+	}
+	tx.commit().unwrap();
+	// Insert a different prefix at the same density
+	let mut tx = db.transaction(true);
+	for i in 0..(LARGE * 4 / 5) {
+		tx.set(pkey("new", i), b"v".to_vec()).unwrap();
+	}
+	tx.commit().unwrap();
+	let mut tx = db.transaction(false);
+	let k_lo: &[u8] = b"k:";
+	let k_hi = prefix_end("k:");
+	let k_count = tx.total(k_lo..k_hi.as_slice(), None, None).unwrap();
+	let n_lo: &[u8] = b"new:";
+	let n_hi = prefix_end("new:");
+	let new_count = tx.total(n_lo..n_hi.as_slice(), None, None).unwrap();
+	assert_eq!(k_count, LARGE / 5);
+	assert_eq!(new_count, LARGE * 4 / 5);
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn multiple_prefix_groups_isolated_scans() {
+	let db = Database::new();
+	let groups = ["account:1", "account:2", "account:3", "account:10"];
+	let per_group = 1_000;
+	let mut tx = db.transaction(true);
+	for g in &groups {
+		for i in 0..per_group {
+			tx.set(format!("{g}:post:{i:08}").into_bytes(), b"v".to_vec()).unwrap();
+		}
+	}
+	tx.commit().unwrap();
+	let mut tx = db.transaction(false);
+	for g in &groups {
+		let lo = format!("{g}:post:").into_bytes();
+		let hi = prefix_end(&format!("{g}:post:"));
+		let res = tx.scan(lo.as_slice()..hi.as_slice(), None, None).unwrap();
+		assert_eq!(res.len(), per_group, "group {g}");
+		assert_eq!(res.first().unwrap().0.as_ref(), format!("{g}:post:00000000").as_bytes());
+		assert_eq!(
+			res.last().unwrap().0.as_ref(),
+			format!("{g}:post:{:08}", per_group - 1).as_bytes()
+		);
+	}
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn scan_across_prefix_boundary() {
+	let db = Database::new();
+	let mut tx = db.transaction(true);
+	for i in 0..500 {
+		tx.set(format!("a:{i:06}").into_bytes(), b"va".to_vec()).unwrap();
+		tx.set(format!("b:{i:06}").into_bytes(), b"vb".to_vec()).unwrap();
+	}
+	tx.commit().unwrap();
+	let mut tx = db.transaction(false);
+	// Range that crosses the a→b boundary
+	let lo: &[u8] = b"a:000400";
+	let hi: &[u8] = b"b:000100";
+	let res = tx.scan(lo..hi, None, None).unwrap();
+	// Entries: a:000400..a:000499 (100) + b:000000..b:000099 (100) = 200
+	assert_eq!(res.len(), 200);
+	assert_eq!(res.first().unwrap().0.as_ref(), b"a:000400".as_ref());
+	assert_eq!(res.last().unwrap().0.as_ref(), b"b:000099".as_ref());
+	for (i, (k, _)) in res.iter().enumerate() {
+		if i < 100 {
+			assert!(k.starts_with(b"a:"));
+		} else {
+			assert!(k.starts_with(b"b:"));
+		}
+	}
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn long_shared_prefix_small_suffix() {
+	// 200-byte shared prefix + 4-byte distinguishing suffix
+	let db = Database::new();
+	let prefix = "x".repeat(200);
+	let mut tx = db.transaction(true);
+	for i in 0..2_000u32 {
+		tx.set(format!("{prefix}:{i:04}").into_bytes(), b"v".to_vec()).unwrap();
+	}
+	tx.commit().unwrap();
+	let mut tx = db.transaction(false);
+	let lo = format!("{prefix}:").into_bytes();
+	let hi = prefix_end(&format!("{prefix}:"));
+	let res = tx.scan(lo.as_slice()..hi.as_slice(), None, None).unwrap();
+	assert_eq!(res.len(), 2_000);
+	for (i, (k, _)) in res.iter().enumerate() {
+		assert_eq!(k.as_ref(), format!("{prefix}:{i:04}").as_bytes());
+	}
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn cursor_seek_at_prefix_boundary() {
+	let db = Database::new();
+	let mut tx = db.transaction(true);
+	for i in 0..500 {
+		tx.set(format!("a:{i:06}").into_bytes(), b"va".to_vec()).unwrap();
+		tx.set(format!("b:{i:06}").into_bytes(), b"vb".to_vec()).unwrap();
+	}
+	tx.commit().unwrap();
+
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"a:";
+	let hi: &[u8] = b"c:";
+	{
+		let mut cursor = tx.cursor(lo..hi).unwrap();
+		// Seek to the start of group "b"
+		cursor.seek(b"b:000000");
+		assert!(cursor.valid());
+		assert_eq!(cursor.key().unwrap().as_ref(), b"b:000000");
+
+		// Walk forward — should yield exactly the 500 b: entries
+		let mut forward_count = 0;
+		while cursor.valid() {
+			forward_count += 1;
+			cursor.next();
+		}
+		assert_eq!(forward_count, 500);
+	}
+	// seek_for_prev to last "a" key
+	{
+		let mut cursor = tx.cursor(lo..hi).unwrap();
+		cursor.seek_for_prev(b"a:999999");
+		assert_eq!(cursor.key().unwrap().as_ref(), b"a:000499");
+		cursor.prev();
+		assert_eq!(cursor.key().unwrap().as_ref(), b"a:000498");
+	}
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn versioning_under_repeated_writes_shared_prefix() {
+	let db = Database::new().with_gc_history(std::time::Duration::from_secs(60));
+	// Five writes per key, on 200 prefix-sharing keys
+	for round in 0..5 {
+		let mut tx = db.transaction(true);
+		for i in 0..200 {
+			tx.set(pkey("doc", i), format!("round{round}-i{i}").into_bytes()).unwrap();
+		}
+		tx.commit().unwrap();
+	}
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"doc:";
+	let hi = prefix_end("doc:");
+	// Latest scan sees the last round
+	let res = tx.scan(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(res.len(), 200);
+	for (i, (_, v)) in res.iter().enumerate() {
+		assert_eq!(v.as_ref(), format!("round4-i{i}").as_bytes());
+	}
+	// scan_all_versions sees the full chain (5 versions × 200 keys = 1000)
+	let all = tx.scan_all_versions(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(all.len(), 1_000);
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn range_query_bounds_inside_prefix_group() {
+	let db = Database::new();
+	let mut tx = db.transaction(true);
+	for i in 0..1_000 {
+		tx.set(pkey("g", i), b"v".to_vec()).unwrap();
+	}
+	tx.commit().unwrap();
+
+	let mut tx = db.transaction(false);
+	// [200, 700) — 500 keys
+	let lo = pkey("g", 200);
+	let hi = pkey("g", 700);
+	let res = tx.scan(lo.as_slice()..hi.as_slice(), None, None).unwrap();
+	assert_eq!(res.len(), 500);
+	assert_eq!(res.first().unwrap().0.as_ref(), pkey("g", 200).as_slice());
+	assert_eq!(res.last().unwrap().0.as_ref(), pkey("g", 699).as_slice());
+	// limit + skip in the middle of the range
+	let lo_all = pkey("g", 0);
+	let hi_all = pkey("g", 1000);
+	let lim = tx.scan(lo_all.as_slice()..hi_all.as_slice(), Some(50), Some(100)).unwrap();
+	assert_eq!(lim.len(), 100);
+	assert_eq!(lim.first().unwrap().0.as_ref(), pkey("g", 50).as_slice());
+	assert_eq!(lim.last().unwrap().0.as_ref(), pkey("g", 149).as_slice());
+	tx.cancel().unwrap();
+}
+
+#[test]
+fn deeply_nested_surrealdb_style_keys() {
+	let db = Database::new();
+	let namespaces = ["ns_alpha", "ns_beta"];
+	let dbs = ["main", "audit"];
+	let tables = ["user", "post", "comment"];
+	let per_table = 200;
+
+	let mut tx = db.transaction(true);
+	for ns in &namespaces {
+		for d in &dbs {
+			for tbl in &tables {
+				for id in 0..per_table {
+					let key = format!("surreal:{ns}:{d}:{tbl}:{id:06}").into_bytes();
+					tx.set(key, format!("{ns}-{d}-{tbl}-{id}").into_bytes()).unwrap();
+				}
+			}
+		}
+	}
+	tx.commit().unwrap();
+
+	let mut tx = db.transaction(false);
+	let lo: &[u8] = b"surreal:";
+	let hi = prefix_end("surreal:");
+	let total = namespaces.len() * dbs.len() * tables.len() * per_table;
+	let all = tx.total(lo..hi.as_slice(), None, None).unwrap();
+	assert_eq!(all, total);
+
+	// Scope one table
+	let t_lo = b"surreal:ns_alpha:main:user:".to_vec();
+	let t_hi = prefix_end("surreal:ns_alpha:main:user:");
+	let res = tx.scan(t_lo.as_slice()..t_hi.as_slice(), None, None).unwrap();
+	assert_eq!(res.len(), per_table);
+	for (i, (k, v)) in res.iter().enumerate() {
+		assert_eq!(k.as_ref(), format!("surreal:ns_alpha:main:user:{i:06}").as_bytes());
+		assert_eq!(v.as_ref(), format!("ns_alpha-main-user-{i}").as_bytes());
+	}
+
+	// Scope one whole namespace
+	let n_lo = b"surreal:ns_beta:".to_vec();
+	let n_hi = prefix_end("surreal:ns_beta:");
+	let ns_res = tx.total(n_lo.as_slice()..n_hi.as_slice(), None, None).unwrap();
+	assert_eq!(ns_res, dbs.len() * tables.len() * per_table);
+	tx.cancel().unwrap();
+}


### PR DESCRIPTION
## Summary

Replace the `SkipMap<Bytes, RwLock<Versions>>` datastore with a [`ferntree::Tree<Bytes, Versions>`](https://github.com/surrealdb/ferntree) — a concurrent B+tree with optimistic lock coupling — and rework the scan path to take advantage of contiguous leaves.

### What changes
- **Storage swap:** `inner.rs` uses `Tree<Bytes, Versions>` (no per-value RwLock — ferntree's latches handle concurrency). Commit path uses `raw_iter_mut` scoped per writeset key. Reads use `datastore.lookup(key, |v| ...)`.
- **MergeIterator rewrite:** wraps ferntree's `Range`/`RangeRev` in a `TreeIterState` enum. Cache holds `(key, exists)` only — value is fetched lazily at emit time from the still-parked iterator, so `next_count` / `next_key` never pay the byte clone.
- **Bulk leaf walks:** forward fast paths go through a new `for_each_in_range` helper that drives ferntree's `RawSharedIter::for_each_in_leaf`. A whole leaf's `SmallVec<(K, V)>` is processed in one tight loop without re-entering the iterator state machine; only the cross-leaf boundary pays a regular `next()`.
- **Tests:** two new modules covering access patterns the existing suite doesn't exercise:
  - `tests/prefix_keys.rs` — single-threaded B+tree split/merge stress with SurrealDB-style shared-prefix keys at 5k entries (sequential / random / reverse insertion, half-deletion to force leaf merges, multiple prefix groups, scans across prefix boundaries, very long shared prefixes, cursor seeks at prefix boundaries, version chains on prefix-sharing keys, deeply nested keys).
  - `tests/prefix_concurrency.rs` — concurrent commit / scan / MVCC tests on the patterns that hit the B+tree hardest: disjoint and contended prefix groups, retry-on-conflict integrity, SSI increment counter, snapshot consistency under concurrent writers, phantom-free deletes, sustained mixed workload with end-state invariant check, monotonic version chain under concurrent writers.

### Bench vs `origin/main` (`cargo bench --quick`)

| Group | Improvement |
|---|---|
| `scan_operations/*` | −15% to −51% |
| `keys_operations/*` | −18% to −52% |
| `total_operations/*` | −29% to −63% |

### Bench vs the skipmap + fast-path baseline

Isolates the storage-layer delta — both branches share the fast-path scaffolding:

| Group | Speedup (ferntree over skipmap-fast-path) |
|---|---|
| Point lookups (`get_operations`) | **1.2x – 1.8x** |
| Range scans (`scan_operations`) | **1.3x – 2.7x** |
| Key scans (`keys_operations`) | **1.2x – 1.7x** |
| Full scans (`total_operations`) | **1.1x – 2.4x** |

### ferntree concurrency race

The earlier `smallvec "entered unreachable code"` panic in `tests/stress.rs` under high concurrent commit pressure (filed as surrealdb/ferntree#4) is fixed in ferntree **0.3.0**. With 0.2.0 the stress test failed 1–15% of debug runs; with 0.3.0 it passes 100/100, and the new `prefix_concurrency` suite passes 50/50.

## Test plan

- [x] `cargo test` (lib + integration): 392 tests pass
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] Stress test (`tests/stress.rs`) — 100 / 100 debug runs
- [x] `tests/prefix_concurrency.rs` — 50 / 50 debug runs
- [x] ferntree 0.3.0 from crates.io (no path dependency)