### PR TITLE
Lazy k-way merge over the transaction merge queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,11 @@ wasm-bindgen-test = "0.3.71"
 [[bench]]
 name = "operations"
 harness = false
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = true
+
+[profile.bench]
+inherits = "release"

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -17,7 +17,9 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use rand::{rngs::StdRng, RngExt, SeedableRng};
 use std::hint::black_box;
 use std::sync::Arc;
-use surrealmx::bench_internals::{ReadsetConflictScenario, WritesetConflictScenario};
+use surrealmx::bench_internals::{
+	MergeQueueScenario, ReadsetConflictScenario, WritesetConflictScenario,
+};
 use surrealmx::{Database, DatabaseOptions};
 
 const SEED: u64 = 42;
@@ -1329,6 +1331,84 @@ fn bench_bloom_concurrent_throughput(c: &mut Criterion) {
 	group.finish();
 }
 
+// ---------------------------------------------------------------------------
+// Lazy k-way merge over the transaction merge queue. Microbenchmark over
+// the `MergeQueueIter` in isolation (built via bench_internals because the
+// production merge queue drains synchronously at commit, so the only way to
+// get reproducible queue depth in a single-threaded bench is to construct it
+// directly).
+// ---------------------------------------------------------------------------
+
+fn bench_merge_queue_iter(c: &mut Criterion) {
+	let mut group = c.benchmark_group("merge_queue_iter");
+
+	let total_keys = 10_000;
+	let keys_per_source = 50;
+
+	for num_sources in [1, 4, 16, 64].iter() {
+		let scenario = MergeQueueScenario::new(*num_sources, keys_per_source, total_keys);
+
+		// Full drain: scales with merge-queue depth × keys per source.
+		group.bench_function(BenchmarkId::new("drain", format!("{}sources", num_sources)), |b| {
+			b.iter(|| {
+				black_box(scenario.iter_forward_count());
+			})
+		});
+
+		// Early termination at 100 entries: highlights the lazy iterator's
+		// advantage over the previous eager BTreeMap materialisation, which
+		// always paid the full merge cost up front.
+		group.bench_function(
+			BenchmarkId::new("take_100", format!("{}sources", num_sources)),
+			|b| {
+				b.iter(|| {
+					black_box(scenario.iter_forward_take(100));
+				})
+			},
+		);
+	}
+	group.finish();
+}
+
+// Cursor pagination: open a cursor over a 10k-key range and fetch the first
+// 100 keys via `next()`. Targets the cursor's `create_iterator` path which
+// used to re-slice a BTreeMap on every direction change and now builds a
+// fresh `MergeQueueIter` from the pre-snapshotted `Vec<Arc<Merge>>`.
+fn bench_cursor_pagination(c: &mut Criterion) {
+	let mut group = c.benchmark_group("cursor_pagination");
+
+	let entry_count = 10_000;
+	let db = setup_database_with_sequential_data(entry_count, 100);
+
+	for page_size in [10, 100, 1000].iter() {
+		group.throughput(Throughput::Elements(*page_size as u64));
+		group.bench_with_input(
+			BenchmarkId::new("first_n", format!("page{}", page_size)),
+			page_size,
+			|b, &page| {
+				b.iter(|| {
+					let tx = db.transaction(false);
+					let start_key = b"".to_vec();
+					let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
+					let mut cursor = tx.cursor(start_key..end_key).unwrap();
+					cursor.seek_to_first();
+					let mut count = 0;
+					while cursor.valid() && count < page {
+						if cursor.exists() {
+							black_box(cursor.key());
+							black_box(cursor.value());
+							count += 1;
+						}
+						cursor.next();
+					}
+					black_box(count);
+				})
+			},
+		);
+	}
+	group.finish();
+}
+
 criterion_group!(
 	database_benchmarks,
 	bench_transaction_creation,
@@ -1358,6 +1438,8 @@ criterion_group!(
 
 criterion_group!(configuration_benchmarks, bench_database_options);
 
+criterion_group!(merge_benchmarks, bench_merge_queue_iter, bench_cursor_pagination);
+
 criterion_group!(
 	optimization_benchmarks,
 	bench_scan_for_each,
@@ -1376,5 +1458,6 @@ criterion_main!(
 	scan_benchmarks,
 	concurrent_benchmarks,
 	configuration_benchmarks,
-	optimization_benchmarks
+	optimization_benchmarks,
+	merge_benchmarks
 );

--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -16,7 +16,9 @@
 //! bloom filter pre-checks. Not part of the public API.
 
 use crate::bloom::BloomFilter;
-use crate::queue::Commit;
+use crate::direction::Direction;
+use crate::iter::MergeQueueIter;
+use crate::queue::{Commit, Merge};
 use bytes::Bytes;
 use papaya::HashSet;
 use std::collections::BTreeMap;
@@ -134,5 +136,69 @@ impl WritesetConflictScenario {
 			min_key,
 			max_key,
 		}
+	}
+}
+
+/// A prepared merge-queue scenario for benchmarking the lazy k-way merge.
+/// Holds a vector of `Arc<Merge>` source writesets and the iteration bounds.
+pub struct MergeQueueScenario {
+	sources: Vec<Arc<Merge>>,
+	beg: Bytes,
+	end: Bytes,
+}
+
+impl MergeQueueScenario {
+	/// Build a scenario with `num_sources` writesets, each populated with
+	/// `keys_per_source` keys drawn pseudo-randomly from `0..total_keys` so
+	/// that sources statistically overlap and the merge has to dedup.
+	pub fn new(num_sources: usize, keys_per_source: usize, total_keys: usize) -> Self {
+		let mut sources = Vec::with_capacity(num_sources);
+		for i in 0..num_sources {
+			let mut ws = BTreeMap::new();
+			for j in 0..keys_per_source {
+				// Cheap deterministic spread; collisions across sources are
+				// expected and exercise the dedup path.
+				let key_idx = (i.wrapping_mul(31) + j.wrapping_mul(17)) % total_keys;
+				let key = Bytes::from(format!("key_{:08}", key_idx).into_bytes());
+				ws.insert(key, Some(Bytes::from_static(b"v")));
+			}
+			sources.push(Arc::new(Merge {
+				id: i as u64,
+				writeset: Arc::new(ws),
+			}));
+		}
+		let beg = Bytes::from(b"key_00000000".to_vec());
+		let end = Bytes::from(format!("key_{:08}", total_keys).into_bytes());
+		Self {
+			sources,
+			beg,
+			end,
+		}
+	}
+
+	/// Fully iterate the lazy merge in forward direction and return the
+	/// total number of entries yielded.
+	pub fn iter_forward_count(&self) -> usize {
+		MergeQueueIter::new(
+			self.sources.clone(),
+			self.beg.clone(),
+			self.end.clone(),
+			Direction::Forward,
+		)
+		.count()
+	}
+
+	/// Iterate the lazy merge forward, taking only the first `n` entries —
+	/// exercises the early-termination path that the previous eager
+	/// materialisation could not benefit from.
+	pub fn iter_forward_take(&self, n: usize) -> usize {
+		MergeQueueIter::new(
+			self.sources.clone(),
+			self.beg.clone(),
+			self.end.clone(),
+			Direction::Forward,
+		)
+		.take(n)
+		.count()
 	}
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -16,7 +16,8 @@
 
 use crate::direction::Direction;
 use crate::inner::Inner;
-use crate::iter::MergeIterator;
+use crate::iter::{MergeIterator, MergeQueueIter};
+use crate::queue::Merge;
 use bytes::Bytes;
 use std::collections::BTreeMap;
 use std::ops::Bound;
@@ -56,8 +57,10 @@ pub struct Cursor<'a> {
 	end: Bytes,
 	/// Transaction version for MVCC
 	version: u64,
-	/// Combined writeset from merge queue (owned, built at cursor creation)
-	combined_writeset: BTreeMap<Bytes, Option<Bytes>>,
+	/// Snapshot of merge-queue writesets visible to this cursor (Arc bumps,
+	/// captured once at construction so direction changes don't have to
+	/// re-walk the queue).
+	merge_sources: Vec<Arc<Merge>>,
 	/// Current direction of iteration
 	direction: Direction,
 	/// Current cached entry (key, value) - None means invalid position
@@ -80,20 +83,14 @@ impl<'a> Cursor<'a> {
 		end: Bytes,
 		version: u64,
 	) -> Self {
-		// Build combined writeset from merge queue entries.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in database.transaction_merge_queue.range(..=version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(&beg..&end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
-					}
-				}
-				ws
-			};
+		// Snapshot the merge-queue writesets once (Arc bumps); the lazy
+		// iterator built in `create_iterator` ranges into them on demand.
+		let merge_sources: Vec<Arc<Merge>> = database
+			.transaction_merge_queue
+			.range(..=version)
+			.rev()
+			.map(|e| e.value().clone())
+			.collect();
 
 		Cursor {
 			database,
@@ -101,7 +98,7 @@ impl<'a> Cursor<'a> {
 			beg,
 			end,
 			version,
-			combined_writeset,
+			merge_sources,
 			direction: Direction::Forward,
 			current: None,
 			positioned: false,
@@ -263,17 +260,18 @@ impl<'a> Cursor<'a> {
 	/// Create a new merge iterator over the given range and direction.
 	/// Replaces any existing iterator.
 	fn create_iterator(&mut self, start: &Bytes, end: &Bytes, direction: Direction) {
-		let join: BTreeMap<Bytes, Option<Bytes>> = self
-			.combined_writeset
-			.range::<Bytes, _>(start..end)
-			.map(|(k, v)| (k.clone(), v.clone()))
-			.collect();
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.merge_sources.clone(),
+			start.clone(),
+			end.clone(),
+			direction,
+		));
 
 		self.iter = Some(MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(start.clone()), Bound::Excluded(end.clone()))),
-			join,
+			join_iter,
 			self.writeset.range::<Bytes, _>(start..end),
 			direction,
 			self.version,

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -15,6 +15,7 @@
 //! This module stores the database iteration direction.
 
 /// The direction that the iterator should iterate
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Direction {
 	Forward,
 	Reverse,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -86,18 +86,18 @@ fn seek_in_writeset(
 ) -> Option<(Bytes, Option<Bytes>)> {
 	let ws = &src.writeset;
 	let entry = match (direction, after) {
-		(Direction::Forward, None) => ws
-			.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(end)))
-			.next(),
-		(Direction::Forward, Some(k)) => ws
-			.range::<Bytes, _>((Bound::Excluded(k), Bound::Excluded(end)))
-			.next(),
-		(Direction::Reverse, None) => ws
-			.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(end)))
-			.next_back(),
-		(Direction::Reverse, Some(k)) => ws
-			.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(k)))
-			.next_back(),
+		(Direction::Forward, None) => {
+			ws.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(end))).next()
+		}
+		(Direction::Forward, Some(k)) => {
+			ws.range::<Bytes, _>((Bound::Excluded(k), Bound::Excluded(end))).next()
+		}
+		(Direction::Reverse, None) => {
+			ws.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(end))).next_back()
+		}
+		(Direction::Reverse, Some(k)) => {
+			ws.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(k))).next_back()
+		}
 	};
 	entry.map(|(k, v)| (k.clone(), v.clone()))
 }
