### PR TITLE
Revert datastore from ferntree back to crossbeam-skiplist SkipMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "surrealmx"
-version = "0.22.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,19 +313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "ferntree"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c631d458d3a990f4281cbf6e3d92f7b47ff3935e03841a62aa1100085f11f4"
-dependencies = [
- "bytes",
- "crossbeam-epoch",
- "parking_lot",
- "parking_lot_core",
- "thiserror",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "surrealmx"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -868,7 +855,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-skiplist",
- "ferntree",
  "lz4",
  "papaya",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealmx"
 publish = true
 edition = "2021"
-version = "0.21.0"
+version = "0.22.0"
 readme = "CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 description = "An embedded, in-memory, lock-free, transaction-based, key-value database engine"
@@ -25,7 +25,6 @@ bytes = { version = "1.11.1", features = ["serde"] }
 crossbeam-deque = "0.8.6"
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
-ferntree = { version = "0.7", features = ["bytes"] }
 papaya = "0.2.4"
 parking_lot = "0.12.5"
 serde = { version = "1.0.228", features = ["derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealmx"
 publish = true
 edition = "2021"
-version = "0.22.0"
+version = "0.21.0"
 readme = "CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 description = "An embedded, in-memory, lock-free, transaction-based, key-value database engine"

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -16,10 +16,11 @@
 
 use crate::direction::Direction;
 use crate::inner::Inner;
-use crate::iter::{MergeIterator, MergeQueueIter, TreeIterState};
+use crate::iter::{MergeIterator, MergeQueueIter};
 use crate::queue::Merge;
 use bytes::Bytes;
 use std::collections::BTreeMap;
+use std::ops::Bound;
 use std::sync::Arc;
 
 // --------------------------------------------------
@@ -267,7 +268,9 @@ impl<'a> Cursor<'a> {
 		));
 
 		self.iter = Some(MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, start, end, direction),
+			self.database
+				.datastore
+				.range((Bound::Included(start.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(start..end),
 			direction,

--- a/src/db.rs
+++ b/src/db.rs
@@ -286,10 +286,12 @@ impl Database {
 				let mut versions = entry.value().write();
 				// Clean up unnecessary older versions
 				if versions.gc_older_versions(cleanup_ts) == 0 {
-					// Drop the version reference
-					drop(versions);
-					// Remove the entry from the datastore
-					self.datastore.remove(&key);
+					// Remove the entry while still holding the version write
+					// lock, so a committer blocked on that lock observes
+					// `is_removed()` and re-inserts rather than writing into a
+					// node we are about to unlink. `Entry::remove` also unlinks
+					// at the cursor with no second key lookup.
+					entry.remove();
 				}
 			}
 		}
@@ -303,10 +305,8 @@ impl Database {
 			let mut versions = versions.write();
 			// Clean up unnecessary older versions
 			if versions.gc_older_versions(cleanup_ts) == 0 {
-				// Drop the version reference
-				drop(versions);
-				// Remove the entry from the datastore
-				self.datastore.remove(entry.key());
+				// Remove under the version write lock (see `run_gc_dirty_inner`).
+				entry.remove();
 			}
 		}
 	}
@@ -434,8 +434,8 @@ impl Database {
 						if let Some(entry) = db.datastore.get(&key) {
 							let mut versions = entry.value().write();
 							if versions.gc_older_versions(cleanup_ts) == 0 {
-								drop(versions);
-								db.datastore.remove(&key);
+								// Remove under the version write lock (see `run_gc_dirty_inner`).
+								entry.remove();
 							}
 						}
 					}
@@ -447,10 +447,8 @@ impl Database {
 							// Clean up unnecessary older versions
 							let mut versions = entry.value().write();
 							if versions.gc_older_versions(cleanup_ts) == 0 {
-								// Drop the version reference
-								drop(versions);
-								// Remove the entry from the datastore
-								db.datastore.remove(entry.key());
+								// Remove under the version write lock (see `run_gc_dirty_inner`).
+								entry.remove();
 							}
 						}
 					}

--- a/src/db.rs
+++ b/src/db.rs
@@ -26,7 +26,7 @@ use crate::pool::Pool;
 use crate::pool::DEFAULT_POOL_SIZE;
 use crate::tx::Transaction;
 use std::ops::Deref;
-use std::sync::atomic::{fence, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -248,69 +248,6 @@ impl Database {
 		self.run_gc_dirty_inner(cleanup_ts);
 	}
 
-	/// Compute the next `cleanup_ts`, publishing it into `gc_floor` so
-	/// concurrent `register_counter` retries any reader whose snapshot
-	/// is below it, then re-scan to bound by any newly-arrived reader.
-	///
-	/// The proposed value is capped at the current oracle timestamp.
-	/// Without that cap, an idle database (oracle frozen while wall
-	/// clock advances) would push `gc_floor` above any value a future
-	/// reader could load — causing `register_counter` to spin forever
-	/// retrying.
-	fn compute_cleanup_ts(&self) -> u64 {
-		let now = self.oracle.current_time_ns();
-		let history = self.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
-		let history_cutoff = now.saturating_sub(history as u64);
-		let earliest_tx = self.earliest_active_version(now);
-		let oracle_now = self.oracle.inner.timestamp.load(Ordering::SeqCst);
-		// `gc_floor` must stay <= oracle so any future reader's load
-		// (which returns >= current oracle) satisfies the floor check.
-		let proposed = history_cutoff.min(earliest_tx).min(oracle_now);
-		// Publish proposed cleanup_ts via `gc_floor` BEFORE reclaiming.
-		// A `register_counter` that fences after CAS-publish will see
-		// either the old floor (and its publish becomes visible to our
-		// re-scan below via fence-fence SC ordering) or the new floor
-		// (and will retry to a fresh snapshot above it).
-		self.gc_floor.fetch_max(proposed, Ordering::SeqCst);
-		fence(Ordering::SeqCst);
-		let earliest_after = self.earliest_active_version(now);
-		proposed.min(earliest_after)
-	}
-
-	fn run_gc_dirty_inner(&self, cleanup_ts: u64) {
-		// Drain all keys from the dirty queue
-		while let Some(key) = self.gc_dirty_keys.pop() {
-			// Check if this key still exists in the datastore
-			if let Some(entry) = self.datastore.get(&key) {
-				// Get a mutable reference to the versions list
-				let mut versions = entry.value().write();
-				// Clean up unnecessary older versions
-				if versions.gc_older_versions(cleanup_ts) == 0 {
-					// Remove the entry while still holding the version write
-					// lock, so a committer blocked on that lock observes
-					// `is_removed()` and re-inserts rather than writing into a
-					// node we are about to unlink. `Entry::remove` also unlinks
-					// at the cursor with no second key lookup.
-					entry.remove();
-				}
-			}
-		}
-	}
-
-	fn run_gc_full(&self, cleanup_ts: u64) {
-		// Iterate over the entire datastore
-		for entry in self.datastore.iter() {
-			// Get a mutable reference to the versions list
-			let versions = entry.value();
-			let mut versions = versions.write();
-			// Clean up unnecessary older versions
-			if versions.gc_older_versions(cleanup_ts) == 0 {
-				// Remove under the version write lock (see `run_gc_dirty_inner`).
-				entry.remove();
-			}
-		}
-	}
-
 	/// Shutdown the datastore, waiting for background threads to exit
 	fn shutdown(&self) {
 		#[cfg(not(target_arch = "wasm32"))]
@@ -416,41 +353,13 @@ impl Database {
 					// a fresh oracle read above the floor. The proposed
 					// value is capped at the current oracle so an idle
 					// database does not lock readers out forever.
-					let cleanup_ts = {
-						let now = db.oracle.current_time_ns();
-						let history =
-							db.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
-						let history_cutoff = now.saturating_sub(history as u64);
-						let earliest_tx = db.earliest_active_version(now);
-						let oracle_now = db.oracle.inner.timestamp.load(Ordering::SeqCst);
-						let proposed = history_cutoff.min(earliest_tx).min(oracle_now);
-						db.gc_floor.fetch_max(proposed, Ordering::SeqCst);
-						fence(Ordering::SeqCst);
-						let earliest_after = db.earliest_active_version(now);
-						proposed.min(earliest_after)
-					};
-					// Drain all keys from the dirty queue (incremental GC).
-					while let Some(key) = db.gc_dirty_keys.pop() {
-						if let Some(entry) = db.datastore.get(&key) {
-							let mut versions = entry.value().write();
-							if versions.gc_older_versions(cleanup_ts) == 0 {
-								// Remove under the version write lock (see `run_gc_dirty_inner`).
-								entry.remove();
-							}
-						}
-					}
-					// Periodically do a full datastore scan
+					let cleanup_ts = db.compute_cleanup_ts();
+					// Drain the dirty-key queue every cycle (incremental GC).
+					db.run_gc_dirty_inner(cleanup_ts);
+					// Periodically do a full datastore scan.
 					cycle += 1;
 					if cycle.is_multiple_of(full_scan_frequency) {
-						// Iterate over the entire datastore
-						for entry in db.datastore.iter() {
-							// Clean up unnecessary older versions
-							let mut versions = entry.value().write();
-							if versions.gc_older_versions(cleanup_ts) == 0 {
-								// Remove under the version write lock (see `run_gc_dirty_inner`).
-								entry.remove();
-							}
-						}
+						db.run_gc_full(cleanup_ts);
 					}
 				}
 			});

--- a/src/db.rs
+++ b/src/db.rs
@@ -279,15 +279,17 @@ impl Database {
 
 	fn run_gc_dirty_inner(&self, cleanup_ts: u64) {
 		// Drain all keys from the dirty queue
-		let mut iter = self.datastore.raw_iter_mut();
 		while let Some(key) = self.gc_dirty_keys.pop() {
 			// Check if this key still exists in the datastore
-			if iter.seek_exact(&key) {
-				let (_, versions) = iter.next().expect("seek_exact returned true");
+			if let Some(entry) = self.datastore.get(&key) {
+				// Get a mutable reference to the versions list
+				let mut versions = entry.value().write();
 				// Clean up unnecessary older versions
 				if versions.gc_older_versions(cleanup_ts) == 0 {
-					// Remove the entry just yielded by next()
-					iter.remove_here();
+					// Drop the version reference
+					drop(versions);
+					// Remove the entry from the datastore
+					self.datastore.remove(&key);
 				}
 			}
 		}
@@ -295,13 +297,16 @@ impl Database {
 
 	fn run_gc_full(&self, cleanup_ts: u64) {
 		// Iterate over the entire datastore
-		let mut iter = self.datastore.raw_iter_mut();
-		iter.seek_to_first();
-		while let Some((_, versions)) = iter.next() {
+		for entry in self.datastore.iter() {
+			// Get a mutable reference to the versions list
+			let versions = entry.value();
+			let mut versions = versions.write();
 			// Clean up unnecessary older versions
 			if versions.gc_older_versions(cleanup_ts) == 0 {
-				// Remove the entry just yielded by next()
-				iter.remove_here();
+				// Drop the version reference
+				drop(versions);
+				// Remove the entry from the datastore
+				self.datastore.remove(entry.key());
 			}
 		}
 	}
@@ -425,17 +430,12 @@ impl Database {
 						proposed.min(earliest_after)
 					};
 					// Drain all keys from the dirty queue (incremental GC).
-					// A fresh `raw_iter_mut` is opened per key so the
-					// exclusive leaf guard is scoped to a single key —
-					// this avoids any iterator-state bugs from reusing the
-					// same cursor across `remove_here` calls that may
-					// trigger leaf merges.
 					while let Some(key) = db.gc_dirty_keys.pop() {
-						let mut iter = db.datastore.raw_iter_mut();
-						if iter.seek_exact(&key) {
-							let (_, versions) = iter.next().expect("seek_exact returned true");
+						if let Some(entry) = db.datastore.get(&key) {
+							let mut versions = entry.value().write();
 							if versions.gc_older_versions(cleanup_ts) == 0 {
-								iter.remove_here();
+								drop(versions);
+								db.datastore.remove(&key);
 							}
 						}
 					}
@@ -443,13 +443,14 @@ impl Database {
 					cycle += 1;
 					if cycle.is_multiple_of(full_scan_frequency) {
 						// Iterate over the entire datastore
-						let mut iter = db.datastore.raw_iter_mut();
-						iter.seek_to_first();
-						while let Some((_, versions)) = iter.next() {
+						for entry in db.datastore.iter() {
 							// Clean up unnecessary older versions
+							let mut versions = entry.value().write();
 							if versions.gc_older_versions(cleanup_ts) == 0 {
-								// Remove the entry just yielded by next()
-								iter.remove_here();
+								// Drop the version reference
+								drop(versions);
+								// Remove the entry from the datastore
+								db.datastore.remove(entry.key());
 							}
 						}
 					}

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -23,7 +23,6 @@ use crate::DatabaseOptions;
 use bytes::Bytes;
 use crossbeam_queue::SegQueue;
 use crossbeam_skiplist::SkipMap;
-use ferntree::Tree;
 use parking_lot::RwLock;
 use std::sync::atomic::{fence, AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -41,8 +40,8 @@ pub(crate) const COUNTER_TOMBSTONE: u64 = u64::MAX;
 pub struct Inner {
 	/// The timestamp version oracle
 	pub(crate) oracle: Arc<Oracle>,
-	/// The underlying lock-free B+tree datastructure
-	pub(crate) datastore: Tree<Bytes, Versions>,
+	/// The underlying lock-free skip-list datastructure
+	pub(crate) datastore: SkipMap<Bytes, RwLock<Versions>>,
 	/// A count of total transactions grouped by oracle version
 	pub(crate) counter_by_oracle: SkipMap<u64, Arc<AtomicU64>>,
 	/// A count of total transactions grouped by commit id
@@ -94,7 +93,7 @@ impl Inner {
 	pub fn new(opts: &DatabaseOptions) -> Self {
 		Self {
 			oracle: Oracle::new(opts.resync_interval),
-			datastore: Tree::new(),
+			datastore: SkipMap::new(),
 			counter_by_oracle: SkipMap::new(),
 			counter_by_commit: SkipMap::new(),
 			transaction_queue_id: AtomicU64::new(0),

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -24,6 +24,7 @@ use bytes::Bytes;
 use crossbeam_queue::SegQueue;
 use crossbeam_skiplist::SkipMap;
 use parking_lot::RwLock;
+use std::collections::HashSet;
 use std::sync::atomic::{fence, AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
@@ -132,6 +133,91 @@ impl Inner {
 	#[inline]
 	pub(crate) fn earliest_active_commit(&self, fallback: u64) -> u64 {
 		earliest_active(&self.counter_by_commit, fallback)
+	}
+
+	/// Compute the next `cleanup_ts`, publishing it into `gc_floor` so
+	/// concurrent `register_counter` retries any reader whose snapshot
+	/// is below it, then re-scan to bound by any newly-arrived reader.
+	///
+	/// The proposed value is capped at the current oracle timestamp.
+	/// Without that cap, an idle database (oracle frozen while wall
+	/// clock advances) would push `gc_floor` above any value a future
+	/// reader could load — causing `register_counter` to spin forever
+	/// retrying.
+	pub(crate) fn compute_cleanup_ts(&self) -> u64 {
+		let now = self.oracle.current_time_ns();
+		let history = self.garbage_collection_epoch.read().unwrap_or_default().as_nanos();
+		let history_cutoff = now.saturating_sub(history as u64);
+		let earliest_tx = self.earliest_active_version(now);
+		let oracle_now = self.oracle.inner.timestamp.load(Ordering::SeqCst);
+		// `gc_floor` must stay <= oracle so any future reader's load
+		// (which returns >= current oracle) satisfies the floor check.
+		let proposed = history_cutoff.min(earliest_tx).min(oracle_now);
+		// Publish proposed cleanup_ts via `gc_floor` BEFORE reclaiming.
+		// A `register_counter` that fences after CAS-publish will see
+		// either the old floor (and its publish becomes visible to our
+		// re-scan below via fence-fence SC ordering) or the new floor
+		// (and will retry to a fresh snapshot above it).
+		self.gc_floor.fetch_max(proposed, Ordering::SeqCst);
+		fence(Ordering::SeqCst);
+		let earliest_after = self.earliest_active_version(now);
+		proposed.min(earliest_after)
+	}
+
+	/// Drain the dirty-key queue, reclaiming stale versions on each key and
+	/// unlinking any whose version chain becomes empty.
+	///
+	/// Keys are de-duplicated within a pass: a hot key committed many times
+	/// between gc cycles is enqueued once per commit, but reclaiming it more
+	/// than once under a fixed `cleanup_ts` is wasted lock traffic — every
+	/// pass after the first is a no-op. A version added by a commit that
+	/// re-dirties the key mid-drain is newer than `cleanup_ts` and so not
+	/// reclaimable this pass anyway; it is caught on the next commit or the
+	/// periodic full scan.
+	pub(crate) fn run_gc_dirty_inner(&self, cleanup_ts: u64) {
+		let mut seen = HashSet::new();
+		// Drain all keys from the dirty queue
+		while let Some(key) = self.gc_dirty_keys.pop() {
+			// Skip keys already reclaimed in this pass
+			if !seen.insert(key.clone()) {
+				continue;
+			}
+			// Reclaim stale versions on this key
+			self.gc_key(&key, cleanup_ts);
+		}
+	}
+
+	/// Scan the entire datastore, reclaiming stale versions on every key.
+	pub(crate) fn run_gc_full(&self, cleanup_ts: u64) {
+		// Iterate over the entire datastore
+		for entry in self.datastore.iter() {
+			// Get a mutable reference to the versions list
+			let mut versions = entry.value().write();
+			// Clean up unnecessary older versions
+			if versions.gc_older_versions(cleanup_ts) == 0 {
+				// Remove under the version write lock (see `gc_key`).
+				entry.remove();
+			}
+		}
+	}
+
+	/// Reclaim stale versions on a single key, unlinking the entry if its
+	/// version chain becomes empty.
+	fn gc_key(&self, key: &Bytes, cleanup_ts: u64) {
+		// Look the key up in the datastore
+		if let Some(entry) = self.datastore.get(key) {
+			// Get a mutable reference to the versions list
+			let mut versions = entry.value().write();
+			// Clean up unnecessary older versions
+			if versions.gc_older_versions(cleanup_ts) == 0 {
+				// Remove the entry while still holding the version write lock,
+				// so a committer blocked on that lock observes `is_removed()`
+				// and re-inserts rather than writing into a node we are about
+				// to unlink. `Entry::remove` also unlinks at the cursor with
+				// no second key lookup.
+				entry.remove();
+			}
+		}
 	}
 }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -19,98 +19,17 @@ use crate::direction::Direction;
 use crate::queue::Merge;
 use crate::versions::Versions;
 use bytes::Bytes;
-use ferntree::iter::{Range as FernRange, RangeRev};
-use ferntree::Tree;
+use crossbeam_skiplist::map::Entry;
+use crossbeam_skiplist::map::Range as SkipRange;
+use parking_lot::RwLock;
 use std::collections::btree_map::Range as TreeRange;
 use std::ops::Bound;
-use std::ops::ControlFlow;
 use std::sync::Arc;
 
-// Tree fanout used by the surrealmx datastore tree.
-// Kept aliased here so iterator types match the tree configured in `inner.rs`.
-const IC: usize = 64;
-const LC: usize = 64;
-
-/// Forward or reverse iterator over the underlying tree.
-pub(crate) enum TreeIterState<'a> {
-	Forward(FernRange<'a, Bytes, Versions, IC, LC>),
-	Reverse(RangeRev<'a, Bytes, Versions, IC, LC>),
-}
-
-impl<'a> TreeIterState<'a> {
-	/// Build a tree iterator over `[beg, end)` for the given direction.
-	#[inline]
-	pub(crate) fn build(
-		tree: &'a Tree<Bytes, Versions>,
-		beg: &Bytes,
-		end: &Bytes,
-		direction: Direction,
-	) -> Self {
-		match direction {
-			Direction::Forward => {
-				TreeIterState::Forward(tree.range(Bound::Included(beg), Bound::Excluded(end)))
-			}
-			Direction::Reverse => {
-				TreeIterState::Reverse(tree.range_rev(Bound::Included(beg), Bound::Excluded(end)))
-			}
-		}
-	}
-}
-
-/// Walk every `(key, versions)` pair in `[beg, end)` in forward order,
-/// dispatching `f` per entry. The closure returns `ControlFlow::Break` to
-/// stop iteration early.
-///
-/// Internally this uses ferntree's `for_each_in_leaf`, which processes a
-/// whole leaf's `SmallVec<(K, V)>` in a tight loop without re-entering the
-/// iterator state machine. The cross-leaf step still goes through the
-/// regular `next()` path, so one entry per leaf boundary pays the normal
-/// iterator-advance cost.
-#[inline]
-pub(crate) fn for_each_in_range<F>(tree: &Tree<Bytes, Versions>, beg: &Bytes, end: &Bytes, mut f: F)
-where
-	F: FnMut(&Bytes, &Versions) -> ControlFlow<()>,
-{
-	let mut iter = tree.raw_iter();
-	iter.seek(beg);
-	let mut stop = false;
-	loop {
-		let has_more_leaves = iter.for_each_in_leaf(|k, v| {
-			if stop {
-				return;
-			}
-			if k >= end {
-				stop = true;
-				return;
-			}
-			if matches!(f(k, v), ControlFlow::Break(())) {
-				stop = true;
-			}
-		});
-		if stop || !has_more_leaves {
-			break;
-		}
-		// Advance into the next leaf. `next()` yields its first entry, which
-		// would otherwise be skipped by `for_each_in_leaf`'s cursor handling.
-		let Some((k, v)) = iter.next() else {
-			break;
-		};
-		if k >= end {
-			break;
-		}
-		if matches!(f(k, v), ControlFlow::Break(())) {
-			break;
-		}
-	}
-}
-
-/// Cached entry from the tree iterator: (key, exists_at_version).
-/// Only the key and existence flag are precomputed — the value at the current
-/// version is fetched lazily at emit time, while the tree iterator is still
-/// parked at this entry (so `peek()` still returns it). This avoids cloning a
-/// value byte slice for entries that get skipped or that the caller only needs
-/// existence for (`next_count`, `next_key`).
-type CachedTreeEntry = Option<(Bytes, bool)>;
+/// Owned range bounds for the skip list range iterator.
+/// Using owned Bytes avoids lifetime coupling between range bounds
+/// and the MergeIterator, enabling persistent storage (e.g., in a Cursor).
+pub(crate) type SkipBounds = (Bound<Bytes>, Bound<Bytes>);
 
 /// Lazy k-way merge iterator over committed merge-queue writesets.
 ///
@@ -239,17 +158,17 @@ impl Iterator for MergeQueueIter {
 }
 
 /// Three-way merge iterator over tree, merge queue, and current transaction
-/// writesets.
+/// writesets
 pub struct MergeIterator<'a> {
 	// Source iterators
-	pub(crate) tree_iter: TreeIterState<'a>,
+	pub(crate) tree_iter: SkipRange<'a, Bytes, SkipBounds, Bytes, RwLock<Versions>>,
 	pub(crate) self_iter: TreeRange<'a, Bytes, Option<Bytes>>,
 
 	// Lazy iterator over committed merge-queue writesets
 	pub(crate) join_iter: Box<dyn Iterator<Item = (Bytes, Option<Bytes>)> + 'a>,
 
 	// Current buffered entries from each source
-	pub(crate) tree_next: CachedTreeEntry,
+	pub(crate) tree_next: Option<Entry<'a, Bytes, RwLock<Versions>>>,
 	pub(crate) join_next: Option<(Bytes, Option<Bytes>)>,
 	pub(crate) self_next: Option<(&'a Bytes, &'a Option<Bytes>)>,
 
@@ -272,68 +191,38 @@ enum KeySource {
 
 impl<'a> MergeIterator<'a> {
 	pub fn new(
-		tree_iter: TreeIterState<'a>,
+		mut tree_iter: SkipRange<'a, Bytes, SkipBounds, Bytes, RwLock<Versions>>,
 		mut join_iter: Box<dyn Iterator<Item = (Bytes, Option<Bytes>)> + 'a>,
 		mut self_iter: TreeRange<'a, Bytes, Option<Bytes>>,
 		direction: Direction,
 		version: u64,
 		skip: usize,
 	) -> Self {
-		// Prime the join-side from the lazy iterator (direction-baked).
-		let join_next = join_iter.next();
+		// Get initial entries based on direction
+		let tree_next = match direction {
+			Direction::Forward => tree_iter.next(),
+			Direction::Reverse => tree_iter.next_back(),
+		};
 
-		// Prime the transaction-side iterator
 		let self_next = match direction {
 			Direction::Forward => self_iter.next(),
 			Direction::Reverse => self_iter.next_back(),
 		};
 
-		let mut me = MergeIterator {
+		// The lazy join iterator is already direction-baked; just pull the
+		// first entry.
+		let join_next = join_iter.next();
+
+		MergeIterator {
 			tree_iter,
 			self_iter,
 			join_iter,
-			tree_next: None,
+			tree_next,
 			join_next,
 			self_next,
 			direction,
 			version,
 			skip_remaining: skip,
-		};
-
-		// Prime the tree-side cache (peek + resolve version once)
-		me.tree_next = Self::fetch_tree_entry(&mut me.tree_iter, version);
-
-		me
-	}
-
-	/// Peek at the next tree entry and cache its key + existence at the
-	/// current MVCC version. Value resolution is deferred to `peek_tree_value`
-	/// so paths that only need keys or counts don't pay the byte clone.
-	#[inline]
-	fn fetch_tree_entry(tree_iter: &mut TreeIterState<'_>, version: u64) -> CachedTreeEntry {
-		match tree_iter {
-			TreeIterState::Forward(range) => {
-				range.peek().map(|(k, v)| (k.clone(), v.exists_version(version)))
-			}
-			TreeIterState::Reverse(range) => {
-				range.peek().map(|(k, v)| (k.clone(), v.exists_version(version)))
-			}
-		}
-	}
-
-	/// Fetch the value at the current MVCC version for the entry that the
-	/// tree iterator is currently parked on. Call this in `Iterator::next`
-	/// right before advancing past the entry.
-	#[inline]
-	fn peek_tree_value(&mut self) -> Option<Bytes> {
-		let version = self.version;
-		match &mut self.tree_iter {
-			TreeIterState::Forward(range) => {
-				range.peek().and_then(|(_, v)| v.fetch_version(version))
-			}
-			TreeIterState::Reverse(range) => {
-				range.peek().and_then(|(_, v)| v.fetch_version(version))
-			}
 		}
 	}
 
@@ -342,121 +231,126 @@ impl<'a> MergeIterator<'a> {
 		self.join_next = self.join_iter.next();
 	}
 
-	#[inline]
-	fn advance_self(&mut self) {
-		self.self_next = match self.direction {
-			Direction::Forward => self.self_iter.next(),
-			Direction::Reverse => self.self_iter.next_back(),
-		};
-	}
-
-	#[inline]
-	fn advance_tree(&mut self) {
-		match &mut self.tree_iter {
-			TreeIterState::Forward(range) => {
-				range.next();
-			}
-			TreeIterState::Reverse(range) => {
-				range.next();
-			}
-		}
-		self.tree_next = Self::fetch_tree_entry(&mut self.tree_iter, self.version);
-	}
-
-	#[inline]
-	fn tree_key(&self) -> Option<&Bytes> {
-		self.tree_next.as_ref().map(|(k, _)| k)
-	}
-
-	#[inline]
-	fn tree_exists(&self) -> bool {
-		self.tree_next.as_ref().map(|(_, e)| *e).unwrap_or(false)
-	}
-
-	/// Decide which source has the next key to process. Pure inspection,
-	/// no advancing.
-	#[inline]
-	fn next_source(&self) -> KeySource {
-		let mut next_key: Option<&Bytes> = None;
-		let mut next_source = KeySource::None;
-
-		// Check self iterator (highest priority on tie)
-		if let Some((sk, _)) = self.self_next {
-			next_key = Some(sk);
-			next_source = KeySource::Transaction;
-		}
-
-		// Check join iterator (merge queue)
-		if let Some((jk, _)) = &self.join_next {
-			let should_use = match (next_key, &self.direction) {
-				(None, _) => true,
-				(Some(k), Direction::Forward) => jk < k,
-				(Some(k), Direction::Reverse) => jk > k,
-			};
-			if should_use {
-				next_key = Some(jk);
-				next_source = KeySource::Committed;
-			} else if next_key == Some(jk) {
-				// Same key in both self and join - self wins
-				next_source = KeySource::Transaction;
-			}
-		}
-
-		// Check tree iterator
-		if let Some(tk) = self.tree_key() {
-			let should_use = match (next_key, &self.direction) {
-				(None, _) => true,
-				(Some(k), Direction::Forward) => tk < k,
-				(Some(k), Direction::Reverse) => tk > k,
-			};
-			if should_use {
-				next_source = KeySource::Datastore;
-			}
-		}
-
-		next_source
-	}
-
 	/// Get next entry existence only (no key or value cloning) - optimized for
-	/// counting.
+	/// counting
 	pub fn next_count(&mut self) -> Option<bool> {
 		loop {
-			let exists = match self.next_source() {
+			// Find the next key to process (smallest for Forward, largest for Reverse)
+			let mut next_key: Option<&Bytes> = None;
+			let mut next_source = KeySource::None;
+
+			// Check self iterator (highest priority)
+			if let Some((sk, _)) = self.self_next {
+				next_key = Some(sk);
+				next_source = KeySource::Transaction;
+			}
+
+			// Check join iterator (merge queue)
+			if let Some((jk, _)) = &self.join_next {
+				let should_use = match (next_key, &self.direction) {
+					(None, _) => true,
+					(Some(k), Direction::Forward) => jk < k,
+					(Some(k), Direction::Reverse) => jk > k,
+				};
+				if should_use {
+					next_key = Some(jk);
+					next_source = KeySource::Committed;
+				} else if next_key == Some(jk) {
+					// Same key in both self and join - self wins
+					next_source = KeySource::Transaction;
+				}
+			}
+
+			// Check tree iterator
+			if let Some(t_entry) = &self.tree_next {
+				let tk = t_entry.key();
+				let should_use = match (next_key, &self.direction) {
+					(None, _) => true,
+					(Some(k), Direction::Forward) => tk < k,
+					(Some(k), Direction::Reverse) => tk > k,
+				};
+				if should_use {
+					next_source = KeySource::Datastore;
+				}
+			}
+
+			// Process the selected source
+			let exists = match next_source {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
 					let exists = sv.is_some();
-					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
-					let skip_tree = self.tree_key() == Some(sk);
 
-					self.advance_self();
-					if skip_join {
-						self.advance_join();
+					// Advance self iterator
+					self.self_next = match self.direction {
+						Direction::Forward => self.self_iter.next(),
+						Direction::Reverse => self.self_iter.next_back(),
+					};
+
+					// Skip same key in other iterators
+					if let Some((jk, _)) = &self.join_next {
+						if jk == sk {
+							self.advance_join();
+						}
 					}
-					if skip_tree {
-						self.advance_tree();
+					if let Some(t_entry) = &self.tree_next {
+						if t_entry.key() == sk {
+							self.tree_next = match self.direction {
+								Direction::Forward => self.tree_iter.next(),
+								Direction::Reverse => self.tree_iter.next_back(),
+							};
+						}
 					}
 
 					exists
 				}
 				KeySource::Committed => {
 					let exists = self.join_next.as_ref().unwrap().1.is_some();
-					let skip_tree = self.tree_key() == self.join_next.as_ref().map(|(jk, _)| jk);
 
+					// Check if we need to skip same key in tree before advancing join
+					let should_skip_tree = if let Some(t_entry) = &self.tree_next {
+						if let Some((jk, _)) = &self.join_next {
+							t_entry.key() == jk
+						} else {
+							false
+						}
+					} else {
+						false
+					};
+
+					// Advance join iterator
 					self.advance_join();
-					if skip_tree {
-						self.advance_tree();
+
+					// Skip same key in tree iterator if needed
+					if should_skip_tree {
+						self.tree_next = match self.direction {
+							Direction::Forward => self.tree_iter.next(),
+							Direction::Reverse => self.tree_iter.next_back(),
+						};
 					}
 
 					exists
 				}
 				KeySource::Datastore => {
-					let exists = self.tree_exists();
-					self.advance_tree();
+					let t_entry = self.tree_next.as_ref().unwrap();
+					let tv = match t_entry.value().try_read() {
+						Some(guard) => guard,
+						None => t_entry.value().read(),
+					};
+					let exists = tv.exists_version(self.version);
+					drop(tv);
+
+					// Advance tree iterator
+					self.tree_next = match self.direction {
+						Direction::Forward => self.tree_iter.next(),
+						Direction::Reverse => self.tree_iter.next_back(),
+					};
+
 					exists
 				}
 				KeySource::None => return None,
 			};
 
+			// Handle skipping
 			if exists && self.skip_remaining > 0 {
 				self.skip_remaining -= 1;
 				continue;
@@ -466,69 +360,163 @@ impl<'a> MergeIterator<'a> {
 		}
 	}
 
-	/// Get next entry with key (no value cloning) - optimized for key
-	/// iteration.
+	/// Get next entry with key (no value cloning) - optimized for key iteration
 	pub fn next_key(&mut self) -> Option<(Bytes, bool)> {
 		loop {
-			match self.next_source() {
+			// Find the next key to process (smallest for Forward, largest for Reverse)
+			let mut next_key: Option<&Bytes> = None;
+			let mut next_source = KeySource::None;
+
+			// Check self iterator (highest priority)
+			if let Some((sk, _)) = self.self_next {
+				next_key = Some(sk);
+				next_source = KeySource::Transaction;
+			}
+
+			// Check join iterator (merge queue)
+			if let Some((jk, _)) = &self.join_next {
+				let should_use = match (next_key, &self.direction) {
+					(None, _) => true,
+					(Some(k), Direction::Forward) => jk < k,
+					(Some(k), Direction::Reverse) => jk > k,
+				};
+				if should_use {
+					next_key = Some(jk);
+					next_source = KeySource::Committed;
+				} else if next_key == Some(jk) {
+					// Same key in both self and join - self wins
+					next_source = KeySource::Transaction;
+				}
+			}
+
+			// Check tree iterator
+			if let Some(t_entry) = &self.tree_next {
+				let tk = t_entry.key();
+				let should_use = match (next_key, &self.direction) {
+					(None, _) => true,
+					(Some(k), Direction::Forward) => tk < k,
+					(Some(k), Direction::Reverse) => tk > k,
+				};
+				if should_use {
+					next_source = KeySource::Datastore;
+				}
+			}
+
+			// Process the selected source - first determine if entry exists
+			match next_source {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
 					let exists = sv.is_some();
+
+					// Store key reference for later cloning if needed
 					let key_ref = sk;
-					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
-					let skip_tree = self.tree_key() == Some(sk);
 
-					self.advance_self();
-					if skip_join {
-						self.advance_join();
+					// Advance self iterator
+					self.self_next = match self.direction {
+						Direction::Forward => self.self_iter.next(),
+						Direction::Reverse => self.self_iter.next_back(),
+					};
+
+					// Skip same key in other iterators
+					if let Some((jk, _)) = &self.join_next {
+						if jk == key_ref {
+							self.advance_join();
+						}
 					}
-					if skip_tree {
-						self.advance_tree();
+					if let Some(t_entry) = &self.tree_next {
+						if t_entry.key() == key_ref {
+							self.tree_next = match self.direction {
+								Direction::Forward => self.tree_iter.next(),
+								Direction::Reverse => self.tree_iter.next_back(),
+							};
+						}
 					}
 
+					// Handle skipping BEFORE cloning
 					if exists && self.skip_remaining > 0 {
 						self.skip_remaining -= 1;
 						continue;
 					}
 
+					// Only clone if we're returning it
 					return Some((key_ref.clone(), exists));
 				}
 				KeySource::Committed => {
 					let (jk, jv) = self.join_next.as_ref().unwrap();
 
+					// Check if we should skip (only skip existing entries)
 					if jv.is_some() && self.skip_remaining > 0 {
-						let skip_tree = self.tree_key() == Some(jk);
+						// Check if we need to skip same key in tree before advancing join
+						let should_skip_tree = if let Some(t_entry) = &self.tree_next {
+							t_entry.key() == jk
+						} else {
+							false
+						};
+
+						// Advance join iterator
 						self.advance_join();
-						if skip_tree {
-							self.advance_tree();
+
+						// Skip same key in tree iterator if needed
+						if should_skip_tree {
+							self.tree_next = match self.direction {
+								Direction::Forward => self.tree_iter.next(),
+								Direction::Reverse => self.tree_iter.next_back(),
+							};
 						}
+
 						self.skip_remaining -= 1;
 						continue;
 					}
 
+					// Read existence before advancing (avoids value clone)
 					let exists = jv.is_some();
 					let key = jk.clone();
-					let skip_tree = self.tree_key() == Some(&key);
 
+					// Advance join iterator
 					self.advance_join();
-					if skip_tree {
-						self.advance_tree();
+
+					// Skip same key in tree iterator
+					if let Some(t_entry) = &self.tree_next {
+						if t_entry.key() == &key {
+							self.tree_next = match self.direction {
+								Direction::Forward => self.tree_iter.next(),
+								Direction::Reverse => self.tree_iter.next_back(),
+							};
+						}
 					}
 
 					return Some((key, exists));
 				}
 				KeySource::Datastore => {
-					let exists = self.tree_exists();
+					let t_entry = self.tree_next.as_ref().unwrap();
+					let tv = match t_entry.value().try_read() {
+						Some(guard) => guard,
+						None => t_entry.value().read(),
+					};
+					let exists = tv.exists_version(self.version);
+					drop(tv);
 
+					// Handle skipping BEFORE cloning the key
 					if exists && self.skip_remaining > 0 {
-						self.advance_tree();
+						// Advance tree iterator
+						self.tree_next = match self.direction {
+							Direction::Forward => self.tree_iter.next(),
+							Direction::Reverse => self.tree_iter.next_back(),
+						};
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					let key = self.tree_next.as_ref().map(|(k, _)| k.clone()).unwrap();
-					self.advance_tree();
-					return Some((key, exists));
+					// Only clone key if we're returning it
+					let tk = t_entry.key().clone();
+
+					// Advance tree iterator
+					self.tree_next = match self.direction {
+						Direction::Forward => self.tree_iter.next(),
+						Direction::Reverse => self.tree_iter.next_back(),
+					};
+
+					return Some((tk, exists));
 				}
 				KeySource::None => return None,
 			}
@@ -541,72 +529,161 @@ impl<'a> Iterator for MergeIterator<'a> {
 
 	fn next(&mut self) -> Option<Self::Item> {
 		loop {
-			match self.next_source() {
+			// Find the next key to process (smallest for Forward, largest for Reverse)
+			let mut next_key: Option<&Bytes> = None;
+			let mut next_source = KeySource::None;
+
+			// Check self iterator (highest priority)
+			if let Some((sk, _)) = self.self_next {
+				next_key = Some(sk);
+				next_source = KeySource::Transaction;
+			}
+
+			// Check join iterator (merge queue)
+			if let Some((jk, _)) = &self.join_next {
+				let should_use = match (next_key, &self.direction) {
+					(None, _) => true,
+					(Some(k), Direction::Forward) => jk < k,
+					(Some(k), Direction::Reverse) => jk > k,
+				};
+				if should_use {
+					next_key = Some(jk);
+					next_source = KeySource::Committed;
+				} else if next_key == Some(jk) {
+					// Same key in both self and join - self wins
+					next_source = KeySource::Transaction;
+				}
+			}
+
+			// Check tree iterator
+			if let Some(t_entry) = &self.tree_next {
+				let tk = t_entry.key();
+				let should_use = match (next_key, &self.direction) {
+					(None, _) => true,
+					(Some(k), Direction::Forward) => tk < k,
+					(Some(k), Direction::Reverse) => tk > k,
+				};
+				if should_use {
+					next_source = KeySource::Datastore;
+				}
+			}
+
+			// Process the selected source
+			match next_source {
 				KeySource::Transaction => {
 					let (sk, sv) = self.self_next.unwrap();
-					let key_ref = sk;
 					let exists = sv.is_some();
-					let skip_join = self.join_next.as_ref().map(|(jk, _)| jk) == Some(sk);
-					let skip_tree = self.tree_key() == Some(sk);
 
-					self.advance_self();
-					if skip_join {
-						self.advance_join();
+					// Store key reference for deferred cloning
+					let key_ref = sk;
+
+					// Advance self iterator
+					self.self_next = match self.direction {
+						Direction::Forward => self.self_iter.next(),
+						Direction::Reverse => self.self_iter.next_back(),
+					};
+
+					// Skip same key in other iterators
+					if let Some((jk, _)) = &self.join_next {
+						if jk == key_ref {
+							self.advance_join();
+						}
 					}
-					if skip_tree {
-						self.advance_tree();
+					if let Some(t_entry) = &self.tree_next {
+						if t_entry.key() == key_ref {
+							self.tree_next = match self.direction {
+								Direction::Forward => self.tree_iter.next(),
+								Direction::Reverse => self.tree_iter.next_back(),
+							};
+						}
 					}
 
+					// Check if we should skip (only skip existing entries)
 					if exists && self.skip_remaining > 0 {
 						self.skip_remaining -= 1;
 						continue;
 					}
 
+					// Only clone key and value when returning
 					return Some((key_ref.clone(), sv.clone()));
 				}
 				KeySource::Committed => {
 					let (jk, jv) = self.join_next.as_ref().unwrap();
 
+					// Check if we should skip (only skip existing entries)
 					if jv.is_some() && self.skip_remaining > 0 {
-						let skip_tree = self.tree_key() == Some(jk);
+						// Check if we need to skip same key in tree before advancing join
+						let should_skip_tree = if let Some(t_entry) = &self.tree_next {
+							t_entry.key() == jk
+						} else {
+							false
+						};
+
+						// Advance join iterator
 						self.advance_join();
-						if skip_tree {
-							self.advance_tree();
+
+						// Skip same key in tree iterator if needed
+						if should_skip_tree {
+							self.tree_next = match self.direction {
+								Direction::Forward => self.tree_iter.next(),
+								Direction::Reverse => self.tree_iter.next_back(),
+							};
 						}
+
 						self.skip_remaining -= 1;
 						continue;
 					}
 
+					// Only clone key and value when returning
 					let key = jk.clone();
-					let value = jv.clone();
-					let skip_tree = self.tree_key() == Some(&key);
+					let value_opt = jv.clone();
 
+					// Advance join iterator
 					self.advance_join();
-					if skip_tree {
-						self.advance_tree();
+
+					// Skip same key in tree iterator
+					if let Some(t_entry) = &self.tree_next {
+						if t_entry.key() == &key {
+							self.tree_next = match self.direction {
+								Direction::Forward => self.tree_iter.next(),
+								Direction::Reverse => self.tree_iter.next_back(),
+							};
+						}
 					}
 
-					return Some((key, value));
+					return Some((key, value_opt));
 				}
 				KeySource::Datastore => {
-					let exists = self.tree_exists();
+					let t_entry = self.tree_next.as_ref().unwrap();
+					let tv = match t_entry.value().try_read() {
+						Some(guard) => guard,
+						None => t_entry.value().read(),
+					};
+					let value_opt = tv.fetch_version(self.version);
+					let exists = value_opt.is_some();
+					drop(tv);
 
+					// Handle skipping BEFORE cloning the key
 					if exists && self.skip_remaining > 0 {
-						self.advance_tree();
+						// Advance tree iterator
+						self.tree_next = match self.direction {
+							Direction::Forward => self.tree_iter.next(),
+							Direction::Reverse => self.tree_iter.next_back(),
+						};
 						self.skip_remaining -= 1;
 						continue;
 					}
 
-					// Resolve the value lazily while the tree iter is still
-					// parked on this entry, then clone the key and advance.
-					let value = if exists {
-						self.peek_tree_value()
-					} else {
-						None
+					// Only clone key if we're returning it
+					let key_clone = t_entry.key().clone();
+
+					// Advance tree iterator
+					self.tree_next = match self.direction {
+						Direction::Forward => self.tree_iter.next(),
+						Direction::Reverse => self.tree_iter.next_back(),
 					};
-					let key = self.tree_next.as_ref().map(|(k, _)| k.clone()).unwrap();
-					self.advance_tree();
-					return Some((key, value));
+
+					return Some((key_clone, value_opt));
 				}
 				KeySource::None => return None,
 			}

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -314,16 +314,14 @@ impl Persistence {
 				0
 			};
 			// Stream write each key-value pair to reduce memory usage
-			let mut iter = self.inner.datastore.raw_iter();
-			iter.seek_to_first();
-			while let Some((key, versions)) = iter.next() {
+			for entry in self.inner.datastore.iter() {
 				// Get all versions for this key
-				let versions = versions.all_versions();
+				let versions = entry.value().read().all_versions();
 				// Ensure that there are version entries
 				if !versions.is_empty() {
 					// Serialize and write this single entry
 					bincode::serde::encode_into_std_write(
-						&(key.clone(), versions),
+						&(entry.key().clone(), versions),
 						&mut writer,
 						config::standard(),
 					)?;
@@ -398,7 +396,7 @@ impl Persistence {
 									});
 								}
 								// Insert the entry into the datastore
-								self.inner.datastore.insert(k, entries);
+								self.inner.datastore.insert(k, RwLock::new(entries));
 							}
 						}
 						Err(e) => match e {
@@ -441,21 +439,21 @@ impl Persistence {
 					// Detech any end of file errors
 					match result {
 						Ok((k, version, val)) => {
-							// Update existing key, or insert a new one
-							let mut iter = self.inner.datastore.raw_iter_mut();
-							if iter.seek_exact(&k) {
-								let (_, versions) = iter.next().expect("seek_exact returned true");
-								versions.push(Version {
+							// Check if the key already exists
+							if let Some(entry) = self.inner.datastore.get(&k) {
+								// Update existing key with stored version
+								entry.value().write().push(Version {
 									version,
 									value: val,
 								});
 							} else {
-								iter.insert_here(
+								// Insert new key with stored version
+								self.inner.datastore.insert(
 									k.clone(),
-									Versions::from(Version {
+									RwLock::new(Versions::from(Version {
 										version,
 										value: val,
-									}),
+									})),
 								);
 							}
 						}
@@ -638,16 +636,14 @@ impl Persistence {
 							0
 						};
 						// Stream write each entry to reduce memory usage
-						let mut iter = db.datastore.raw_iter();
-						iter.seek_to_first();
-						while let Some((key, versions)) = iter.next() {
+						for entry in db.datastore.iter() {
 							// Get all versions for this key
-							let versions = versions.all_versions();
+							let versions = entry.value().read().all_versions();
 							// Ensure that there are version entries
 							if !versions.is_empty() {
 								// Serialize and write this single entry
 								bincode::serde::encode_into_std_write(
-									&(key.clone(), versions),
+									&(entry.key().clone(), versions),
 									&mut writer,
 									config::standard(),
 								)?;

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -19,7 +19,7 @@ use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
 use crate::inner::{Inner, COUNTER_TOMBSTONE};
-use crate::iter::{for_each_in_range, MergeIterator, MergeQueueIter, TreeIterState};
+use crate::iter::{MergeIterator, MergeQueueIter};
 use crate::kv::IntoBytes;
 use crate::pool::Pool;
 use crate::queue::{Commit, Merge};
@@ -30,10 +30,9 @@ use arc_swap::ArcSwap;
 use bytes::Bytes;
 use crossbeam_skiplist::SkipMap;
 use papaya::HashSet;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use std::collections::BTreeMap;
 use std::ops::Bound;
-use std::ops::ControlFlow;
 use std::ops::Range;
 use std::sync::atomic::{fence, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -637,30 +636,27 @@ pub(crate) struct TransactionInner {
 	savepoint_stack: Vec<SavepointState>,
 }
 
-/// Register a new transaction against one of the `Inner` counter
-/// SkipMaps.
+/// Register a new transaction against one of the `Inner` counter SkipMaps.
 ///
-/// Three races make this non-trivial and motivate the validate-and-retry
+/// Two races make this non-trivial and motivate the validate-and-retry
 /// shape:
 ///
-/// 1. **load-then-register vs writer fetch_max**: between the reader's
-///    load of `atomic` and its insert into `map`, a writer can advance
-///    the watermark via `fetch_max`. The post-fence reload of `atomic`
-///    catches this and retries with a fresh snapshot.
-/// 2. **load-then-register vs gc**: the BG sweeper can run a
-///    cleanup_ts > v_r in the window between our load and our publish,
-///    missing us on its scan. To close this, the sweeper publishes its
-///    cleanup_ts into [`Inner::gc_floor`] *before* reclaiming any
-///    versions, and we re-load `gc_floor` after the fence: if our
-///    snapshot is below the floor, the version we wanted is on its way
-///    out, so we roll back and retry from a fresh oracle read.
-/// 3. **drop/register**: a concurrent `Transaction::Drop` that takes
-///    the last reference on the same key removes the entry from the
-///    SkipMap. The `COUNTER_TOMBSTONE` sentinel claims removal so a
-///    new registration cannot land on a detached counter.
+/// 1. **load-then-register**: between the reader's load of `atomic` and
+///    its insert into `map`, a writer can advance the watermark and run
+///    inline GC against a `front()` that does not yet see the reader.
+///    The reader's subsequent reads at its snapshot then return `None`.
+/// 2. **drop/register**: a concurrent `Transaction::Drop` that takes the
+///    last reference on the same key removes the entry from the SkipMap.
+///    Without coordination the new registration would land on a detached
+///    counter that no later `front()`/`iter()` can observe.
 ///
-/// Only the oracle map needs the gc_floor check; for `counter_by_commit`
-/// we pass `None`.
+/// Closed by:
+///  * `atomic.load(SeqCst)` participates in the same total order as the
+///    writer's SeqCst `fetch_max`/`fetch_add`; a re-load after a SeqCst
+///    fence catches any writer that ran in between.
+///  * Drops claim removal via `1 -> COUNTER_TOMBSTONE` CAS; new
+///    registrations spin past TOMBSTONE-valued counters and retry with a
+///    fresh entry.
 #[inline]
 fn register_counter(
 	map: &SkipMap<u64, Arc<AtomicU64>>,
@@ -688,8 +684,10 @@ fn register_counter(
 		}
 		fence(Ordering::SeqCst);
 		// Two validations after publishing our counter:
-		// (a) `atomic` must not have advanced — a writer's `fetch_max`
-		//     between our load and now means our snapshot is stale.
+		// (a) `atomic` must not have advanced — a writer that reads
+		//     `iter()` after this fence (in SC total order) will see our
+		//     positive count, but a `fetch_max` between our load and now
+		//     means our snapshot is stale.
 		// (b) `gc_floor` (if applicable) must be `<= v`. The BG sweeper
 		//     publishes its cleanup_ts to `gc_floor` before reclaiming
 		//     any versions, so a value above ours means the version we
@@ -742,9 +740,7 @@ fn release_counter(counter: &AtomicU64) -> bool {
 impl TransactionInner {
 	/// Create a new read-only or writeable transaction
 	pub(crate) fn new(db: Arc<Inner>, write: bool) -> Self {
-		// Register against both watermark counters. Only the oracle map
-		// needs the `gc_floor` validation — version reclamation is keyed
-		// off oracle timestamps, not commit ids.
+		// Register against both watermark counters
 		let (version, counter_version) =
 			register_counter(&db.counter_by_oracle, &db.oracle.inner.timestamp, Some(&db.gc_floor));
 		let (commit, counter_commit) =
@@ -1040,49 +1036,40 @@ impl TransactionInner {
 				}
 			}
 		}
-		// Insert this transaction into the merge queue.
+		// Insert this transaction into the merge queue
 		let (version, entry) = self.atomic_merge(Merge {
 			writeset,
 			id: self.database.transaction_merge_id.fetch_add(1, Ordering::AcqRel) + 1,
 		});
-		// Apply each writeset entry independently. A fresh `raw_iter_mut`
-		// is opened per key so the exclusive leaf guard is scoped to a
-		// single update — this keeps concurrent commits from holding leaf
-		// locks across unrelated keys.
-		//
-		// Inline gc has intentionally been removed from this path. The
-		// registration race in PR #77 stems from the gap between
-		// `earliest_active_version` and `gc_older_versions`: a reader
-		// that registers in that window would have its snapshot version
-		// swept by a cleanup_ts computed without it. We defer all
-		// version reclamation to the background gc worker, which runs
-		// far less frequently and so does not race with the steady-state
-		// reader registration pattern. The commit path now only
-		// publishes the new version and queues the key for later
-		// sweeping.
+		// Apply each writeset entry. Inline gc has intentionally been
+		// removed from this path: the registration race in PR #77 stems
+		// from the gap between `earliest_active_version` and
+		// `gc_older_versions`, where a reader registering in that window
+		// would have its snapshot version swept by a cleanup_ts computed
+		// without it. We defer all version reclamation to the background
+		// gc worker (bounded by `gc_floor`), which runs far less
+		// frequently and so does not race with the steady-state reader
+		// registration pattern. The commit path now only publishes the
+		// new version and queues the key for later sweeping.
 		for (key, value) in entry.writeset.iter() {
 			// Clone the value for insertion
 			let value = value.clone();
-			// Open an exclusive iterator scoped to this key
-			let mut iter = self.database.datastore.raw_iter_mut();
-			// Check if this key already exists in the tree
-			if iter.seek_exact(key) {
-				// Yield the entry at the cursor to obtain a mutable
-				// reference and append the new version. Tombstone-only
-				// removals are handled by the background gc.
-				let (_, versions) = iter.next().expect("seek_exact returned true");
-				versions.push(Version {
+			// Check if this key already exists
+			if let Some(entry) = self.database.datastore.get(key) {
+				// Append the new version. Tombstone-only removals are
+				// handled by the background gc.
+				entry.value().write().push(Version {
 					version,
 					value,
 				});
 			} else {
-				// Insert a new entry at the cursor's current position
-				iter.insert_here(
+				// Insert a new entry for this key
+				self.database.datastore.insert(
 					key.clone(),
-					Versions::from(Version {
+					RwLock::new(Versions::from(Version {
 						version,
 						value,
-					}),
+					})),
 				);
 			}
 			// Queue the key for background gc. Each commit publishes
@@ -1666,30 +1653,36 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly via bulk leaf iteration.
+		// range — walk the datastore directly.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let version = self.version;
-			for_each_in_range(&self.database.datastore, beg, end, |k, v| {
-				let Some(value) = v.fetch_version(version) else {
-					return ControlFlow::Continue(());
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			for entry in datastore_range {
+				let value = match entry.value().try_read() {
+					Some(g) => g.fetch_version(self.version),
+					None => entry.value().read().fetch_version(self.version),
+				};
+				let Some(value) = value else {
+					continue;
 				};
 				if skip > 0 {
 					skip -= 1;
-					return ControlFlow::Continue(());
+					continue;
 				}
 				count += 1;
-				if !f(k, &value) {
-					return ControlFlow::Break(());
+				if !f(entry.key(), &value) {
+					break;
 				}
 				if let Some(l) = limit {
 					if count >= l {
-						return ControlFlow::Break(());
+						break;
 					}
 				}
-				ControlFlow::Continue(())
-			});
+			}
 			return Ok(count);
 		}
 		// Lazy k-way merge over the merge-queue writesets.
@@ -1701,7 +1694,9 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1757,30 +1752,36 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly via bulk leaf iteration.
+		// range — walk the datastore directly.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let version = self.version;
-			for_each_in_range(&self.database.datastore, beg, end, |k, v| {
-				if !v.exists_version(version) {
-					return ControlFlow::Continue(());
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			for entry in datastore_range {
+				let exists = match entry.value().try_read() {
+					Some(g) => g.exists_version(self.version),
+					None => entry.value().read().exists_version(self.version),
+				};
+				if !exists {
+					continue;
 				}
 				if skip > 0 {
 					skip -= 1;
-					return ControlFlow::Continue(());
+					continue;
 				}
 				count += 1;
-				if !f(k) {
-					return ControlFlow::Break(());
+				if !f(entry.key()) {
+					break;
 				}
 				if let Some(l) = limit {
 					if count >= l {
-						return ControlFlow::Break(());
+						break;
 					}
 				}
-				ControlFlow::Continue(())
-			});
+			}
 			return Ok(count);
 		}
 		// Lazy k-way merge over the merge-queue writesets.
@@ -1792,7 +1793,9 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1846,28 +1849,33 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly into the buffer via bulk leaf
-		// iteration.
+		// range — walk the datastore directly into the buffer.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let version = self.version;
-			for_each_in_range(&self.database.datastore, beg, end, |k, v| {
-				let Some(value) = v.fetch_version(version) else {
-					return ControlFlow::Continue(());
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			for entry in datastore_range {
+				let value = match entry.value().try_read() {
+					Some(g) => g.fetch_version(self.version),
+					None => entry.value().read().fetch_version(self.version),
+				};
+				let Some(value) = value else {
+					continue;
 				};
 				if skip > 0 {
 					skip -= 1;
-					return ControlFlow::Continue(());
+					continue;
 				}
-				buf.push((k.clone(), value));
+				buf.push((entry.key().clone(), value));
 				if let Some(l) = limit {
 					if buf.len() >= l {
-						return ControlFlow::Break(());
+						break;
 					}
 				}
-				ControlFlow::Continue(())
-			});
+			}
 			return Ok(());
 		}
 		// Lazy k-way merge over the merge-queue writesets.
@@ -1879,7 +1887,9 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -1930,28 +1940,33 @@ impl TransactionInner {
 			self.track_scan_range(beg, end);
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly into the buffer via bulk leaf
-		// iteration.
+		// range — walk the datastore directly into the buffer.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			let version = self.version;
-			for_each_in_range(&self.database.datastore, beg, end, |k, v| {
-				if !v.exists_version(version) {
-					return ControlFlow::Continue(());
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			for entry in datastore_range {
+				let exists = match entry.value().try_read() {
+					Some(g) => g.exists_version(self.version),
+					None => entry.value().read().exists_version(self.version),
+				};
+				if !exists {
+					continue;
 				}
 				if skip > 0 {
 					skip -= 1;
-					return ControlFlow::Continue(());
+					continue;
 				}
-				buf.push(k.clone());
+				buf.push(entry.key().clone());
 				if let Some(l) = limit {
 					if buf.len() >= l {
-						return ControlFlow::Break(());
+						break;
 					}
 				}
-				ControlFlow::Continue(())
-			});
+			}
 			return Ok(());
 		}
 		// Lazy k-way merge over the merge-queue writesets.
@@ -1963,7 +1978,9 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -2051,41 +2068,24 @@ impl TransactionInner {
 				self.track_scan_range(beg, end);
 			}
 		}
-		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly. Forward direction uses
-		// `for_each_in_range`, which processes a whole B+tree leaf in one
-		// tight loop via ferntree's `for_each_in_leaf`. Reverse direction
-		// keeps the entry-at-a-time `RangeRev` iterator since ferntree only
-		// exposes bulk leaf processing in forward order.
+		// Fast path: when there are no in-flight committed transactions and no
+		// uncommitted writes in this range, the merge iterator has nothing to
+		// merge — read straight from the datastore range.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			match direction {
-				Direction::Forward => {
-					for_each_in_range(&self.database.datastore, beg, end, |_, v| {
-						if !v.exists_version(version) {
-							return ControlFlow::Continue(());
-						}
-						if skip > 0 {
-							skip -= 1;
-							return ControlFlow::Continue(());
-						}
-						res += 1;
-						if let Some(l) = limit {
-							if res >= l {
-								return ControlFlow::Break(());
-							}
-						}
-						ControlFlow::Continue(())
-					});
-				}
-				Direction::Reverse => {
-					let mut range = self
-						.database
-						.datastore
-						.range_rev(Bound::Included(beg), Bound::Excluded(end));
-					while let Some((_, v)) = range.next() {
-						if !v.exists_version(version) {
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			macro_rules! consume_fast_path {
+				($iter:expr) => {
+					for entry in $iter {
+						let exists = match entry.value().try_read() {
+							Some(g) => g.exists_version(version),
+							None => entry.value().read().exists_version(version),
+						};
+						if !exists {
 							continue;
 						}
 						if skip > 0 {
@@ -2099,7 +2099,11 @@ impl TransactionInner {
 							}
 						}
 					}
-				}
+				};
+			}
+			match direction {
+				Direction::Forward => consume_fast_path!(datastore_range),
+				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
 			}
 			return Ok(res);
 		}
@@ -2112,7 +2116,9 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, beg, end, direction),
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2168,51 +2174,40 @@ impl TransactionInner {
 			}
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly. Forward uses ferntree's bulk
-		// leaf iteration via `for_each_in_range`; reverse stays on `RangeRev`.
+		// range — read keys straight from the datastore range.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			match direction {
-				Direction::Forward => {
-					for_each_in_range(&self.database.datastore, beg, end, |k, v| {
-						if !v.exists_version(version) {
-							return ControlFlow::Continue(());
-						}
-						if skip > 0 {
-							skip -= 1;
-							return ControlFlow::Continue(());
-						}
-						res.push(k.clone());
-						if let Some(l) = limit {
-							if res.len() >= l {
-								return ControlFlow::Break(());
-							}
-						}
-						ControlFlow::Continue(())
-					});
-				}
-				Direction::Reverse => {
-					let mut range = self
-						.database
-						.datastore
-						.range_rev(Bound::Included(beg), Bound::Excluded(end));
-					while let Some((k, v)) = range.next() {
-						if !v.exists_version(version) {
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			macro_rules! consume_fast_path {
+				($iter:expr) => {
+					for entry in $iter {
+						let exists = match entry.value().try_read() {
+							Some(g) => g.exists_version(version),
+							None => entry.value().read().exists_version(version),
+						};
+						if !exists {
 							continue;
 						}
 						if skip > 0 {
 							skip -= 1;
 							continue;
 						}
-						res.push(k.clone());
+						res.push(entry.key().clone());
 						if let Some(l) = limit {
 							if res.len() >= l {
 								break;
 							}
 						}
 					}
-				}
+				};
+			}
+			match direction {
+				Direction::Forward => consume_fast_path!(datastore_range),
+				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
 			}
 			return Ok(res);
 		}
@@ -2225,7 +2220,9 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let mut iter = MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, beg, end, direction),
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2281,51 +2278,40 @@ impl TransactionInner {
 			}
 		}
 		// Fast path: no merge queue entries and no transaction writes in this
-		// range — walk the tree range directly. Forward uses ferntree's bulk
-		// leaf iteration via `for_each_in_range`; reverse stays on `RangeRev`.
+		// range — read key/value pairs straight from the datastore range.
 		if self.database.transaction_merge_queue.is_empty()
 			&& self.writeset.range::<Bytes, _>(beg..end).next().is_none()
 		{
-			match direction {
-				Direction::Forward => {
-					for_each_in_range(&self.database.datastore, beg, end, |k, v| {
-						let Some(value) = v.fetch_version(version) else {
-							return ControlFlow::Continue(());
+			let datastore_range = self
+				.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone())));
+			macro_rules! consume_fast_path {
+				($iter:expr) => {
+					for entry in $iter {
+						let value = match entry.value().try_read() {
+							Some(g) => g.fetch_version(version),
+							None => entry.value().read().fetch_version(version),
 						};
-						if skip > 0 {
-							skip -= 1;
-							return ControlFlow::Continue(());
-						}
-						res.push((k.clone(), value));
-						if let Some(l) = limit {
-							if res.len() >= l {
-								return ControlFlow::Break(());
-							}
-						}
-						ControlFlow::Continue(())
-					});
-				}
-				Direction::Reverse => {
-					let mut range = self
-						.database
-						.datastore
-						.range_rev(Bound::Included(beg), Bound::Excluded(end));
-					while let Some((k, v)) = range.next() {
-						let Some(value) = v.fetch_version(version) else {
+						let Some(value) = value else {
 							continue;
 						};
 						if skip > 0 {
 							skip -= 1;
 							continue;
 						}
-						res.push((k.clone(), value));
+						res.push((entry.key().clone(), value));
 						if let Some(l) = limit {
 							if res.len() >= l {
 								break;
 							}
 						}
 					}
-				}
+				};
+			}
+			match direction {
+				Direction::Forward => consume_fast_path!(datastore_range),
+				Direction::Reverse => consume_fast_path!(datastore_range.rev()),
 			}
 			return Ok(res);
 		}
@@ -2338,7 +2324,9 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator
 		let iter = MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, beg, end, direction),
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			direction,
@@ -2402,7 +2390,9 @@ impl TransactionInner {
 		));
 		// Create the 3-way merge iterator to iterate over keys
 		let iter = MergeIterator::new(
-			TreeIterState::build(&self.database.datastore, beg, end, Direction::Forward),
+			self.database
+				.datastore
+				.range((Bound::Included(beg.clone()), Bound::Excluded(end.clone()))),
 			join_iter,
 			self.writeset.range::<Bytes, _>(beg..end),
 			Direction::Forward,
@@ -2416,10 +2406,9 @@ impl TransactionInner {
 			// Use a BTreeMap to collect and merge versions by version number
 			let mut all_versions: BTreeMap<u64, Option<Bytes>> = BTreeMap::new();
 			// Collect all versions from the datastore
-			let collected: Option<Vec<(u64, Option<Bytes>)>> =
-				self.database.datastore.lookup(&key, |v| v.all_versions());
-			if let Some(versions) = collected {
-				for (ver, val) in versions {
+			if let Some(entry) = self.database.datastore.get(&key) {
+				let versions = entry.value().read();
+				for (ver, val) in versions.all_versions() {
 					if ver <= version {
 						all_versions.insert(ver, val);
 					}
@@ -2598,7 +2587,10 @@ impl TransactionInner {
 			}
 		}
 		// Check the key in the datastore
-		self.database.datastore.lookup(key, |v| v.fetch_version(version)).flatten()
+		self.database.datastore.get(key).and_then(|e| match e.value().try_read() {
+			Some(guard) => guard.fetch_version(version),
+			None => e.value().read().fetch_version(version),
+		})
 	}
 
 	/// Check if a key exists in the datastore only
@@ -2622,7 +2614,14 @@ impl TransactionInner {
 			}
 		}
 		// Check the key in the datastore
-		self.database.datastore.lookup(key, |v| v.exists_version(version)).unwrap_or(false)
+		self.database
+			.datastore
+			.get(key)
+			.map(|e| match e.value().try_read() {
+				Some(guard) => guard.exists_version(version),
+				None => e.value().read().exists_version(version),
+			})
+			.is_some_and(|v| v)
 	}
 
 	/// Check if a key equals a value in the datastore only
@@ -2651,8 +2650,17 @@ impl TransactionInner {
 			}
 		}
 		// Check the key in the datastore
-		let stored = self.database.datastore.lookup(key, |v| v.fetch_version(version)).flatten();
-		match (chk.as_ref(), stored.as_ref()) {
+		match (
+			chk.as_ref(),
+			self.database
+				.datastore
+				.get(key)
+				.and_then(|e| match e.value().try_read() {
+					Some(guard) => guard.fetch_version(version),
+					None => e.value().read().fetch_version(version),
+				})
+				.as_ref(),
+		) {
 			(Some(x), Some(y)) => x.as_slice() == y,
 			(None, None) => true,
 			_ => false,

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1054,23 +1054,36 @@ impl TransactionInner {
 		for (key, value) in entry.writeset.iter() {
 			// Clone the value for insertion
 			let value = value.clone();
-			// Check if this key already exists
-			if let Some(entry) = self.database.datastore.get(key) {
-				// Append the new version. Tombstone-only removals are
-				// handled by the background gc.
-				entry.value().write().push(Version {
-					version,
-					value,
-				});
-			} else {
-				// Insert a new entry for this key
-				self.database.datastore.insert(
-					key.clone(),
-					RwLock::new(Versions::from(Version {
+			// Append into the existing entry, but guard against a concurrent
+			// background gc that may be unlinking this key: the sweeper calls
+			// `Entry::remove` while holding the entry's write lock, so once we
+			// hold that lock `is_removed()` tells us whether the node is still
+			// live. If gc unlinked it, fall through to a fresh insert instead
+			// of pushing into a detached node (which would drop this commit's
+			// write). See `Database::run_gc_dirty_inner`.
+			let pending = if let Some(entry) = self.database.datastore.get(key) {
+				let mut versions = entry.value().write();
+				if entry.is_removed() {
+					Some(Version {
 						version,
 						value,
-					})),
-				);
+					})
+				} else {
+					versions.push(Version {
+						version,
+						value,
+					});
+					None
+				}
+			} else {
+				Some(Version {
+					version,
+					value,
+				})
+			};
+			// Insert a new entry when the key was absent or gc unlinked it.
+			if let Some(version) = pending {
+				self.database.datastore.insert(key.clone(), RwLock::new(Versions::from(version)));
 			}
 			// Queue the key for background gc. Each commit publishes
 			// fresh stale versions, so every modified key is dirty.

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1054,36 +1054,36 @@ impl TransactionInner {
 		for (key, value) in entry.writeset.iter() {
 			// Clone the value for insertion
 			let value = value.clone();
-			// Append into the existing entry, but guard against a concurrent
-			// background gc that may be unlinking this key: the sweeper calls
-			// `Entry::remove` while holding the entry's write lock, so once we
-			// hold that lock `is_removed()` tells us whether the node is still
-			// live. If gc unlinked it, fall through to a fresh insert instead
-			// of pushing into a detached node (which would drop this commit's
-			// write). See `Database::run_gc_dirty_inner`.
-			let pending = if let Some(entry) = self.database.datastore.get(key) {
+			// Publish the new version into the datastore, guarding against a
+			// concurrent background gc that may be unlinking this key: the
+			// sweeper calls `Entry::remove` while holding the entry's write
+			// lock, so once we hold that lock `is_removed()` tells us whether
+			// the node is still live. `get_or_insert_with` (unlike `insert`)
+			// never replaces a live node, so a concurrent writer's entry can
+			// never be clobbered; if the sweeper unlinked the node we landed
+			// on, we retry and get a fresh one. The closure seeds the chain
+			// with this version so a freshly-inserted node is never an empty,
+			// immediately-gc-reclaimable node mid-insert. See
+			// `Inner::run_gc_dirty_inner`.
+			loop {
+				let entry = self.database.datastore.get_or_insert_with(key.clone(), || {
+					RwLock::new(Versions::from(Version {
+						version,
+						value: value.clone(),
+					}))
+				});
 				let mut versions = entry.value().write();
+				// The sweeper unlinked this node between lookup and lock; retry
+				// onto a fresh one rather than writing into a detached node.
 				if entry.is_removed() {
-					Some(Version {
-						version,
-						value,
-					})
-				} else {
-					versions.push(Version {
-						version,
-						value,
-					});
-					None
+					continue;
 				}
-			} else {
-				Some(Version {
+				// A no-op when the node was just seeded with this version.
+				versions.push(Version {
 					version,
 					value,
-				})
-			};
-			// Insert a new entry when the key was absent or gc unlinked it.
-			if let Some(version) = pending {
-				self.database.datastore.insert(key.clone(), RwLock::new(Versions::from(version)));
+				});
+				break;
 			}
 			// Queue the key for background gc. Each commit publishes
 			// fresh stale versions, so every modified key is dirty.

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -147,8 +147,13 @@ impl Versions {
 	{
 		// Drain the versions
 		self.inner.drain(range);
-		// Shrink the vec inline
-		self.inner.shrink_to_fit();
+		// Only reclaim backing storage once capacity has grown well beyond
+		// the live set. Shrinking on every drain would thrash allocations
+		// for hot keys under the frequent background GC; the hysteresis keeps
+		// steady-state churn cheap while still bounding wasted capacity.
+		if self.inner.capacity() > self.inner.len().max(4).saturating_mul(2) {
+			self.inner.shrink_to_fit();
+		}
 	}
 
 	/// Find the index of the entry where item.version <= version.

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,6 +1,5 @@
 use crate::version::Version;
 use bytes::Bytes;
-use ferntree::impl_optimistic_read_boxed;
 use smallvec::SmallVec;
 
 pub(crate) enum IndexOrUpdate<'a> {
@@ -12,15 +11,9 @@ pub(crate) enum IndexOrUpdate<'a> {
 	Update(&'a mut Version),
 }
 
-#[derive(Clone)]
 pub struct Versions {
 	inner: SmallVec<[Version; 4]>,
 }
-
-// SAFETY: `Versions` is `Clone + Send + Sync + 'static`; ferntree stores it
-// behind `BoxedSlot`, so the displaced `Box<Versions>` must be routed through
-// the epoch GC on overwrite. See `impl_optimistic_read_boxed!` docs.
-impl_optimistic_read_boxed!(Versions);
 
 impl From<Version> for Versions {
 	fn from(value: Version) -> Self {
@@ -158,33 +151,6 @@ impl Versions {
 		self.inner.shrink_to_fit();
 	}
 
-	/// Check if the item at a specific version is a delete.
-	#[inline]
-	pub(crate) fn is_delete(&self, version: usize) -> bool {
-		self.inner.get(version).is_some_and(|v| v.value.is_none())
-	}
-
-	/// Find the index of the entry where item.version < version.
-	#[inline]
-	pub(crate) fn find_index_lt_version(&self, version: u64) -> usize {
-		// Check for any existing version
-		if let Some(last) = self.inner.last() {
-			// Check if the version is newer
-			if version > last.version {
-				// Return the index of the last version
-				return self.inner.len();
-			}
-		}
-		// Check the list length for reverse iteration or binary search
-		if self.inner.len() <= 4 {
-			// Use linear search to find the first element where v.version > version
-			self.inner.iter().rposition(|v| v.version < version).map_or(0, |i| i + 1)
-		} else {
-			// Find the index of the item where item.version <= version
-			self.inner.partition_point(|v| v.version < version)
-		}
-	}
-
 	/// Find the index of the entry where item.version <= version.
 	#[inline]
 	pub(crate) fn find_index_lte_version(&self, version: u64) -> usize {
@@ -238,29 +204,35 @@ impl Versions {
 		self.inner.iter().map(|v| (v.version, v.value.clone())).collect()
 	}
 
-	/// Remove all versions older than the specified version.
+	/// Remove versions that no reader at a snapshot `>= version` can observe.
+	///
+	/// `version` is the GC floor: no reader exists below it, but readers may
+	/// sit exactly at it or anywhere above. The earliest snapshot any surviving
+	/// reader can hold is `version` itself, so the oldest entry we must retain
+	/// is the one *visible at* `version` — the latest entry with
+	/// `entry.version <= version` — together with every newer entry. Removing
+	/// that entry would let a reader whose snapshot lands between it and the
+	/// next entry observe the key vanish mid-snapshot (an SI violation).
 	#[inline]
 	pub(crate) fn gc_older_versions(&mut self, version: u64) -> usize {
-		// Find the index of the item where item.version < version
-		let idx = self.find_index_lt_version(version);
-		// Handle the case where all versions are older than the cutoff
-		if idx >= self.inner.len() {
-			// Check if the last version is a delete
-			if let Some(last) = self.inner.last() {
-				if last.value.is_none() {
-					// Last version is a delete, remove everything
-					self.inner.clear();
-				} else if idx > 1 {
-					// Last version has data, keep it and remove all others
-					self.drain(..idx - 1);
-				}
-			}
-		} else if self.is_delete(idx) {
-			// Remove all versions up to and including this delete
-			self.drain(..=idx);
-		} else if idx > 0 {
-			// Remove all versions up to this version
-			self.drain(..idx);
+		// Number of entries with entry.version <= version.
+		let lte = self.find_index_lte_version(version);
+		// No entry is <= version: every entry is newer and still required.
+		if lte == 0 {
+			return self.inner.len();
+		}
+		// The entry visible at `version`.
+		let visible = lte - 1;
+		if self.inner[visible].value.is_none() {
+			// The visible entry is a delete tombstone. A reader at or above
+			// `version` (and below the next entry) observes "absent", which is
+			// identical to the entry being gone — so drop the tombstone and
+			// everything before it.
+			self.drain(..lte);
+		} else {
+			// The visible entry carries a value a surviving reader may read.
+			// Keep it; drop only the strictly-older entries before it.
+			self.drain(..visible);
 		}
 		// Return the length
 		self.inner.len()
@@ -289,90 +261,6 @@ mod tests {
 			v.push(make_version(version, value));
 		}
 		v
-	}
-
-	// ==================== Tests for find_index_lt_version ====================
-
-	#[test]
-	fn test_find_index_lt_version_empty() {
-		let versions = Versions::new();
-		assert_eq!(versions.find_index_lt_version(0), 0);
-		assert_eq!(versions.find_index_lt_version(1), 0);
-		assert_eq!(versions.find_index_lt_version(100), 0);
-	}
-
-	#[test]
-	fn test_find_index_lt_version_single_version() {
-		let versions = make_versions(vec![(10, Some("value"))]);
-		// Query before the version
-		assert_eq!(versions.find_index_lt_version(5), 0);
-		assert_eq!(versions.find_index_lt_version(9), 0);
-		// Query at the version
-		assert_eq!(versions.find_index_lt_version(10), 0);
-		// Query after the version
-		assert_eq!(versions.find_index_lt_version(11), 1);
-		assert_eq!(versions.find_index_lt_version(100), 1);
-	}
-
-	#[test]
-	fn test_find_index_lt_version_multiple_versions() {
-		// Create a small list (≤32 elements) to trigger linear search
-		let versions = make_versions(vec![
-			(10, Some("v1")),
-			(20, Some("v2")),
-			(30, Some("v3")),
-			(40, Some("v4")),
-			(50, Some("v5")),
-		]);
-		// Query before the first version
-		assert_eq!(versions.find_index_lt_version(0), 0);
-		assert_eq!(versions.find_index_lt_version(5), 0);
-		// Query at the first version
-		assert_eq!(versions.find_index_lt_version(10), 0);
-		// Query after the first version
-		assert_eq!(versions.find_index_lt_version(15), 1);
-		// Query at the second version
-		assert_eq!(versions.find_index_lt_version(20), 1);
-		// Query after the second version
-		assert_eq!(versions.find_index_lt_version(25), 2);
-		assert_eq!(versions.find_index_lt_version(30), 2);
-		// Query at the third version
-		assert_eq!(versions.find_index_lt_version(35), 3);
-		assert_eq!(versions.find_index_lt_version(40), 3);
-		// Query at the fourth version
-		assert_eq!(versions.find_index_lt_version(45), 4);
-		// Query at the fifth version
-		assert_eq!(versions.find_index_lt_version(50), 4);
-		// Query after the fifth version
-		assert_eq!(versions.find_index_lt_version(51), 5);
-		assert_eq!(versions.find_index_lt_version(100), 5);
-	}
-
-	#[test]
-	fn test_find_index_lt_version_with_deletes() {
-		let versions = make_versions(vec![
-			(10, Some("v1")),
-			(20, None), // Delete
-			(30, Some("v3")),
-			(40, None), // Delete
-		]);
-		// Query before the first version
-		assert_eq!(versions.find_index_lt_version(5), 0);
-		assert_eq!(versions.find_index_lt_version(9), 0);
-		// Query at the first version
-		assert_eq!(versions.find_index_lt_version(10), 0);
-		// Query after the first version
-		assert_eq!(versions.find_index_lt_version(15), 1);
-		// Query at the second version
-		assert_eq!(versions.find_index_lt_version(20), 1);
-		// Query after the second version
-		assert_eq!(versions.find_index_lt_version(25), 2);
-		assert_eq!(versions.find_index_lt_version(30), 2);
-		// Query at the third version
-		assert_eq!(versions.find_index_lt_version(35), 3);
-		assert_eq!(versions.find_index_lt_version(40), 3);
-		// Query after the third version
-		assert_eq!(versions.find_index_lt_version(50), 4);
 	}
 
 	// ==================== Tests for find_index_lte_version ====================
@@ -460,31 +348,59 @@ mod tests {
 		assert_eq!(versions.find_index_lte_version(50), 4);
 	}
 
+	// ==================== Tests for gc_older_versions ====================
+
 	#[test]
-	fn test_find_index_lt_vs_lte_difference() {
-		// This test demonstrates the key difference between < and <=
-		let versions = make_versions(vec![
-			(10, Some("v1")),
-			(20, Some("v2")),
-			(30, Some("v3")),
-			(40, Some("v4")),
-			(50, Some("v5")),
-		]);
-		// Query at the first version
-		assert_eq!(versions.find_index_lt_version(10), 0);
-		assert_eq!(versions.find_index_lte_version(10), 1);
-		// Query after the first version
-		assert_eq!(versions.find_index_lt_version(15), 1);
-		assert_eq!(versions.find_index_lte_version(15), 1);
-		// Query at the second version
-		assert_eq!(versions.find_index_lt_version(20), 1);
-		assert_eq!(versions.find_index_lte_version(20), 2);
-		// Query at the third version
-		assert_eq!(versions.find_index_lt_version(30), 2);
-		assert_eq!(versions.find_index_lte_version(30), 3);
-		// Query after the third version
-		assert_eq!(versions.find_index_lt_version(35), 3);
-		assert_eq!(versions.find_index_lte_version(35), 3);
+	fn test_gc_keeps_version_visible_at_floor() {
+		// Regression: the GC floor falls in the gap between a value and a
+		// later delete. A reader whose snapshot lands in [floor, delete) must
+		// still observe the value, so it must survive GC.
+		let mut v = make_versions(vec![(10, Some("v1")), (40, None)]);
+		v.gc_older_versions(30);
+		// The value visible at 30 (and at 35) must remain readable.
+		assert_eq!(v.fetch_version(30), Some(Bytes::from("v1".to_string())));
+		assert_eq!(v.fetch_version(35), Some(Bytes::from("v1".to_string())));
+		// At/after the delete it is gone.
+		assert_eq!(v.fetch_version(40), None);
+	}
+
+	#[test]
+	fn test_gc_keeps_value_before_newer_version_in_gap() {
+		// Floor in the gap between two values: the earlier value is visible at
+		// the floor and must survive.
+		let mut v = make_versions(vec![(10, Some("v1")), (50, Some("v2"))]);
+		v.gc_older_versions(30);
+		assert_eq!(v.fetch_version(30), Some(Bytes::from("v1".to_string())));
+		assert_eq!(v.fetch_version(49), Some(Bytes::from("v1".to_string())));
+		assert_eq!(v.fetch_version(50), Some(Bytes::from("v2".to_string())));
+	}
+
+	#[test]
+	fn test_gc_drops_versions_below_visible() {
+		// Floor exactly on a value: older versions are reclaimed, the visible
+		// one is kept.
+		let mut v = make_versions(vec![(10, Some("v1")), (30, Some("v2"))]);
+		assert_eq!(v.gc_older_versions(30), 1);
+		assert_eq!(v.fetch_version(30), Some(Bytes::from("v2".to_string())));
+		assert_eq!(v.fetch_version(35), Some(Bytes::from("v2".to_string())));
+	}
+
+	#[test]
+	fn test_gc_collapses_fully_deleted_key() {
+		// Visible entry at the floor is a delete tombstone: the whole chain is
+		// reclaimable.
+		let mut v = make_versions(vec![(10, Some("v1")), (30, None)]);
+		assert_eq!(v.gc_older_versions(40), 0);
+		assert_eq!(v.fetch_version(40), None);
+	}
+
+	#[test]
+	fn test_gc_retains_all_when_floor_below_everything() {
+		// Floor below the earliest version: nothing is reclaimable.
+		let mut v = make_versions(vec![(10, Some("v1")), (20, Some("v2"))]);
+		assert_eq!(v.gc_older_versions(5), 2);
+		assert_eq!(v.fetch_version(10), Some(Bytes::from("v1".to_string())));
+		assert_eq!(v.fetch_version(20), Some(Bytes::from("v2".to_string())));
 	}
 
 	// ==================== Tests for fetch_version ====================

--- a/tests/concurrent_deletes.rs
+++ b/tests/concurrent_deletes.rs
@@ -308,3 +308,84 @@ fn ssi_delete_read_conflict() {
 	let tx = db.transaction(false);
 	assert!(tx.get("key").unwrap().is_none(), "Key should be deleted");
 }
+
+/// Stress guard for delete-then-recreate under aggressive concurrent GC: a key
+/// that is deleted and immediately recreated must always read back as its new
+/// value, never `None`. This exercises the path the GC remove/commit-reinsert
+/// coordination protects — the sweeper unlinks a tombstoned entry while holding
+/// its write lock, and the committer re-checks `is_removed()` under that same
+/// lock so a recreate either lands in a fresh entry or blocks the removal.
+///
+/// Note: the specific remove-vs-reinsert window is extremely narrow and this
+/// test is not a deterministic reproducer of it (it did not fail even with the
+/// guard removed under ThreadSanitizer); it is a sanity/stress guard over the
+/// delete-recreate-under-GC pattern. A side thread hammers `run_gc()`.
+#[test]
+fn delete_then_recreate_under_gc_keeps_value() {
+	use std::sync::atomic::{AtomicBool, Ordering};
+
+	const WRITERS: usize = 4;
+	const KEYS_PER_WRITER: usize = 32;
+	const ROUNDS: usize = 150;
+
+	// Background GC is enabled by default; we also drive it synchronously below.
+	let db = Arc::new(Database::new());
+
+	// Seed every key so the first delete always has something to remove.
+	{
+		let mut tx = db.transaction(true);
+		for w in 0..WRITERS {
+			for k in 0..KEYS_PER_WRITER {
+				tx.set(format!("w{w}:k{k}"), "seed").unwrap();
+			}
+		}
+		tx.commit().unwrap();
+	}
+
+	// Hammer GC to maximise the chance of a remove landing next to a recreate.
+	let stop = Arc::new(AtomicBool::new(false));
+	let gc = {
+		let db = db.clone();
+		let stop = stop.clone();
+		thread::spawn(move || {
+			while !stop.load(Ordering::Relaxed) {
+				db.run_gc();
+			}
+		})
+	};
+
+	let mut handles = Vec::new();
+	for w in 0..WRITERS {
+		// Each writer owns a disjoint key set, so commits never conflict.
+		let db = db.clone();
+		handles.push(thread::spawn(move || {
+			for round in 0..ROUNDS {
+				for k in 0..KEYS_PER_WRITER {
+					let key = format!("w{w}:k{k}");
+					let val = format!("w{w}:k{k}:r{round}");
+					// Delete, then recreate, each in its own commit.
+					let mut tx = db.transaction(true);
+					tx.del(key.as_str()).unwrap();
+					tx.commit().unwrap();
+					let mut tx = db.transaction(true);
+					tx.set(key.as_str(), val.as_str()).unwrap();
+					tx.commit().unwrap();
+					// A fresh snapshot (version above the recreate) must observe it.
+					let mut tx = db.transaction(false);
+					let got = tx.get(key.as_str()).unwrap();
+					tx.cancel().unwrap();
+					assert_eq!(
+						got.as_deref(),
+						Some(val.as_bytes()),
+						"recreated key {key} lost its value — GC removed a concurrently-committed entry"
+					);
+				}
+			}
+		}));
+	}
+	for h in handles {
+		h.join().unwrap();
+	}
+	stop.store(true, Ordering::Relaxed);
+	gc.join().unwrap();
+}


### PR DESCRIPTION
## Motivation

We are moving the keyspace datastore off `ferntree` and back to its predecessor,
`crossbeam_skiplist::SkipMap<Bytes, RwLock<Versions>>` (the implementation that was in use
before #74). This restores the pre-`ferntree` data structure while **preserving** every
correctness improvement that landed in or after the `ferntree` switch.

## What changed

**Datastore swap** (`SkipMap<Bytes, RwLock<Versions>>` ← `ferntree::Tree<Bytes, Versions>`):
- `src/iter.rs`, `src/cursor.rs`, `src/persistence.rs`, `src/versions.rs` restored from the
  last pre-`ferntree` commit (`714cf39`, parent of #74).
- `src/inner.rs` — datastore field/ctor reverted; `gc_floor` kept.
- `Cargo.toml` — `ferntree` dependency removed; version `0.21.0` → `0.22.0`.

**Correctness work forward-ported onto the SkipMap base** (not lost in the revert):
- `gc_floor` scan/GC race barrier (introduced by #74) — `register_counter` validation + the
  publish-fence-rescan `compute_cleanup_ts` protocol, re-wired to the SkipMap GC reclaim loops
  in `src/db.rs`.
- #79 — `Transaction: Send + Sync` (`RefCell` → `parking_lot::Mutex` for the readset bloom)
  and "skip readset bookkeeping outside SSI".
- The deferred-commit GC model (no inline GC in `commit()`; all reclamation via the
  `gc_floor`-protected background sweeper). `src/options.rs` GC tuning retained.
- #80's `tests/scan_out_of_range.rs` retained and passing (the SkipMap `MergeIterator` is
  bound-correct by construction).

**Bug fix — `Versions::gc_older_versions` over-prune (snapshot-isolation violation):**
While validating the revert under ThreadSanitizer + heavy parallel load, the SkipMap path
failed `concurrent_deletes_no_phantom_within_snapshot` with *"key disappeared mid-snapshot"*
(5/6 runs; ferntree was 0/5). Root cause: when the GC floor landed in the gap between a key's
value version `S` and a later delete `D` (`S < floor < D`), `gc_older_versions` discarded
**both** — but a reader whose snapshot fell in `[floor, D)` still needed `S`. This requires
only `floor ≤ V` (it is **not** a `gc_floor` violation; the floor machinery was correct and
identical to before).

The fix retains the entry *visible at* the GC floor (latest entry with `version ≤ floor`) plus
everything newer, dropping only a leading tombstone. Orphaned helpers (`is_delete`,
`find_index_lt_version`) removed; `gc_older_versions` regression tests added.

> Note: this over-prune is **latent in `ferntree` HEAD too** (identical `gc_older_versions`),
> masked there by `ferntree`'s optimistic boxed reads rather than fixed. SkipMap's `RwLock`
> reads + the 500ms GC interval exposed it. Worth porting the same fix regardless of datastore.

## Post-review hardening (commit 2)

Code review additionally flagged that the SkipMap GC reclaim does a **non-atomic
check-then-remove** (`gc_older_versions == 0` → drop lock → `datastore.remove`), so a commit
recreating a key in that window could push into the about-to-be-removed node and lose the
write — a hazard `ferntree`'s leaf-locked removal did not have. GC now removes **under the
version write lock** via `Entry::remove()` (also dropping a redundant key lookup), and the
commit apply loop re-checks `Entry::is_removed()` under that lock, inserting a fresh entry if
the sweeper unlinked it.

This window is analyzable but **practically unreproducible** (0 lost writes across 12 TSan runs
with the guard removed), so it's defensive hardening; the added `concurrent_deletes` test is a
stress/sanity guard over the delete-recreate-under-GC path, not a deterministic reproducer.

A focused security review found **no findings** (no network/auth/crypto/untrusted-input surface
in the changed code).

## Testing

- Full suite green: **129 lib + 26 integration suites** (incl. `gc`, `scan_out_of_range`,
  `prefix_concurrency`, `prefix_keys`, `concurrent_deletes`).
- The previously-failing SI test under **ThreadSanitizer high-load: 0/10** (was 5/6 pre-fix);
  comprehensive TSan across 5 concurrency suites: 0/10.
- Normal-speed concurrency stress: 0/20.
- TSan otherwise clean apart from known `crossbeam-epoch` reclamation false positives (in deps,
  shared with `ferntree`).
- Not verified locally: `wasm32-unknown-unknown` build (target not installed); the WASM-gated
  files were reverted verbatim.
