### PR TITLE
Switch to scc::TreeIndex with guarded range iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "saa"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,10 +765,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcd12b6caff5213cc3c03123cde8c3db5e413008a63b0c0ba35e6275825ea92"
+dependencies = [
+ "saa",
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "4.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f0e40a01b94e35d1dacbcfbe5bfd3d31e37d9590b2e6d86a82b0e87bd4f551"
+dependencies = [
+ "saa",
+]
 
 [[package]]
 name = "seize"
@@ -859,6 +884,7 @@ dependencies = [
  "papaya",
  "parking_lot",
  "rand",
+ "scc",
  "serde",
  "smallvec",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
 papaya = "0.2.4"
 parking_lot = "0.12.5"
+scc = "3.7"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 smallvec = { version = "1.15.1", features = ["serde"] }
 thiserror = "2.0.18"

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -16,11 +16,10 @@
 
 use crate::direction::Direction;
 use crate::inner::Inner;
-use crate::iter::{MergeIterator, MergeQueueIter};
+use crate::iter::{MergeIterator, MergeQueueIter, TreeIter};
 use crate::queue::Merge;
 use bytes::Bytes;
 use std::collections::BTreeMap;
-use std::ops::Bound;
 use std::sync::Arc;
 
 // --------------------------------------------------
@@ -268,9 +267,7 @@ impl<'a> Cursor<'a> {
 		));
 
 		self.iter = Some(MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(start.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, start, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(start..end),
 			direction,

--- a/src/db.rs
+++ b/src/db.rs
@@ -16,6 +16,7 @@
 
 use crate::inner::Inner;
 use crate::options::DatabaseOptions;
+use bytes::Bytes;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::options::{DEFAULT_CLEANUP_INTERVAL, DEFAULT_GC_INTERVAL};
 #[cfg(not(target_arch = "wasm32"))]
@@ -259,34 +260,38 @@ impl Database {
 	fn run_gc_dirty_inner(&self, cleanup_ts: u64) {
 		// Drain all keys from the dirty queue
 		while let Some(key) = self.gc_dirty_keys.pop() {
-			// Check if this key still exists in the datastore
-			if let Some(entry) = self.datastore.get(&key) {
-				// Get a mutable reference to the versions list
-				let mut versions = entry.value().write();
-				// Clean up unnecessary older versions
+			// Check if this key still exists in the datastore and clean up
+			// stale versions via the per-key RwLock. `read_sync` holds a
+			// shared leaf lock so interior mutability is observable.
+			let mut empty = false;
+			self.datastore.read_sync(&key, |_, arc| {
+				let mut versions = arc.write();
 				if versions.gc_older_versions(cleanup_ts) == 0 {
-					// Drop the version reference
-					drop(versions);
-					// Remove the entry from the datastore
-					self.datastore.remove(&key);
+					empty = true;
 				}
+			});
+			if empty {
+				self.datastore.remove_if_sync(&key, |arc| arc.read().is_empty());
 			}
 		}
 	}
 
 	fn run_gc_full(&self, cleanup_ts: u64) {
-		// Iterate over the entire datastore
-		for entry in self.datastore.iter() {
-			// Get a mutable reference to the versions list
-			let versions = entry.value();
-			let mut versions = versions.write();
-			// Clean up unnecessary older versions
+		// Snapshot keys whose versions chains might be empty after GC,
+		// then re-check under a conditional remove. We collect into a Vec
+		// so we don't hold an EBR guard across `remove_if_sync` calls,
+		// which would prevent EBR reclamation while we work.
+		let guard = scc::Guard::new();
+		let mut to_check: Vec<Bytes> = Vec::new();
+		for (key, arc) in self.datastore.iter(&guard) {
+			let mut versions = arc.write();
 			if versions.gc_older_versions(cleanup_ts) == 0 {
-				// Drop the version reference
-				drop(versions);
-				// Remove the entry from the datastore
-				self.datastore.remove(entry.key());
+				to_check.push(key.clone());
 			}
+		}
+		drop(guard);
+		for key in to_check {
+			self.datastore.remove_if_sync(&key, |arc| arc.read().is_empty());
 		}
 	}
 
@@ -399,34 +404,33 @@ impl Database {
 					let cleanup_ts = history_cutoff.min(earliest_tx);
 					// Drain all keys from the dirty queue (incremental GC)
 					while let Some(key) = db.gc_dirty_keys.pop() {
-						// Check if this key still exists in the datastore
-						if let Some(entry) = db.datastore.get(&key) {
-							// Get a mutable reference to the versions list
-							let mut versions = entry.value().write();
-							// Clean up unnecessary older versions
+						let mut empty = false;
+						db.datastore.read_sync(&key, |_, arc| {
+							let mut versions = arc.write();
 							if versions.gc_older_versions(cleanup_ts) == 0 {
-								// Drop the version reference
-								drop(versions);
-								// Remove the entry from the datastore
-								db.datastore.remove(&key);
+								empty = true;
 							}
+						});
+						if empty {
+							db.datastore
+								.remove_if_sync(&key, |arc| arc.read().is_empty());
 						}
 					}
 					// Periodically do a full datastore scan
 					cycle += 1;
 					if cycle.is_multiple_of(FULL_SCAN_FREQUENCY) {
-						// Iterate over the entire datastore
-						for entry in db.datastore.iter() {
-							// Get a mutable reference to the versions list
-							let versions = entry.value();
-							let mut versions = versions.write();
-							// Clean up unnecessary older versions
+						let guard = scc::Guard::new();
+						let mut to_check: Vec<Bytes> = Vec::new();
+						for (key, arc) in db.datastore.iter(&guard) {
+							let mut versions = arc.write();
 							if versions.gc_older_versions(cleanup_ts) == 0 {
-								// Drop the version reference
-								drop(versions);
-								// Remove the entry from the datastore
-								db.datastore.remove(entry.key());
+								to_check.push(key.clone());
 							}
+						}
+						drop(guard);
+						for key in to_check {
+							db.datastore
+								.remove_if_sync(&key, |arc| arc.read().is_empty());
 						}
 					}
 				}

--- a/src/db.rs
+++ b/src/db.rs
@@ -16,7 +16,6 @@
 
 use crate::inner::Inner;
 use crate::options::DatabaseOptions;
-use bytes::Bytes;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::options::{DEFAULT_CLEANUP_INTERVAL, DEFAULT_GC_INTERVAL};
 #[cfg(not(target_arch = "wasm32"))]
@@ -24,6 +23,7 @@ use crate::persistence::Persistence;
 use crate::pool::Pool;
 use crate::pool::DEFAULT_POOL_SIZE;
 use crate::tx::Transaction;
+use bytes::Bytes;
 use std::ops::Deref;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -412,8 +412,7 @@ impl Database {
 							}
 						});
 						if empty {
-							db.datastore
-								.remove_if_sync(&key, |arc| arc.read().is_empty());
+							db.datastore.remove_if_sync(&key, |arc| arc.read().is_empty());
 						}
 					}
 					// Periodically do a full datastore scan
@@ -429,8 +428,7 @@ impl Database {
 						}
 						drop(guard);
 						for key in to_check {
-							db.datastore
-								.remove_if_sync(&key, |arc| arc.read().is_empty());
+							db.datastore.remove_if_sync(&key, |arc| arc.read().is_empty());
 						}
 					}
 				}

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -24,11 +24,18 @@ use bytes::Bytes;
 use crossbeam_queue::SegQueue;
 use crossbeam_skiplist::SkipMap;
 use parking_lot::RwLock;
+use scc::TreeIndex;
 use std::sync::atomic::{fence, AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use std::thread::JoinHandle;
 use std::time::Duration;
+
+/// Shared MVCC version chain for a single datastore key. Wrapped in `Arc`
+/// because `scc::TreeIndex` requires `V: Clone` — `RwLock<Versions>` is not
+/// `Clone`, but cloning an `Arc` only bumps a refcount and lets the tree
+/// snapshot pointers around leaf splits without affecting interior state.
+pub(crate) type DataValue = Arc<RwLock<Versions>>;
 
 /// Sentinel value stored in a counter entry while its owning [`Inner`]
 /// SkipMap entry is being removed by [`crate::tx::Transaction::drop`]. A
@@ -40,8 +47,8 @@ pub(crate) const COUNTER_TOMBSTONE: u64 = u64::MAX;
 pub struct Inner {
 	/// The timestamp version oracle
 	pub(crate) oracle: Arc<Oracle>,
-	/// The underlying lock-free Skip Map datastructure
-	pub(crate) datastore: SkipMap<Bytes, RwLock<Versions>>,
+	/// The underlying lock-free B+tree datastructure
+	pub(crate) datastore: TreeIndex<Bytes, DataValue>,
 	/// A count of total transactions grouped by oracle version
 	pub(crate) counter_by_oracle: SkipMap<u64, Arc<AtomicU64>>,
 	/// A count of total transactions grouped by commit id
@@ -80,7 +87,7 @@ impl Inner {
 	pub fn new(opts: &DatabaseOptions) -> Self {
 		Self {
 			oracle: Oracle::new(opts.resync_interval),
-			datastore: SkipMap::new(),
+			datastore: TreeIndex::new(),
 			counter_by_oracle: SkipMap::new(),
 			counter_by_commit: SkipMap::new(),
 			transaction_queue_id: AtomicU64::new(0),

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -19,8 +19,8 @@ use crate::direction::Direction;
 use crate::inner::DataValue;
 use crate::queue::Merge;
 use bytes::Bytes;
-use scc::Guard;
 use scc::tree_index::Range as TreeRange;
+use scc::Guard;
 use scc::TreeIndex;
 use std::collections::btree_map::Range as BTreeRange;
 use std::ops::Bound;
@@ -84,8 +84,7 @@ impl<'a> TreeIter<'a> {
 		// to construct `range`, which is dropped before `_guard` thanks to
 		// the field declaration order. No other code may observe the
 		// transmuted reference.
-		let guard_ref: &'a Guard =
-			unsafe { std::mem::transmute::<&Guard, &'a Guard>(&*guard) };
+		let guard_ref: &'a Guard = unsafe { std::mem::transmute::<&Guard, &'a Guard>(&*guard) };
 		let range = tree.range::<Bytes, _>(tree_bounds(beg, end), guard_ref);
 		Self {
 			range,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -34,6 +34,23 @@ pub(crate) type SkipBounds = (Bound<Bytes>, Bound<Bytes>);
 /// Concrete type of the `scc::TreeIndex` range iterator over the datastore.
 type DataRange<'a> = TreeRange<'a, Bytes, DataValue, Bytes, SkipBounds>;
 
+/// Compute `scc::TreeIndex::range` bounds with the empty-prefix workaround.
+///
+/// `scc::TreeIndex::range` becomes ~30ms slow (on 100k+ entries) when the
+/// lower bound sorts before every stored key — its `start_forward` falls
+/// into a hot loop while walking forward from the leftmost leaf. Mapping
+/// `Bound::Included(empty)` to `Bound::Unbounded` is semantically
+/// equivalent for `Bytes` keys and stays sub-microsecond.
+#[inline]
+pub(crate) fn tree_bounds(beg: &Bytes, end: &Bytes) -> SkipBounds {
+	let start = if beg.is_empty() {
+		Bound::Unbounded
+	} else {
+		Bound::Included(beg.clone())
+	};
+	(start, Bound::Excluded(end.clone()))
+}
+
 /// Wraps a `scc::TreeIndex::range` iterator together with its owning EBR
 /// `Guard`. `scc::TreeIndex` returns references that are only valid while the
 /// `Guard` is alive, so the iterator and the guard must be held together.
@@ -52,6 +69,13 @@ pub(crate) struct TreeIter<'a> {
 
 impl<'a> TreeIter<'a> {
 	/// Build a new tree iterator over `[beg, end)` for the given tree.
+	///
+	/// An empty `beg` is mapped to `Bound::Unbounded` because
+	/// `scc::TreeIndex::range` has a pathologically slow start path when the
+	/// lower bound sorts before every stored key (observed ~30ms per call on
+	/// 100k entries with shared-prefix keys), while the unbounded path is
+	/// sub-microsecond. The semantics are identical for our `Bytes` keys —
+	/// no entry can be lexicographically smaller than an empty key.
 	#[inline]
 	pub(crate) fn new(tree: &'a TreeIndex<Bytes, DataValue>, beg: &Bytes, end: &Bytes) -> Self {
 		let guard = Box::new(Guard::new());
@@ -62,9 +86,7 @@ impl<'a> TreeIter<'a> {
 		// transmuted reference.
 		let guard_ref: &'a Guard =
 			unsafe { std::mem::transmute::<&Guard, &'a Guard>(&*guard) };
-		let bounds: SkipBounds =
-			(Bound::Included(beg.clone()), Bound::Excluded(end.clone()));
-		let range = tree.range::<Bytes, _>(bounds, guard_ref);
+		let range = tree.range::<Bytes, _>(tree_bounds(beg, end), guard_ref);
 		Self {
 			range,
 			_guard: guard,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -16,20 +16,86 @@
 //! sources.
 
 use crate::direction::Direction;
+use crate::inner::DataValue;
 use crate::queue::Merge;
-use crate::versions::Versions;
 use bytes::Bytes;
-use crossbeam_skiplist::map::Entry;
-use crossbeam_skiplist::map::Range as SkipRange;
-use parking_lot::RwLock;
-use std::collections::btree_map::Range as TreeRange;
+use scc::Guard;
+use scc::tree_index::Range as TreeRange;
+use scc::TreeIndex;
+use std::collections::btree_map::Range as BTreeRange;
 use std::ops::Bound;
 use std::sync::Arc;
 
-/// Owned range bounds for the skip list range iterator.
-/// Using owned Bytes avoids lifetime coupling between range bounds
-/// and the MergeIterator, enabling persistent storage (e.g., in a Cursor).
+/// Owned range bounds for the tree range iterator.
+/// Using owned Bytes avoids lifetime coupling between range bounds and the
+/// MergeIterator, enabling persistent storage (e.g., in a Cursor).
 pub(crate) type SkipBounds = (Bound<Bytes>, Bound<Bytes>);
+
+/// Concrete type of the `scc::TreeIndex` range iterator over the datastore.
+type DataRange<'a> = TreeRange<'a, Bytes, DataValue, Bytes, SkipBounds>;
+
+/// Wraps a `scc::TreeIndex::range` iterator together with its owning EBR
+/// `Guard`. `scc::TreeIndex` returns references that are only valid while the
+/// `Guard` is alive, so the iterator and the guard must be held together.
+///
+/// Drop order matters: `range` is dropped before `_guard` (struct fields drop
+/// in declaration order), so any references the iterator may still hold are
+/// torn down while the EBR pin is still active.
+pub(crate) struct TreeIter<'a> {
+	// Range is constructed with the guard's lifetime extended to `'a` via
+	// `transmute`. Safety relies on the guard living as long as the range —
+	// guaranteed by storing the guard in the same struct and on field-order
+	// drop semantics. The range is dropped first; the guard last.
+	range: DataRange<'a>,
+	_guard: Box<Guard>,
+}
+
+impl<'a> TreeIter<'a> {
+	/// Build a new tree iterator over `[beg, end)` for the given tree.
+	#[inline]
+	pub(crate) fn new(tree: &'a TreeIndex<Bytes, DataValue>, beg: &Bytes, end: &Bytes) -> Self {
+		let guard = Box::new(Guard::new());
+		// SAFETY: `guard` is owned by this struct via `Box`, so the heap
+		// allocation has a stable address. The transmuted reference is used
+		// to construct `range`, which is dropped before `_guard` thanks to
+		// the field declaration order. No other code may observe the
+		// transmuted reference.
+		let guard_ref: &'a Guard =
+			unsafe { std::mem::transmute::<&Guard, &'a Guard>(&*guard) };
+		let bounds: SkipBounds =
+			(Bound::Included(beg.clone()), Bound::Excluded(end.clone()));
+		let range = tree.range::<Bytes, _>(bounds, guard_ref);
+		Self {
+			range,
+			_guard: guard,
+		}
+	}
+
+	/// Yield the next entry in `direction` order.
+	#[inline]
+	pub(crate) fn next(&mut self, direction: Direction) -> Option<(&Bytes, &DataValue)> {
+		match direction {
+			Direction::Forward => self.range.next(),
+			Direction::Reverse => self.range.next_back(),
+		}
+	}
+}
+
+/// Cached entry from the tree iterator: (key, exists_at_version).
+///
+/// Only the key and existence flag are precomputed — the value at the current
+/// version is fetched lazily at emit time, while the tree iterator is parked
+/// past this entry. This avoids cloning a value byte slice for entries that
+/// get skipped or that the caller only needs existence for (`next_count`,
+/// `next_key`).
+///
+/// The lazy fetch is a separate `peek_with` lookup on the underlying tree
+/// rather than holding the iterator on the entry. This trades one extra tree
+/// lookup per yielded value for the simplicity of single-threaded iterator
+/// advancement and avoids `scc::TreeIndex`'s warning about stale value
+/// references during concurrent leaf splits — the cached `Arc<RwLock>` we
+/// pull out via `peek_with` is the canonical pointer, not a snapshot copy.
+type CachedTreeEntry = Option<(Bytes, DataValue, bool)>;
 
 /// Lazy k-way merge iterator over committed merge-queue writesets.
 ///
@@ -158,17 +224,17 @@ impl Iterator for MergeQueueIter {
 }
 
 /// Three-way merge iterator over tree, merge queue, and current transaction
-/// writesets
+/// writesets.
 pub struct MergeIterator<'a> {
 	// Source iterators
-	pub(crate) tree_iter: SkipRange<'a, Bytes, SkipBounds, Bytes, RwLock<Versions>>,
-	pub(crate) self_iter: TreeRange<'a, Bytes, Option<Bytes>>,
+	pub(crate) tree_iter: TreeIter<'a>,
+	pub(crate) self_iter: BTreeRange<'a, Bytes, Option<Bytes>>,
 
 	// Lazy iterator over committed merge-queue writesets
 	pub(crate) join_iter: Box<dyn Iterator<Item = (Bytes, Option<Bytes>)> + 'a>,
 
 	// Current buffered entries from each source
-	pub(crate) tree_next: Option<Entry<'a, Bytes, RwLock<Versions>>>,
+	pub(crate) tree_next: CachedTreeEntry,
 	pub(crate) join_next: Option<(Bytes, Option<Bytes>)>,
 	pub(crate) self_next: Option<(&'a Bytes, &'a Option<Bytes>)>,
 
@@ -191,26 +257,24 @@ enum KeySource {
 
 impl<'a> MergeIterator<'a> {
 	pub fn new(
-		mut tree_iter: SkipRange<'a, Bytes, SkipBounds, Bytes, RwLock<Versions>>,
+		mut tree_iter: TreeIter<'a>,
 		mut join_iter: Box<dyn Iterator<Item = (Bytes, Option<Bytes>)> + 'a>,
-		mut self_iter: TreeRange<'a, Bytes, Option<Bytes>>,
+		mut self_iter: BTreeRange<'a, Bytes, Option<Bytes>>,
 		direction: Direction,
 		version: u64,
 		skip: usize,
 	) -> Self {
-		// Get initial entries based on direction
-		let tree_next = match direction {
-			Direction::Forward => tree_iter.next(),
-			Direction::Reverse => tree_iter.next_back(),
-		};
+		// Prime the tree-side from the underlying scc Range. We pull a
+		// `(key, Arc, exists)` triple up front and keep them cached. The
+		// Arc clone is cheap (refcount) and lets us release the borrow on
+		// the iterator so subsequent advances don't conflict.
+		let tree_next = fetch_tree_entry(&mut tree_iter, direction, version);
 
 		let self_next = match direction {
 			Direction::Forward => self_iter.next(),
 			Direction::Reverse => self_iter.next_back(),
 		};
 
-		// The lazy join iterator is already direction-baked; just pull the
-		// first entry.
 		let join_next = join_iter.next();
 
 		MergeIterator {
@@ -231,126 +295,113 @@ impl<'a> MergeIterator<'a> {
 		self.join_next = self.join_iter.next();
 	}
 
-	/// Get next entry existence only (no key or value cloning) - optimized for
-	/// counting
-	pub fn next_count(&mut self) -> Option<bool> {
-		loop {
-			// Find the next key to process (smallest for Forward, largest for Reverse)
-			let mut next_key: Option<&Bytes> = None;
-			let mut next_source = KeySource::None;
+	#[inline]
+	fn advance_self(&mut self) {
+		self.self_next = match self.direction {
+			Direction::Forward => self.self_iter.next(),
+			Direction::Reverse => self.self_iter.next_back(),
+		};
+	}
 
-			// Check self iterator (highest priority)
-			if let Some((sk, _)) = self.self_next {
-				next_key = Some(sk);
+	#[inline]
+	fn advance_tree(&mut self) {
+		self.tree_next = fetch_tree_entry(&mut self.tree_iter, self.direction, self.version);
+	}
+
+	#[inline]
+	fn tree_key(&self) -> Option<&Bytes> {
+		self.tree_next.as_ref().map(|(k, _, _)| k)
+	}
+
+	#[inline]
+	fn tree_exists(&self) -> bool {
+		self.tree_next.as_ref().map(|(_, _, e)| *e).unwrap_or(false)
+	}
+
+	/// Decide which source has the next key to process. Pure inspection,
+	/// no advancing.
+	#[inline]
+	fn next_source(&self) -> KeySource {
+		let mut next_key: Option<&Bytes> = None;
+		let mut next_source = KeySource::None;
+
+		// Check self iterator (highest priority on tie)
+		if let Some((sk, _)) = self.self_next {
+			next_key = Some(sk);
+			next_source = KeySource::Transaction;
+		}
+
+		// Check join iterator (merge queue)
+		if let Some((jk, _)) = &self.join_next {
+			let should_use = match (next_key, &self.direction) {
+				(None, _) => true,
+				(Some(k), Direction::Forward) => jk < k,
+				(Some(k), Direction::Reverse) => jk > k,
+			};
+			if should_use {
+				next_key = Some(jk);
+				next_source = KeySource::Committed;
+			} else if next_key == Some(jk) {
+				// Same key in both self and join - self wins
 				next_source = KeySource::Transaction;
 			}
+		}
 
-			// Check join iterator (merge queue)
-			if let Some((jk, _)) = &self.join_next {
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => jk < k,
-					(Some(k), Direction::Reverse) => jk > k,
-				};
-				if should_use {
-					next_key = Some(jk);
-					next_source = KeySource::Committed;
-				} else if next_key == Some(jk) {
-					// Same key in both self and join - self wins
-					next_source = KeySource::Transaction;
-				}
+		// Check tree iterator
+		if let Some(tk) = self.tree_key() {
+			let should_use = match (next_key, &self.direction) {
+				(None, _) => true,
+				(Some(k), Direction::Forward) => tk < k,
+				(Some(k), Direction::Reverse) => tk > k,
+			};
+			if should_use {
+				next_source = KeySource::Datastore;
 			}
+		}
 
-			// Check tree iterator
-			if let Some(t_entry) = &self.tree_next {
-				let tk = t_entry.key();
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => tk < k,
-					(Some(k), Direction::Reverse) => tk > k,
-				};
-				if should_use {
-					next_source = KeySource::Datastore;
-				}
-			}
+		next_source
+	}
 
-			// Process the selected source
-			let exists = match next_source {
+	/// Get next entry existence only (no key or value cloning) - optimized
+	/// for counting.
+	pub fn next_count(&mut self) -> Option<bool> {
+		loop {
+			let exists = match self.next_source() {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
 					let exists = sv.is_some();
+					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
+					let skip_tree = self.tree_key() == Some(sk);
 
-					// Advance self iterator
-					self.self_next = match self.direction {
-						Direction::Forward => self.self_iter.next(),
-						Direction::Reverse => self.self_iter.next_back(),
-					};
-
-					// Skip same key in other iterators
-					if let Some((jk, _)) = &self.join_next {
-						if jk == sk {
-							self.advance_join();
-						}
+					self.advance_self();
+					if skip_join {
+						self.advance_join();
 					}
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == sk {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
 					exists
 				}
 				KeySource::Committed => {
 					let exists = self.join_next.as_ref().unwrap().1.is_some();
+					let skip_tree = self.tree_key() == self.join_next.as_ref().map(|(jk, _)| jk);
 
-					// Check if we need to skip same key in tree before advancing join
-					let should_skip_tree = if let Some(t_entry) = &self.tree_next {
-						if let Some((jk, _)) = &self.join_next {
-							t_entry.key() == jk
-						} else {
-							false
-						}
-					} else {
-						false
-					};
-
-					// Advance join iterator
 					self.advance_join();
-
-					// Skip same key in tree iterator if needed
-					if should_skip_tree {
-						self.tree_next = match self.direction {
-							Direction::Forward => self.tree_iter.next(),
-							Direction::Reverse => self.tree_iter.next_back(),
-						};
+					if skip_tree {
+						self.advance_tree();
 					}
 
 					exists
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
-					let tv = match t_entry.value().try_read() {
-						Some(guard) => guard,
-						None => t_entry.value().read(),
-					};
-					let exists = tv.exists_version(self.version);
-					drop(tv);
-
-					// Advance tree iterator
-					self.tree_next = match self.direction {
-						Direction::Forward => self.tree_iter.next(),
-						Direction::Reverse => self.tree_iter.next_back(),
-					};
-
+					let exists = self.tree_exists();
+					self.advance_tree();
 					exists
 				}
 				KeySource::None => return None,
 			};
 
-			// Handle skipping
 			if exists && self.skip_remaining > 0 {
 				self.skip_remaining -= 1;
 				continue;
@@ -360,163 +411,69 @@ impl<'a> MergeIterator<'a> {
 		}
 	}
 
-	/// Get next entry with key (no value cloning) - optimized for key iteration
+	/// Get next entry with key (no value cloning) - optimized for key
+	/// iteration.
 	pub fn next_key(&mut self) -> Option<(Bytes, bool)> {
 		loop {
-			// Find the next key to process (smallest for Forward, largest for Reverse)
-			let mut next_key: Option<&Bytes> = None;
-			let mut next_source = KeySource::None;
-
-			// Check self iterator (highest priority)
-			if let Some((sk, _)) = self.self_next {
-				next_key = Some(sk);
-				next_source = KeySource::Transaction;
-			}
-
-			// Check join iterator (merge queue)
-			if let Some((jk, _)) = &self.join_next {
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => jk < k,
-					(Some(k), Direction::Reverse) => jk > k,
-				};
-				if should_use {
-					next_key = Some(jk);
-					next_source = KeySource::Committed;
-				} else if next_key == Some(jk) {
-					// Same key in both self and join - self wins
-					next_source = KeySource::Transaction;
-				}
-			}
-
-			// Check tree iterator
-			if let Some(t_entry) = &self.tree_next {
-				let tk = t_entry.key();
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => tk < k,
-					(Some(k), Direction::Reverse) => tk > k,
-				};
-				if should_use {
-					next_source = KeySource::Datastore;
-				}
-			}
-
-			// Process the selected source - first determine if entry exists
-			match next_source {
+			match self.next_source() {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
 					let exists = sv.is_some();
-
-					// Store key reference for later cloning if needed
 					let key_ref = sk;
+					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
+					let skip_tree = self.tree_key() == Some(sk);
 
-					// Advance self iterator
-					self.self_next = match self.direction {
-						Direction::Forward => self.self_iter.next(),
-						Direction::Reverse => self.self_iter.next_back(),
-					};
-
-					// Skip same key in other iterators
-					if let Some((jk, _)) = &self.join_next {
-						if jk == key_ref {
-							self.advance_join();
-						}
+					self.advance_self();
+					if skip_join {
+						self.advance_join();
 					}
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == key_ref {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
-					// Handle skipping BEFORE cloning
 					if exists && self.skip_remaining > 0 {
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone if we're returning it
 					return Some((key_ref.clone(), exists));
 				}
 				KeySource::Committed => {
 					let (jk, jv) = self.join_next.as_ref().unwrap();
 
-					// Check if we should skip (only skip existing entries)
 					if jv.is_some() && self.skip_remaining > 0 {
-						// Check if we need to skip same key in tree before advancing join
-						let should_skip_tree = if let Some(t_entry) = &self.tree_next {
-							t_entry.key() == jk
-						} else {
-							false
-						};
-
-						// Advance join iterator
+						let skip_tree = self.tree_key() == Some(jk);
 						self.advance_join();
-
-						// Skip same key in tree iterator if needed
-						if should_skip_tree {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
+						if skip_tree {
+							self.advance_tree();
 						}
-
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Read existence before advancing (avoids value clone)
 					let exists = jv.is_some();
 					let key = jk.clone();
+					let skip_tree = self.tree_key() == Some(&key);
 
-					// Advance join iterator
 					self.advance_join();
-
-					// Skip same key in tree iterator
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == &key {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
 					return Some((key, exists));
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
-					let tv = match t_entry.value().try_read() {
-						Some(guard) => guard,
-						None => t_entry.value().read(),
-					};
-					let exists = tv.exists_version(self.version);
-					drop(tv);
+					let exists = self.tree_exists();
 
-					// Handle skipping BEFORE cloning the key
 					if exists && self.skip_remaining > 0 {
-						// Advance tree iterator
-						self.tree_next = match self.direction {
-							Direction::Forward => self.tree_iter.next(),
-							Direction::Reverse => self.tree_iter.next_back(),
-						};
+						self.advance_tree();
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone key if we're returning it
-					let tk = t_entry.key().clone();
-
-					// Advance tree iterator
-					self.tree_next = match self.direction {
-						Direction::Forward => self.tree_iter.next(),
-						Direction::Reverse => self.tree_iter.next_back(),
-					};
-
-					return Some((tk, exists));
+					let key = self.tree_next.as_ref().map(|(k, _, _)| k.clone()).unwrap();
+					self.advance_tree();
+					return Some((key, exists));
 				}
 				KeySource::None => return None,
 			}
@@ -524,166 +481,100 @@ impl<'a> MergeIterator<'a> {
 	}
 }
 
+/// Pull the next entry from the underlying tree iterator, capturing
+/// `(key, Arc<RwLock<Versions>>, exists_at_version)`. The Arc clone is a
+/// refcount bump; resolving existence is cheap (no value clone). The actual
+/// value bytes are fetched lazily in `Iterator::next` only when needed.
+#[inline]
+fn fetch_tree_entry(
+	tree_iter: &mut TreeIter<'_>,
+	direction: Direction,
+	version: u64,
+) -> CachedTreeEntry {
+	tree_iter.next(direction).map(|(k, arc)| {
+		let exists = match arc.try_read() {
+			Some(g) => g.exists_version(version),
+			None => arc.read().exists_version(version),
+		};
+		(k.clone(), arc.clone(), exists)
+	})
+}
+
 impl<'a> Iterator for MergeIterator<'a> {
 	type Item = (Bytes, Option<Bytes>);
 
 	fn next(&mut self) -> Option<Self::Item> {
 		loop {
-			// Find the next key to process (smallest for Forward, largest for Reverse)
-			let mut next_key: Option<&Bytes> = None;
-			let mut next_source = KeySource::None;
-
-			// Check self iterator (highest priority)
-			if let Some((sk, _)) = self.self_next {
-				next_key = Some(sk);
-				next_source = KeySource::Transaction;
-			}
-
-			// Check join iterator (merge queue)
-			if let Some((jk, _)) = &self.join_next {
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => jk < k,
-					(Some(k), Direction::Reverse) => jk > k,
-				};
-				if should_use {
-					next_key = Some(jk);
-					next_source = KeySource::Committed;
-				} else if next_key == Some(jk) {
-					// Same key in both self and join - self wins
-					next_source = KeySource::Transaction;
-				}
-			}
-
-			// Check tree iterator
-			if let Some(t_entry) = &self.tree_next {
-				let tk = t_entry.key();
-				let should_use = match (next_key, &self.direction) {
-					(None, _) => true,
-					(Some(k), Direction::Forward) => tk < k,
-					(Some(k), Direction::Reverse) => tk > k,
-				};
-				if should_use {
-					next_source = KeySource::Datastore;
-				}
-			}
-
-			// Process the selected source
-			match next_source {
+			match self.next_source() {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
-					let exists = sv.is_some();
-
-					// Store key reference for deferred cloning
 					let key_ref = sk;
+					let exists = sv.is_some();
+					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
+					let skip_tree = self.tree_key() == Some(sk);
 
-					// Advance self iterator
-					self.self_next = match self.direction {
-						Direction::Forward => self.self_iter.next(),
-						Direction::Reverse => self.self_iter.next_back(),
-					};
-
-					// Skip same key in other iterators
-					if let Some((jk, _)) = &self.join_next {
-						if jk == key_ref {
-							self.advance_join();
-						}
+					self.advance_self();
+					if skip_join {
+						self.advance_join();
 					}
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == key_ref {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
-					// Check if we should skip (only skip existing entries)
 					if exists && self.skip_remaining > 0 {
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone key and value when returning
 					return Some((key_ref.clone(), sv.clone()));
 				}
 				KeySource::Committed => {
 					let (jk, jv) = self.join_next.as_ref().unwrap();
 
-					// Check if we should skip (only skip existing entries)
 					if jv.is_some() && self.skip_remaining > 0 {
-						// Check if we need to skip same key in tree before advancing join
-						let should_skip_tree = if let Some(t_entry) = &self.tree_next {
-							t_entry.key() == jk
-						} else {
-							false
-						};
-
-						// Advance join iterator
+						let skip_tree = self.tree_key() == Some(jk);
 						self.advance_join();
-
-						// Skip same key in tree iterator if needed
-						if should_skip_tree {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
+						if skip_tree {
+							self.advance_tree();
 						}
-
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone key and value when returning
 					let key = jk.clone();
-					let value_opt = jv.clone();
+					let value = jv.clone();
+					let skip_tree = self.tree_key() == Some(&key);
 
-					// Advance join iterator
 					self.advance_join();
-
-					// Skip same key in tree iterator
-					if let Some(t_entry) = &self.tree_next {
-						if t_entry.key() == &key {
-							self.tree_next = match self.direction {
-								Direction::Forward => self.tree_iter.next(),
-								Direction::Reverse => self.tree_iter.next_back(),
-							};
-						}
+					if skip_tree {
+						self.advance_tree();
 					}
 
-					return Some((key, value_opt));
+					return Some((key, value));
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
-					let tv = match t_entry.value().try_read() {
-						Some(guard) => guard,
-						None => t_entry.value().read(),
-					};
-					let value_opt = tv.fetch_version(self.version);
-					let exists = value_opt.is_some();
-					drop(tv);
+					let exists = self.tree_exists();
 
-					// Handle skipping BEFORE cloning the key
 					if exists && self.skip_remaining > 0 {
-						// Advance tree iterator
-						self.tree_next = match self.direction {
-							Direction::Forward => self.tree_iter.next(),
-							Direction::Reverse => self.tree_iter.next_back(),
-						};
+						self.advance_tree();
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Only clone key if we're returning it
-					let key_clone = t_entry.key().clone();
-
-					// Advance tree iterator
-					self.tree_next = match self.direction {
-						Direction::Forward => self.tree_iter.next(),
-						Direction::Reverse => self.tree_iter.next_back(),
+					// Resolve the value lazily from the cached Arc, then
+					// advance past the entry.
+					let (key, arc, _) = self.tree_next.as_ref().unwrap();
+					let value = if exists {
+						match arc.try_read() {
+							Some(g) => g.fetch_version(self.version),
+							None => arc.read().fetch_version(self.version),
+						}
+					} else {
+						None
 					};
-
-					return Some((key_clone, value_opt));
+					let key = key.clone();
+					self.advance_tree();
+					return Some((key, value));
 				}
 				KeySource::None => return None,
 			}

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -314,19 +314,21 @@ impl Persistence {
 				0
 			};
 			// Stream write each key-value pair to reduce memory usage
-			for entry in self.inner.datastore.iter() {
+			let guard = scc::Guard::new();
+			for (key, arc) in self.inner.datastore.iter(&guard) {
 				// Get all versions for this key
-				let versions = entry.value().read().all_versions();
+				let versions = arc.read().all_versions();
 				// Ensure that there are version entries
 				if !versions.is_empty() {
 					// Serialize and write this single entry
 					bincode::serde::encode_into_std_write(
-						&(entry.key().clone(), versions),
+						&(key.clone(), versions),
 						&mut writer,
 						config::standard(),
 					)?;
 				}
 			}
+			drop(guard);
 			// Flush the compressed writer
 			writer.flush()?;
 			// Finish compression (finalizes LZ4 stream)
@@ -396,7 +398,10 @@ impl Persistence {
 									});
 								}
 								// Insert the entry into the datastore
-								self.inner.datastore.insert(k, RwLock::new(entries));
+								let _ = self
+									.inner
+									.datastore
+									.insert_sync(k, Arc::new(RwLock::new(entries)));
 							}
 						}
 						Err(e) => match e {
@@ -440,21 +445,33 @@ impl Persistence {
 					match result {
 						Ok((k, version, val)) => {
 							// Check if the key already exists
-							if let Some(entry) = self.inner.datastore.get(&k) {
-								// Update existing key with stored version
-								entry.value().write().push(Version {
+							let mut applied = false;
+							self.inner.datastore.read_sync(&k, |_, arc| {
+								arc.write().push(Version {
 									version,
-									value: val,
+									value: val.clone(),
 								});
-							} else {
-								// Insert new key with stored version
-								self.inner.datastore.insert(
-									k.clone(),
-									RwLock::new(Versions::from(Version {
-										version,
-										value: val,
-									})),
-								);
+								applied = true;
+							});
+							if !applied {
+								// Insert new key with stored version. If a
+								// concurrent reader has just inserted, fall
+								// back to a `read_sync` push on the existing
+								// entry.
+								let new = Arc::new(RwLock::new(Versions::from(Version {
+									version,
+									value: val.clone(),
+								})));
+								if let Err((_, _)) =
+									self.inner.datastore.insert_sync(k.clone(), new)
+								{
+									self.inner.datastore.read_sync(&k, |_, arc| {
+										arc.write().push(Version {
+											version,
+											value: val.clone(),
+										});
+									});
+								}
 							}
 						}
 						Err(e) => match e {
@@ -636,19 +653,21 @@ impl Persistence {
 							0
 						};
 						// Stream write each entry to reduce memory usage
-						for entry in db.datastore.iter() {
+						let guard = scc::Guard::new();
+						for (key, arc) in db.datastore.iter(&guard) {
 							// Get all versions for this key
-							let versions = entry.value().read().all_versions();
+							let versions = arc.read().all_versions();
 							// Ensure that there are version entries
 							if !versions.is_empty() {
 								// Serialize and write this single entry
 								bincode::serde::encode_into_std_write(
-									&(entry.key().clone(), versions),
+									&(key.clone(), versions),
 									&mut writer,
 									config::standard(),
 								)?;
 							}
 						}
+						drop(guard);
 						// Flush the compressed writer
 						writer.flush()?;
 						// Finish compression (finalizes LZ4 stream)

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -19,7 +19,7 @@ use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
 use crate::inner::{Inner, COUNTER_TOMBSTONE};
-use crate::iter::{MergeIterator, MergeQueueIter};
+use crate::iter::{MergeIterator, MergeQueueIter, TreeIter};
 use crate::kv::IntoBytes;
 use crate::pool::Pool;
 use crate::queue::{Commit, Merge};
@@ -1027,41 +1027,85 @@ impl TransactionInner {
 		let cleanup_ts = history.min(earliest);
 		// Loop over the updates in the writeset
 		for (key, value) in entry.writeset.iter() {
-			// Clone the value for insertion
-			let value = value.clone();
-			// Check if this key already exists
-			if let Some(entry) = self.database.datastore.get(key) {
-				// Get a mutable reference to the versions list
-				let mut versions = entry.value().write();
-				// Clean up unnecessary older versions
+			// `scc::TreeIndex` lacks an entry-style mutate-or-insert API, so
+			// we open a `read_sync` (shared lock on the leaf) and mutate
+			// `Versions` through the `Arc<RwLock<_>>` interior. The shared
+			// lock blocks structural splits, satisfying the docs' requirement
+			// for observable interior mutability. When the key is absent we
+			// fall through to a tight `insert_sync` retry loop that handles
+			// concurrent inserts at the same key.
+			let mut existed = false;
+			let mut needs_remove = false;
+			self.database.datastore.read_sync(key, |_, arc| {
+				existed = true;
+				let mut versions = arc.write();
 				let len = versions.gc_older_versions(cleanup_ts);
-				// If no versions remain and the value is none, remove the entry fully
 				if len == 0 && value.is_none() {
-					// Drop the version reference
-					drop(versions);
-					// Remove the entry from the datastore
-					self.database.datastore.remove(key);
-				}
-				// If a value is set, add the new version entry
-				else {
-					// Add the version entry to the versions list
+					// Mark for removal; conditional removal happens after the
+					// `read_sync` shared lock has been released.
+					needs_remove = true;
+				} else {
 					versions.push(Version {
 						version,
-						value,
+						value: value.clone(),
 					});
-					// If stale versions remain, mark this key for background GC
 					if len > 1 {
 						self.database.gc_dirty_keys.push(key.clone());
 					}
 				}
-			} else {
-				self.database.datastore.insert(
-					key.clone(),
-					RwLock::new(Versions::from(Version {
-						version,
-						value,
-					})),
-				);
+			});
+			if existed {
+				if needs_remove {
+					// Re-check under exclusive: another committer may have
+					// pushed a fresh version on this key since we released
+					// the shared lock above.
+					self.database.datastore.remove_if_sync(key, |arc| {
+						arc.read().is_empty()
+					});
+				}
+				continue;
+			}
+			// Key absent — try to insert. If a concurrent committer races
+			// us, `insert_sync` returns the rejected `(K, V)` and we retry
+			// the `read_sync` mutate path on the next iteration.
+			let mut pending = Arc::new(RwLock::new(Versions::from(Version {
+				version,
+				value: value.clone(),
+			})));
+			loop {
+				match self.database.datastore.insert_sync(key.clone(), pending) {
+					Ok(()) => break,
+					Err((_, returned)) => {
+						let mut took_path = false;
+						self.database.datastore.read_sync(key, |_, arc| {
+							took_path = true;
+							let mut versions = arc.write();
+							let len = versions.gc_older_versions(cleanup_ts);
+							if len == 0 && value.is_none() {
+								needs_remove = true;
+							} else {
+								versions.push(Version {
+									version,
+									value: value.clone(),
+								});
+								if len > 1 {
+									self.database.gc_dirty_keys.push(key.clone());
+								}
+							}
+						});
+						if took_path {
+							if needs_remove {
+								self.database.datastore.remove_if_sync(key, |arc| {
+									arc.read().is_empty()
+								});
+							}
+							break;
+						}
+						// Both lookups raced — try insert again with the
+						// same pending Arc.
+						pending = returned;
+					}
+				}
 			}
 		}
 		// Append the transaction to the persistence layer
@@ -1641,14 +1685,15 @@ impl TransactionInner {
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
-			for entry in datastore_range {
-				let value = match entry.value().try_read() {
+			let guard = scc::Guard::new();
+			let datastore_range = self.database.datastore.range::<Bytes, _>(
+				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
+				&guard,
+			);
+			for (k, arc) in datastore_range {
+				let value = match arc.try_read() {
 					Some(g) => g.fetch_version(self.version),
-					None => entry.value().read().fetch_version(self.version),
+					None => arc.read().fetch_version(self.version),
 				};
 				let Some(value) = value else {
 					continue;
@@ -1658,7 +1703,7 @@ impl TransactionInner {
 					continue;
 				}
 				count += 1;
-				if !f(entry.key(), &value) {
+				if !f(k, &value) {
 					break;
 				}
 				if let Some(l) = limit {
@@ -1678,9 +1723,7 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, beg, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1740,14 +1783,15 @@ impl TransactionInner {
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
-			for entry in datastore_range {
-				let exists = match entry.value().try_read() {
+			let guard = scc::Guard::new();
+			let datastore_range = self.database.datastore.range::<Bytes, _>(
+				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
+				&guard,
+			);
+			for (k, arc) in datastore_range {
+				let exists = match arc.try_read() {
 					Some(g) => g.exists_version(self.version),
-					None => entry.value().read().exists_version(self.version),
+					None => arc.read().exists_version(self.version),
 				};
 				if !exists {
 					continue;
@@ -1757,7 +1801,7 @@ impl TransactionInner {
 					continue;
 				}
 				count += 1;
-				if !f(entry.key()) {
+				if !f(k) {
 					break;
 				}
 				if let Some(l) = limit {
@@ -1777,9 +1821,7 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, beg, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1837,14 +1879,15 @@ impl TransactionInner {
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
-			for entry in datastore_range {
-				let value = match entry.value().try_read() {
+			let guard = scc::Guard::new();
+			let datastore_range = self.database.datastore.range::<Bytes, _>(
+				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
+				&guard,
+			);
+			for (k, arc) in datastore_range {
+				let value = match arc.try_read() {
 					Some(g) => g.fetch_version(self.version),
-					None => entry.value().read().fetch_version(self.version),
+					None => arc.read().fetch_version(self.version),
 				};
 				let Some(value) = value else {
 					continue;
@@ -1853,7 +1896,7 @@ impl TransactionInner {
 					skip -= 1;
 					continue;
 				}
-				buf.push((entry.key().clone(), value));
+				buf.push((k.clone(), value));
 				if let Some(l) = limit {
 					if buf.len() >= l {
 						break;
@@ -1871,9 +1914,7 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, beg, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1928,14 +1969,15 @@ impl TransactionInner {
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
-			for entry in datastore_range {
-				let exists = match entry.value().try_read() {
+			let guard = scc::Guard::new();
+			let datastore_range = self.database.datastore.range::<Bytes, _>(
+				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
+				&guard,
+			);
+			for (k, arc) in datastore_range {
+				let exists = match arc.try_read() {
 					Some(g) => g.exists_version(self.version),
-					None => entry.value().read().exists_version(self.version),
+					None => arc.read().exists_version(self.version),
 				};
 				if !exists {
 					continue;
@@ -1944,7 +1986,7 @@ impl TransactionInner {
 					skip -= 1;
 					continue;
 				}
-				buf.push(entry.key().clone());
+				buf.push(k.clone());
 				if let Some(l) = limit {
 					if buf.len() >= l {
 						break;
@@ -1962,9 +2004,7 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, beg, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -2058,16 +2098,17 @@ impl TransactionInner {
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			let guard = scc::Guard::new();
+			let datastore_range = self.database.datastore.range::<Bytes, _>(
+				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
+				&guard,
+			);
 			macro_rules! consume_fast_path {
 				($iter:expr) => {
-					for entry in $iter {
-						let exists = match entry.value().try_read() {
+					for (_k, arc) in $iter {
+						let exists = match arc.try_read() {
 							Some(g) => g.exists_version(version),
-							None => entry.value().read().exists_version(version),
+							None => arc.read().exists_version(version),
 						};
 						if !exists {
 							continue;
@@ -2100,9 +2141,7 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, beg, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2162,16 +2201,17 @@ impl TransactionInner {
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			let guard = scc::Guard::new();
+			let datastore_range = self.database.datastore.range::<Bytes, _>(
+				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
+				&guard,
+			);
 			macro_rules! consume_fast_path {
 				($iter:expr) => {
-					for entry in $iter {
-						let exists = match entry.value().try_read() {
+					for (k, arc) in $iter {
+						let exists = match arc.try_read() {
 							Some(g) => g.exists_version(version),
-							None => entry.value().read().exists_version(version),
+							None => arc.read().exists_version(version),
 						};
 						if !exists {
 							continue;
@@ -2180,7 +2220,7 @@ impl TransactionInner {
 							skip -= 1;
 							continue;
 						}
-						res.push(entry.key().clone());
+						res.push(k.clone());
 						if let Some(l) = limit {
 							if res.len() >= l {
 								break;
@@ -2204,9 +2244,7 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, beg, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2266,16 +2304,17 @@ impl TransactionInner {
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let datastore_range = self
-				.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			let guard = scc::Guard::new();
+			let datastore_range = self.database.datastore.range::<Bytes, _>(
+				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
+				&guard,
+			);
 			macro_rules! consume_fast_path {
 				($iter:expr) => {
-					for entry in $iter {
-						let value = match entry.value().try_read() {
+					for (k, arc) in $iter {
+						let value = match arc.try_read() {
 							Some(g) => g.fetch_version(version),
-							None => entry.value().read().fetch_version(version),
+							None => arc.read().fetch_version(version),
 						};
 						let Some(value) = value else {
 							continue;
@@ -2284,7 +2323,7 @@ impl TransactionInner {
 							skip -= 1;
 							continue;
 						}
-						res.push((entry.key().clone(), value));
+						res.push((k.clone(), value));
 						if let Some(l) = limit {
 							if res.len() >= l {
 								break;
@@ -2308,9 +2347,7 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, beg, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2374,9 +2411,7 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator to iterate over keys
 		let iter = MergeIterator::new(
-			self.database
-				.datastore
-				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
+			TreeIter::new(&self.database.datastore, beg, end),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -2389,15 +2424,17 @@ impl TransactionInner {
 		for (key, _) in iter {
 			// Use a BTreeMap to collect and merge versions by version number
 			let mut all_versions: BTreeMap<u64, Option<Bytes>> = BTreeMap::new();
-			// Collect all versions from the datastore
-			if let Some(entry) = self.database.datastore.get(&key) {
-				let versions = entry.value().read();
+			// Collect all versions from the datastore. `read_sync` keeps the
+			// leaf shared-locked while we read, ensuring `Versions` mutations
+			// are observable per `scc::TreeIndex` docs.
+			self.database.datastore.read_sync(&key, |_, arc| {
+				let versions = arc.read();
 				for (ver, val) in versions.all_versions() {
 					if ver <= version {
 						all_versions.insert(ver, val);
 					}
 				}
-			}
+			});
 			// Collect version from the current writeset
 			if self.write {
 				if let Some(val) = self.writeset.get(&key) {
@@ -2570,11 +2607,16 @@ impl TransactionInner {
 				}
 			}
 		}
-		// Check the key in the datastore
-		self.database.datastore.get(key).and_then(|e| match e.value().try_read() {
-			Some(guard) => guard.fetch_version(version),
-			None => e.value().read().fetch_version(version),
-		})
+		// Check the key in the datastore — `read_sync` holds a shared lock
+		// on the leaf so interior mutability through the `RwLock` is
+		// observable (per `scc::TreeIndex` docs).
+		self.database
+			.datastore
+			.read_sync(key, |_, arc| match arc.try_read() {
+				Some(guard) => guard.fetch_version(version),
+				None => arc.read().fetch_version(version),
+			})
+			.flatten()
 	}
 
 	/// Check if a key exists in the datastore only
@@ -2600,12 +2642,11 @@ impl TransactionInner {
 		// Check the key in the datastore
 		self.database
 			.datastore
-			.get(key)
-			.map(|e| match e.value().try_read() {
+			.read_sync(key, |_, arc| match arc.try_read() {
 				Some(guard) => guard.exists_version(version),
-				None => e.value().read().exists_version(version),
+				None => arc.read().exists_version(version),
 			})
-			.is_some_and(|v| v)
+			.unwrap_or(false)
 	}
 
 	/// Check if a key equals a value in the datastore only
@@ -2634,17 +2675,15 @@ impl TransactionInner {
 			}
 		}
 		// Check the key in the datastore
-		match (
-			chk.as_ref(),
-			self.database
-				.datastore
-				.get(key)
-				.and_then(|e| match e.value().try_read() {
-					Some(guard) => guard.fetch_version(version),
-					None => e.value().read().fetch_version(version),
-				})
-				.as_ref(),
-		) {
+		let datastore_value: Option<Bytes> = self
+			.database
+			.datastore
+			.read_sync(key, |_, arc| match arc.try_read() {
+				Some(guard) => guard.fetch_version(version),
+				None => arc.read().fetch_version(version),
+			})
+			.flatten();
+		match (chk.as_ref(), datastore_value.as_ref()) {
 			(Some(x), Some(y)) => x.as_slice() == y,
 			(None, None) => true,
 			_ => false,

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -19,7 +19,7 @@ use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
 use crate::inner::{Inner, COUNTER_TOMBSTONE};
-use crate::iter::{MergeIterator, MergeQueueIter, TreeIter};
+use crate::iter::{tree_bounds, MergeIterator, MergeQueueIter, TreeIter};
 use crate::kv::IntoBytes;
 use crate::pool::Pool;
 use crate::queue::{Commit, Merge};
@@ -33,7 +33,6 @@ use papaya::HashSet;
 use parking_lot::RwLock;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::ops::Bound;
 use std::ops::Range;
 use std::sync::atomic::{fence, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -1686,10 +1685,8 @@ impl TransactionInner {
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
 			let guard = scc::Guard::new();
-			let datastore_range = self.database.datastore.range::<Bytes, _>(
-				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
-				&guard,
-			);
+			let datastore_range =
+				self.database.datastore.range::<Bytes, _>(tree_bounds(beg, end), &guard);
 			for (k, arc) in datastore_range {
 				let value = match arc.try_read() {
 					Some(g) => g.fetch_version(self.version),
@@ -1784,10 +1781,8 @@ impl TransactionInner {
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
 			let guard = scc::Guard::new();
-			let datastore_range = self.database.datastore.range::<Bytes, _>(
-				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
-				&guard,
-			);
+			let datastore_range =
+				self.database.datastore.range::<Bytes, _>(tree_bounds(beg, end), &guard);
 			for (k, arc) in datastore_range {
 				let exists = match arc.try_read() {
 					Some(g) => g.exists_version(self.version),
@@ -1880,10 +1875,8 @@ impl TransactionInner {
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
 			let guard = scc::Guard::new();
-			let datastore_range = self.database.datastore.range::<Bytes, _>(
-				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
-				&guard,
-			);
+			let datastore_range =
+				self.database.datastore.range::<Bytes, _>(tree_bounds(beg, end), &guard);
 			for (k, arc) in datastore_range {
 				let value = match arc.try_read() {
 					Some(g) => g.fetch_version(self.version),
@@ -1970,10 +1963,8 @@ impl TransactionInner {
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
 			let guard = scc::Guard::new();
-			let datastore_range = self.database.datastore.range::<Bytes, _>(
-				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
-				&guard,
-			);
+			let datastore_range =
+				self.database.datastore.range::<Bytes, _>(tree_bounds(beg, end), &guard);
 			for (k, arc) in datastore_range {
 				let exists = match arc.try_read() {
 					Some(g) => g.exists_version(self.version),
@@ -2099,10 +2090,8 @@ impl TransactionInner {
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
 			let guard = scc::Guard::new();
-			let datastore_range = self.database.datastore.range::<Bytes, _>(
-				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
-				&guard,
-			);
+			let datastore_range =
+				self.database.datastore.range::<Bytes, _>(tree_bounds(beg, end), &guard);
 			macro_rules! consume_fast_path {
 				($iter:expr) => {
 					for (_k, arc) in $iter {
@@ -2202,10 +2191,8 @@ impl TransactionInner {
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
 			let guard = scc::Guard::new();
-			let datastore_range = self.database.datastore.range::<Bytes, _>(
-				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
-				&guard,
-			);
+			let datastore_range =
+				self.database.datastore.range::<Bytes, _>(tree_bounds(beg, end), &guard);
 			macro_rules! consume_fast_path {
 				($iter:expr) => {
 					for (k, arc) in $iter {
@@ -2305,10 +2292,8 @@ impl TransactionInner {
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
 			let guard = scc::Guard::new();
-			let datastore_range = self.database.datastore.range::<Bytes, _>(
-				(Bound::Included(beg.clone()), Bound::Excluded(end.clone())),
-				&guard,
-			);
+			let datastore_range =
+				self.database.datastore.range::<Bytes, _>(tree_bounds(beg, end), &guard);
 			macro_rules! consume_fast_path {
 				($iter:expr) => {
 					for (k, arc) in $iter {

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1058,9 +1058,7 @@ impl TransactionInner {
 					// Re-check under exclusive: another committer may have
 					// pushed a fresh version on this key since we released
 					// the shared lock above.
-					self.database.datastore.remove_if_sync(key, |arc| {
-						arc.read().is_empty()
-					});
+					self.database.datastore.remove_if_sync(key, |arc| arc.read().is_empty());
 				}
 				continue;
 			}
@@ -1094,9 +1092,9 @@ impl TransactionInner {
 						});
 						if took_path {
 							if needs_remove {
-								self.database.datastore.remove_if_sync(key, |arc| {
-									arc.read().is_empty()
-								});
+								self.database
+									.datastore
+									.remove_if_sync(key, |arc| arc.read().is_empty());
 							}
 							break;
 						}

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -151,6 +151,12 @@ impl Versions {
 		self.inner.shrink_to_fit();
 	}
 
+	/// Whether the version chain is empty.
+	#[inline]
+	pub(crate) fn is_empty(&self) -> bool {
+		self.inner.is_empty()
+	}
+
 	/// Check if the item at a specific version is a delete.
 	#[inline]
 	pub(crate) fn is_delete(&self, version: usize) -> bool {


### PR DESCRIPTION
## Summary

Swap the `SkipMap<Bytes, RwLock<Versions>>` datastore for an [`scc::TreeIndex<Bytes, Arc<RwLock<Versions>>>`](https://docs.rs/scc/latest/scc/#treeindex) — a widely-used concurrent B+tree — and benchmark it the same way as #74 (ferntree). `scc::TreeIndex` requires `V: Clone`, so the per-key `RwLock<Versions>` is wrapped in an `Arc` (refcount-only clones, identity preserved across leaf splits).

### What changes
- **Storage swap:** [`inner.rs`](src/inner.rs) holds `TreeIndex<Bytes, Arc<RwLock<Versions>>>`. Commit path in [`tx.rs`](src/tx.rs) uses `read_sync` (shared leaf lock — the only mode that observes interior mutability per `scc::TreeIndex` docs) plus `remove_if_sync` for empty version chains, with an `insert_sync` retry loop for racing inserts on absent keys.
- **Guarded range iterator:** new [`TreeIter`](src/iter.rs) in `iter.rs` wraps a `Box<scc::Guard>` and a `Range` whose `'t` lifetime is extended to the tree's lifetime; field order ensures the range drops before the guard. The merge iterator caches `(key, Arc, exists)` so subsequent advances don't conflict with the borrow on the underlying iterator.
- **scc::TreeIndex::range workaround:** `scc::TreeIndex::range`'s `start_forward` runs `approximate(start_key)` and then walks the leaf forward until the first key satisfies the lower bound. When `start_key` sorts before every stored key (e.g. an empty `Bytes` used as \"scan everything\"), that walk degenerates to a ~30 ms hot loop per call on 100 k-entry trees — verified in a standalone reproducer. `Bound::Unbounded` uses a separate `root.min()` path that stays sub-microsecond, so [`tree_bounds`](src/iter.rs) maps `Bound::Included(empty)` → `Bound::Unbounded`. Semantics are identical because no key sorts before empty.
- **GC / persistence:** full GC re-checks emptiness under `remove_if_sync` rather than relying on guard drop ordering; persistence load path retries `insert_sync` against a `read_sync` push on race.

### Bench vs `origin/main` (`cargo bench --quick`)

| Group | Change |
|---|---|
| `get_operations` | **−5% to −25%** |
| `scan_operations` (limit ≥ 100) | **−14% to −22%** |
| `keys_operations` | **−9% to −36%** |
| `scan_for_each` / `keys_for_each` | **−16% to −46%** |
| `delete_operations` | +28% to +140% |
| `concurrent_writers` (multi-thread) | +20% to +316% |
| `concurrent_mixed` | +83% to +267% |
| `bloom_concurrent_throughput` | +66% to +960% |

### Bench vs `tobiemh/ferntree` (#74)

| Group | Change |
|---|---|
| `get_operations` | **−5% to −20%** (scc wins) |
| `scan_operations` | +3% to +15% (ferntree wins) |
| `keys_operations` | +2% to +11% (ferntree wins) |
| `delete_operations` | +9% to +130% (ferntree wins) |
| `concurrent_writers` | +20% to +180% (ferntree wins) |
| `concurrent_mixed` | +25% to +220% (ferntree wins) |
| `mixed_workload` | +60% to +310% (ferntree wins) |

### Verdict

`scc::TreeIndex` wins on single-threaded point lookups and forward scans but loses heavily under concurrent commits and on deletes — the closure-scoped `read_sync` / `remove_if_sync` dance can't match `crossbeam_skiplist`'s per-entry `Arc` semantics, and scc's leaf locks serialize writes more aggressively than skiplist. **Net unfavorable for SurrealMX's workload; ferntree (#74) remains the better swap.** This branch is preserved for reference and to document the `scc::TreeIndex::range` start-path landmine.

## Test plan

- [x] `cargo test` (lib + integration): 392 / 392 pass
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets` clean (pre-existing unused-import warnings in release-only paths are unrelated)
- [x] `tests/stress.rs` passes
- [x] `cargo bench --quick` against `main` and `origin/tobiemh/ferntree` baselines