@@ -132,11 +132,7 @@ impl Iterator for MergeQueueIter {
 		let (out_key, out_val) = self.heads[winner].take().unwrap();
 		// Discard older duplicates at the same key, re-seeking past it.
 		for i in (winner + 1)..self.heads.len() {
-			let same = self
-				.heads[i]
-				.as_ref()
-				.map(|(k, _)| k == &out_key)
-				.unwrap_or(false);
+			let same = self.heads[i].as_ref().map(|(k, _)| k == &out_key).unwrap_or(false);
 			if same {
 				let new = seek_in_writeset(
 					&self.sources[i],

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -16,20 +16,150 @@
 //! sources.
 
 use crate::direction::Direction;
+use crate::queue::Merge;
 use crate::versions::Versions;
 use bytes::Bytes;
 use crossbeam_skiplist::map::Entry;
 use crossbeam_skiplist::map::Range as SkipRange;
 use parking_lot::RwLock;
 use std::collections::btree_map::Range as TreeRange;
-use std::collections::BTreeMap;
-use std::collections::VecDeque;
 use std::ops::Bound;
+use std::sync::Arc;
 
 /// Owned range bounds for the skip list range iterator.
 /// Using owned Bytes avoids lifetime coupling between range bounds
 /// and the MergeIterator, enabling persistent storage (e.g., in a Cursor).
 pub(crate) type SkipBounds = (Bound<Bytes>, Bound<Bytes>);
+
+/// Lazy k-way merge iterator over committed merge-queue writesets.
+///
+/// Yields `(Bytes, Option<Bytes>)` pairs in sorted order with newest-wins
+/// dedup. Sources must be passed in newest-first order (index 0 = newest).
+/// On a tie, the lowest-index source wins; older sources at the same key
+/// are advanced past it.
+///
+/// Holds an `Arc<Merge>` per source to keep the underlying `Arc<BTreeMap>`
+/// alive without storing any borrows from it; advancement re-seeks the
+/// BTreeMap each step (O(log n) per advance).
+pub(crate) struct MergeQueueIter {
+	sources: Vec<Arc<Merge>>,
+	heads: Vec<Option<(Bytes, Option<Bytes>)>>,
+	beg: Bytes,
+	end: Bytes,
+	direction: Direction,
+}
+
+impl MergeQueueIter {
+	/// Build a new lazy merge iterator.
+	///
+	/// `sources` must be ordered newest-first (typically by collecting
+	/// `transaction_merge_queue.range(..=version).rev()`). `beg` is included,
+	/// `end` is excluded.
+	pub(crate) fn new(
+		sources: Vec<Arc<Merge>>,
+		beg: Bytes,
+		end: Bytes,
+		direction: Direction,
+	) -> Self {
+		let mut heads = Vec::with_capacity(sources.len());
+		for src in &sources {
+			heads.push(seek_in_writeset(src, direction, &beg, &end, None));
+		}
+		Self {
+			sources,
+			heads,
+			beg,
+			end,
+			direction,
+		}
+	}
+}
+
+/// Seek the next entry within `[beg, end)` for `direction`, optionally past
+/// `after`. Returns owned `(Bytes, Option<Bytes>)` (refcount clones only).
+fn seek_in_writeset(
+	src: &Arc<Merge>,
+	direction: Direction,
+	beg: &Bytes,
+	end: &Bytes,
+	after: Option<&Bytes>,
+) -> Option<(Bytes, Option<Bytes>)> {
+	let ws = &src.writeset;
+	let entry = match (direction, after) {
+		(Direction::Forward, None) => ws
+			.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(end)))
+			.next(),
+		(Direction::Forward, Some(k)) => ws
+			.range::<Bytes, _>((Bound::Excluded(k), Bound::Excluded(end)))
+			.next(),
+		(Direction::Reverse, None) => ws
+			.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(end)))
+			.next_back(),
+		(Direction::Reverse, Some(k)) => ws
+			.range::<Bytes, _>((Bound::Included(beg), Bound::Excluded(k)))
+			.next_back(),
+	};
+	entry.map(|(k, v)| (k.clone(), v.clone()))
+}
+
+impl Iterator for MergeQueueIter {
+	type Item = (Bytes, Option<Bytes>);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		// Find the winning source: smallest (Forward) or largest (Reverse)
+		// head. On ties, lower index wins (newest), so a strict comparison
+		// keeps the first-seen source as the winner.
+		let mut winner: Option<usize> = None;
+		for (i, head) in self.heads.iter().enumerate() {
+			let Some((k, _)) = head else {
+				continue;
+			};
+			match winner {
+				None => winner = Some(i),
+				Some(wi) => {
+					let (wk, _) = self.heads[wi].as_ref().unwrap();
+					let take = match self.direction {
+						Direction::Forward => k < wk,
+						Direction::Reverse => k > wk,
+					};
+					if take {
+						winner = Some(i);
+					}
+				}
+			}
+		}
+		let winner = winner?;
+		let (out_key, out_val) = self.heads[winner].take().unwrap();
+		// Discard older duplicates at the same key, re-seeking past it.
+		for i in (winner + 1)..self.heads.len() {
+			let same = self
+				.heads[i]
+				.as_ref()
+				.map(|(k, _)| k == &out_key)
+				.unwrap_or(false);
+			if same {
+				let new = seek_in_writeset(
+					&self.sources[i],
+					self.direction,
+					&self.beg,
+					&self.end,
+					Some(&out_key),
+				);
+				self.heads[i] = new;
+			}
+		}
+		// Advance the winning source.
+		let new = seek_in_writeset(
+			&self.sources[winner],
+			self.direction,
+			&self.beg,
+			&self.end,
+			Some(&out_key),
+		);
+		self.heads[winner] = new;
+		Some((out_key, out_val))
+	}
+}
 
 /// Three-way merge iterator over tree, merge queue, and current transaction
 /// writesets
