### PR TITLE
Make Transaction Sync, skip readset bookkeeping outside SSI

### DIFF
--- a/src/tx.rs
+++ b/src/tx.rs
@@ -30,7 +30,7 @@ use arc_swap::ArcSwap;
 use bytes::Bytes;
 use crossbeam_skiplist::SkipMap;
 use papaya::HashSet;
-use std::cell::RefCell;
+use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::ops::ControlFlow;
@@ -57,6 +57,13 @@ pub struct Transaction {
 	/// The inner transaction for this transaction
 	pub(crate) inner: Option<TransactionInner>,
 }
+
+// Transaction must be Send + Sync so downstream callers can place it
+// behind shared locks like `tokio::sync::RwLock<Transaction>`.
+const _: fn() = || {
+	fn assert_send_sync<T: Send + Sync>() {}
+	assert_send_sync::<Transaction>();
+};
 
 impl Drop for Transaction {
 	fn drop(&mut self) {
@@ -613,7 +620,7 @@ pub(crate) struct TransactionInner {
 	/// The local set of key reads
 	pub(crate) readset: HashSet<Bytes>,
 	/// Bloom filter over the readset for fast conflict pre-checks
-	pub(crate) readset_bloom: RefCell<BloomFilter>,
+	pub(crate) readset_bloom: Mutex<BloomFilter>,
 	/// The local set of key scans
 	pub(crate) scanset: SkipMap<Bytes, ArcSwap<Bytes>>,
 	/// The local set of updates and deletes
@@ -752,7 +759,7 @@ impl TransactionInner {
 			commit,
 			version,
 			readset: HashSet::new(),
-			readset_bloom: RefCell::new(BloomFilter::new()),
+			readset_bloom: Mutex::new(BloomFilter::new()),
 			scanset: SkipMap::new(),
 			writeset: BTreeMap::new(),
 			database: db,
@@ -789,7 +796,7 @@ impl TransactionInner {
 		// Clear the transaction readset
 		self.readset.pin().clear();
 		// Clear the readset bloom filter
-		self.readset_bloom.borrow_mut().clear();
+		self.readset_bloom.lock().clear();
 		// Clear or completely reset the allocated writeset
 		match self.writeset.len() > threshold {
 			true => self.writeset = BTreeMap::new(),
@@ -827,8 +834,10 @@ impl TransactionInner {
 		// Mark this transaction as done
 		self.done = true;
 		// Clear the transaction state
-		self.readset.pin().clear();
-		self.readset_bloom.borrow_mut().clear();
+		if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+			self.readset.pin().clear();
+			self.readset_bloom.lock().clear();
+		}
 		self.scanset.clear();
 		self.writeset.clear();
 		// Clear savepoint stack
@@ -924,8 +933,10 @@ impl TransactionInner {
 		if self.writeset.is_empty() {
 			// Clear the transaction state
 			self.scanset.clear();
-			self.readset.pin().clear();
-			self.readset_bloom.borrow_mut().clear();
+			if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+				self.readset.pin().clear();
+				self.readset_bloom.lock().clear();
+			}
 			// Clear savepoint stack
 			self.savepoint_stack.clear();
 			// Continue
@@ -959,8 +970,10 @@ impl TransactionInner {
 					self.database.transaction_commit_queue.remove(&version);
 					// Clear the transaction state
 					self.scanset.clear();
-					self.readset.pin().clear();
-					self.readset_bloom.borrow_mut().clear();
+					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+						self.readset.pin().clear();
+						self.readset_bloom.lock().clear();
+					}
 					self.writeset.clear();
 					// Clear savepoint stack
 					self.savepoint_stack.clear();
@@ -972,14 +985,14 @@ impl TransactionInner {
 					// Check if a previous transaction conflicts against reads
 					if !tx
 						.value()
-						.is_disjoint_readset_bloom(&self.readset, &self.readset_bloom.borrow())
+						.is_disjoint_readset_bloom(&self.readset, &self.readset_bloom.lock())
 					{
 						// Remove the transaction from the commit queue
 						self.database.transaction_commit_queue.remove(&version);
 						// Clear the transaction state
 						self.scanset.clear();
 						self.readset.pin().clear();
-						self.readset_bloom.borrow_mut().clear();
+						self.readset_bloom.lock().clear();
 						self.writeset.clear();
 						// Clear savepoint stack
 						self.savepoint_stack.clear();
@@ -1010,7 +1023,7 @@ impl TransactionInner {
 									self.database.transaction_commit_queue.remove(&version);
 									// Clear the transaction state
 									self.readset.pin().clear();
-									self.readset_bloom.borrow_mut().clear();
+									self.readset_bloom.lock().clear();
 									self.scanset.clear();
 									self.writeset.clear();
 									// Clear savepoint stack
@@ -1084,8 +1097,10 @@ impl TransactionInner {
 				self.database.transaction_merge_queue.remove(&version);
 				// Clear the transaction state
 				self.scanset.clear();
-				self.readset.pin().clear();
-				self.readset_bloom.borrow_mut().clear();
+				if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+					self.readset.pin().clear();
+					self.readset_bloom.lock().clear();
+				}
 				self.writeset.clear();
 				// Clear savepoint stack
 				self.savepoint_stack.clear();
@@ -1097,8 +1112,10 @@ impl TransactionInner {
 		self.database.transaction_merge_queue.remove(&version);
 		// Clear the transaction state
 		self.scanset.clear();
-		self.readset.pin().clear();
-		self.readset_bloom.borrow_mut().clear();
+		if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+			self.readset.pin().clear();
+			self.readset_bloom.lock().clear();
+		}
 		self.writeset.clear();
 		// Clear savepoint stack
 		self.savepoint_stack.clear();
@@ -1129,7 +1146,7 @@ impl TransactionInner {
 					let res = self.exists_in_datastore(lookup, self.version);
 					// Check whether we should track key reads
 					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
-						self.readset_bloom.borrow_mut().insert(lookup);
+						self.readset_bloom.lock().insert(lookup);
 						self.readset.pin().insert(key.into_bytes());
 					}
 					// Return the result
@@ -1189,7 +1206,7 @@ impl TransactionInner {
 					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 						let guard = self.readset.pin();
 						if !guard.contains(lookup) {
-							self.readset_bloom.borrow_mut().insert(lookup);
+							self.readset_bloom.lock().insert(lookup);
 							guard.insert(key.into_bytes());
 						}
 					}
@@ -1255,7 +1272,7 @@ impl TransactionInner {
 							if self.mode >= IsolationLevel::SerializableSnapshotIsolation
 								&& !self.readset.pin().contains(lookup)
 							{
-								self.readset_bloom.borrow_mut().insert(lookup);
+								self.readset_bloom.lock().insert(lookup);
 								self.readset.pin().insert(key.into_bytes());
 							}
 							// Return the result


### PR DESCRIPTION
## Summary

- Swap `RefCell<BloomFilter>` for `parking_lot::Mutex<BloomFilter>` on `TransactionInner::readset_bloom` so `Transaction: Send + Sync` again. Restores `tokio::sync::RwLock<Transaction>` usage in downstream callers (e.g. `surrealdb-core`'s `kvs/mem`), where 0.19.0 currently produces ~30 non-Send-future compile errors.
- Add a compile-time `assert_send_sync::<Transaction>()` so future `!Sync` fields fail here instead of downstream.
- Gate the `readset` and `readset_bloom` clears in `commit` and `cancel` on `mode >= SerializableSnapshotIsolation`. Both structures are only populated under SSI, so non-SSI transactions were paying lock acquisitions and `clear()` calls to scrub already-empty state.

The unconditional clears in `reset` stay — that's the pool-checkout boundary, and the previous user of the pooled inner could have been SSI.

## Why

`RefCell` is `!Sync` by construction. The compiler can't see through the downstream `tokio::sync::RwLock` to prove exclusivity, so any `!Sync` field on `TransactionInner` poisons `Sync` for the whole transaction and every async method that captures `&Transaction` ends up non-`Send`. The `Mutex` is paying for a compile-time property; runtime contention is zero in practice because callers already hold the transaction exclusively.

Once that was sorted, the SI-path clears were obvious dead work — the readset and bloom are never written outside SSI, so clearing them on every non-SSI commit was burning lock acquisitions for nothing.

## Performance

- **SSI workload:** one extra uncontended `parking_lot::Mutex` lock (~5-10 ns) per `exists`/`get`/`getm` that misses the writeset. Negligible vs. the b-tree lookup it sits next to.
- **SI workload:** zero `readset_bloom` lock acquisitions per transaction (down from ~3-5 boundary clears). Net win.
- **Read-only workload:** unchanged (no bloom path involved).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` — 129 passed, 0 failed
- [x] Compile-time `Send + Sync` assertion on `Transaction` passes
- [ ] Downstream verification: `surrealdb-core` upgrades from 0.18.0 → this branch without the 30 non-Send-future errors