@@ -38,8 +168,8 @@ pub struct MergeIterator<'a> {
 	pub(crate) tree_iter: SkipRange<'a, Bytes, SkipBounds, Bytes, RwLock<Versions>>,
 	pub(crate) self_iter: TreeRange<'a, Bytes, Option<Bytes>>,
 
-	// Join entries from merge queue, consumed from front (forward) or back (reverse)
-	pub(crate) join_entries: VecDeque<(Bytes, Option<Bytes>)>,
+	// Lazy iterator over committed merge-queue writesets
+	pub(crate) join_iter: Box<dyn Iterator<Item = (Bytes, Option<Bytes>)> + 'a>,
 
 	// Current buffered entries from each source
 	pub(crate) tree_next: Option<Entry<'a, Bytes, RwLock<Versions>>>,
@@ -66,7 +196,7 @@ enum KeySource {
 impl<'a> MergeIterator<'a> {
 	pub fn new(
 		mut tree_iter: SkipRange<'a, Bytes, SkipBounds, Bytes, RwLock<Versions>>,
-		join_storage: BTreeMap<Bytes, Option<Bytes>>,
+		mut join_iter: Box<dyn Iterator<Item = (Bytes, Option<Bytes>)> + 'a>,
 		mut self_iter: TreeRange<'a, Bytes, Option<Bytes>>,
 		direction: Direction,
 		version: u64,
@@ -83,19 +213,14 @@ impl<'a> MergeIterator<'a> {
 			Direction::Reverse => self_iter.next_back(),
 		};
 
-		// Convert BTreeMap to VecDeque for O(1) sequential access
-		let mut join_entries: VecDeque<(Bytes, Option<Bytes>)> = join_storage.into_iter().collect();
-
-		// Get first join entry based on direction
-		let join_next = match direction {
-			Direction::Forward => join_entries.pop_front(),
-			Direction::Reverse => join_entries.pop_back(),
-		};
+		// The lazy join iterator is already direction-baked; just pull the
+		// first entry.
+		let join_next = join_iter.next();
 
 		MergeIterator {
 			tree_iter,
 			self_iter,
-			join_entries,
+			join_iter,
 			tree_next,
 			join_next,
 			self_next,
@@ -107,10 +232,7 @@ impl<'a> MergeIterator<'a> {
 
 	#[inline]
 	fn advance_join(&mut self) {
-		self.join_next = match self.direction {
-			Direction::Forward => self.join_entries.pop_front(),
-			Direction::Reverse => self.join_entries.pop_back(),
-		};
+		self.join_next = self.join_iter.next();
 	}
 
 	/// Get next entry existence only (no key or value cloning) - optimized for

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -19,7 +19,7 @@ use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
 use crate::inner::Inner;
-use crate::iter::MergeIterator;
+use crate::iter::{MergeIterator, MergeQueueIter};
 use crate::kv::IntoBytes;
 use crate::pool::Pool;
 use crate::queue::{Commit, Merge};
@@ -1624,22 +1624,19 @@ impl TransactionInner {
 			}
 			return Ok(count);
 		}
-		// Build combined writeset from merge queue entries only.
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
-			let mut ws = BTreeMap::new();
-			for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
-				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-					ws.entry(k.clone()).or_insert_with(|| v.clone());
-				}
-			}
-			ws
-		};
+		// Lazy k-way merge over the merge-queue writesets.
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.snapshot_merge_sources(self.version),
+			beg.clone(),
+			end.clone(),
+			Direction::Forward,
+		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
-			combined_writeset,
+			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
 			self.version,
@@ -1726,22 +1723,19 @@ impl TransactionInner {
 			}
 			return Ok(count);
 		}
-		// Build combined writeset from merge queue entries only.
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
-			let mut ws = BTreeMap::new();
-			for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
-				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-					ws.entry(k.clone()).or_insert_with(|| v.clone());
-				}
-			}
-			ws
-		};
+		// Lazy k-way merge over the merge-queue writesets.
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.snapshot_merge_sources(self.version),
+			beg.clone(),
+			end.clone(),
+			Direction::Forward,
+		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
-			combined_writeset,
+			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
 			self.version,
@@ -1823,22 +1817,19 @@ impl TransactionInner {
 			}
 			return Ok(());
 		}
-		// Build combined writeset from merge queue entries only.
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
-			let mut ws = BTreeMap::new();
-			for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
-				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-					ws.entry(k.clone()).or_insert_with(|| v.clone());
-				}
-			}
-			ws
-		};
+		// Lazy k-way merge over the merge-queue writesets.
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.snapshot_merge_sources(self.version),
+			beg.clone(),
+			end.clone(),
+			Direction::Forward,
+		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
-			combined_writeset,
+			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
 			self.version,
@@ -1917,22 +1908,19 @@ impl TransactionInner {
 			}
 			return Ok(());
 		}
-		// Build combined writeset from merge queue entries only.
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
-			let mut ws = BTreeMap::new();
-			for entry in self.database.transaction_merge_queue.range(..=self.version).rev() {
-				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-					ws.entry(k.clone()).or_insert_with(|| v.clone());
-				}
-			}
-			ws
-		};
+		// Lazy k-way merge over the merge-queue writesets.
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.snapshot_merge_sources(self.version),
+			beg.clone(),
+			end.clone(),
+			Direction::Forward,
+		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
-			combined_writeset,
+			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
 			self.version,
@@ -1975,6 +1963,18 @@ impl TransactionInner {
 			// This range scan is already covered
 			_ => (),
 		}
+	}
+
+	/// Snapshot the merge-queue writesets visible at `version` as a vector of
+	/// `Arc<Merge>` ordered newest-first. Cheap — each element is an Arc bump.
+	#[inline]
+	fn snapshot_merge_sources(&self, version: u64) -> Vec<Arc<Merge>> {
+		self.database
+			.transaction_merge_queue
+			.range(..=version)
+			.rev()
+			.map(|e| e.value().clone())
+			.collect()
 	}
 
 	/// Retrieve a count of keys from the database
@@ -2046,22 +2046,19 @@ impl TransactionInner {
 			}
 			return Ok(res);
 		}
-		// Build combined writeset from merge queue entries only.
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
-			let mut ws = BTreeMap::new();
-			for entry in self.database.transaction_merge_queue.range(..=version).rev() {
-				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-					ws.entry(k.clone()).or_insert_with(|| v.clone());
-				}
-			}
-			ws
-		};
+		// Lazy k-way merge over the merge-queue writesets.
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.snapshot_merge_sources(version),
+			beg.clone(),
+			end.clone(),
+			direction,
+		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
-			combined_writeset,
+			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
 			version,
@@ -2153,22 +2150,19 @@ impl TransactionInner {
 			}
 			return Ok(res);
 		}
-		// Build combined writeset from merge queue entries only.
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
-			let mut ws = BTreeMap::new();
-			for entry in self.database.transaction_merge_queue.range(..=version).rev() {
-				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-					ws.entry(k.clone()).or_insert_with(|| v.clone());
-				}
-			}
-			ws
-		};
+		// Lazy k-way merge over the merge-queue writesets.
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.snapshot_merge_sources(version),
+			beg.clone(),
+			end.clone(),
+			direction,
+		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
-			combined_writeset,
+			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
 			version,
@@ -2260,22 +2254,19 @@ impl TransactionInner {
 			}
 			return Ok(res);
 		}
-		// Build combined writeset from merge queue entries only.
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> = {
-			let mut ws = BTreeMap::new();
-			for entry in self.database.transaction_merge_queue.range(..=version).rev() {
-				for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-					ws.entry(k.clone()).or_insert_with(|| v.clone());
-				}
-			}
-			ws
-		};
+		// Lazy k-way merge over the merge-queue writesets.
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.snapshot_merge_sources(version),
+			beg.clone(),
+			end.clone(),
+			direction,
+		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
-			combined_writeset,
+			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
 			version,
@@ -2327,26 +2318,21 @@ impl TransactionInner {
 				self.track_scan_range(beg, end);
 			}
 		}
-		// Build combined writeset from merge queue entries only.
-		// Fast path: skip entirely when the merge queue is empty (common case).
-		let combined_writeset: BTreeMap<Bytes, Option<Bytes>> =
-			if self.database.transaction_merge_queue.is_empty() {
-				BTreeMap::new()
-			} else {
-				let mut ws = BTreeMap::new();
-				for entry in self.database.transaction_merge_queue.range(..=version).rev() {
-					for (k, v) in entry.value().writeset.range::<Bytes, _>(beg..end) {
-						ws.entry(k.clone()).or_insert_with(|| v.clone());
-					}
-				}
-				ws
-			};
+		// Lazy k-way merge over the merge-queue writesets. The
+		// `snapshot_merge_sources` helper returns an empty vector when the
+		// queue is empty, so the iterator is effectively a no-op in that case.
+		let join_iter = Box::new(MergeQueueIter::new(
+			self.snapshot_merge_sources(version),
+			beg.clone(),
+			end.clone(),
+			Direction::Forward,
+		));
 		// Create the 3-way merge iterator to iterate over keys
 		let iter = MergeIterator::new(
 			self.database
 				.datastore
 				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
-			combined_writeset,
+			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
 			version,


### PR DESCRIPTION
## Summary

- Replaces the eager `BTreeMap<Bytes, Option<Bytes>>` "combined writeset" materialisation in range operations with a new lazy `MergeQueueIter` that holds `Arc<Merge>` sources and yields newest-wins entries on demand. Eight call sites in `src/tx.rs` (`for_each`, `keys_for_each`, `scan_into`, `keys_into`, `total_any`, `keys_any`, `scan_any`, `scan_all_versions_any`) plus `Cursor` are converted; `MergeIterator::new` now takes `Box<dyn Iterator<Item=(Bytes, Option<Bytes>)> + 'a>` instead of a `BTreeMap`.
- The cursor now snapshots `Vec<Arc<Merge>>` once at open and stops re-slicing a `BTreeMap` on every direction change — `create_iterator` just rebuilds a fresh `MergeQueueIter` over the same sources.
- Adds `[profile.release]` (`lto = "fat"`, `codegen-units = 1`, `strip = true`) and a `[profile.bench]` that inherits it.
- New `MergeQueueScenario` helper in `bench_internals.rs`, plus `merge_queue_iter` (drain vs. take_100 at 1/4/16/64 sources) and `cursor_pagination` bench groups.

## Why

Today's pattern at the eight scan sites walks the merge queue up front, calls `entry(k.clone()).or_insert_with(|| v.clone())` for every overlapping key in every queue entry — cloning keys and values even when an older writeset's contribution is about to be discarded — and then `MergeIterator::new` converts the resulting `BTreeMap` into a `VecDeque` for sequential consumption. The cost scales with `merge_queue_depth × range_width` and is paid even when the consumer terminates after the first few entries (paginated cursors, `scan(.., limit=N)`, predicates returning `false`). The cursor case is worst: it stores the `BTreeMap` as a field and re-slices it into a second `BTreeMap` on every direction-change seek.

The lazy iterator keeps each `Arc<Merge>`'s `Arc<BTreeMap>` pinned without storing borrows from it (avoiding the self-referential lifetime mess), tracks one head per source, and advances by re-seeking the underlying BTreeMap (`O(log n)` per step). Dedup is newest-wins by source index. Each yielded key/value is cloned exactly once (refcount only — `Bytes` is already a shared slice). Early termination naturally avoids the rest of the work.

## Results

Microbench (`cargo bench --bench operations -- "merge_queue_iter|cursor_pagination" --quick`) on the new bench groups:

| Sources | Full drain | Take 100 | Ratio |
|---|---|---|---|
| 1 | 3.7 µs | 3.7 µs | 1.0× |
| 4 | 20.3 µs | 10.3 µs | 2.0× |
| 16 | 150 µs | 20.9 µs | 7.2× |
| 64 | 1.14 ms | 69 µs | **16.5×** |

Cursor pagination (10/100/1000 page size): 1.0 µs / 3.2 µs / 24.8 µs.

The release-profile change also gives every existing bench an additional ~30% from cross-crate inlining (criterion reports "Performance has improved" with −30 to −45% across the board for the same code paths).

## Test plan

- [x] `cargo test` — all 371 tests pass, no regressions in `iterators`, `iteration_edge`, `snapshot_concurrent`, `concurrent_ranges`, or `versioning`.
- [x] `cargo build --release` — LTO build succeeds.
- [x] `cargo bench --bench operations --quick` — new bench groups run and report the expected scaling.
- [ ] Spot-check a downstream consumer to confirm the `MergeIterator::new` signature change (now takes a boxed iterator instead of a `BTreeMap`) doesn't break any external callers. The function is public from `iter.rs` but the type is exposed via `pub use self::iter::*` — worth a quick search before merging if anyone depends on this externally.