### PR TITLE
Store keys only in transaction commit queue entries

### DIFF
--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -37,26 +37,20 @@ pub struct ReadsetConflictScenario {
 impl ReadsetConflictScenario {
 	/// Build a scenario with the given writeset and readset keys
 	pub fn new(writeset_keys: &[Bytes], readset_keys: &[Bytes]) -> Self {
-		// Build the writeset BTreeMap
-		let mut ws = BTreeMap::new();
-		for k in writeset_keys {
-			ws.insert(k.clone(), Some(Bytes::from_static(b"v")));
-		}
+		// Build the sorted writeset keys
+		let mut keys = writeset_keys.to_vec();
+		keys.sort();
+		keys.dedup();
 		// Build the writeset bloom filter
 		let mut writeset_bloom = BloomFilter::new();
-		for k in ws.keys() {
+		for k in keys.iter() {
 			writeset_bloom.insert(k);
 		}
-		// Extract min and max keys
-		let min_key = ws.keys().next().cloned().unwrap_or_default();
-		let max_key = ws.keys().next_back().cloned().unwrap_or_default();
 		// Build the commit entry
 		let commit = Arc::new(Commit {
 			id: 1,
-			writeset: Arc::new(ws),
+			keys,
 			writeset_bloom,
-			min_key,
-			max_key,
 		});
 		// Build the readset and bloom filter
 		let readset = HashSet::new();
@@ -115,26 +109,20 @@ impl WritesetConflictScenario {
 
 	/// Build a Commit entry from a set of keys
 	fn build_commit(keys: &[Bytes], id: u64) -> Commit {
-		// Build the writeset BTreeMap
-		let mut ws = BTreeMap::new();
-		for k in keys {
-			ws.insert(k.clone(), Some(Bytes::from_static(b"v")));
-		}
+		// Build the sorted writeset keys
+		let mut keys = keys.to_vec();
+		keys.sort();
+		keys.dedup();
 		// Build the writeset bloom filter
 		let mut writeset_bloom = BloomFilter::new();
-		for k in ws.keys() {
+		for k in keys.iter() {
 			writeset_bloom.insert(k);
 		}
-		// Extract min and max keys
-		let min_key = ws.keys().next().cloned().unwrap_or_default();
-		let max_key = ws.keys().next_back().cloned().unwrap_or_default();
 		// Build the commit entry
 		Commit {
 			id,
-			writeset: Arc::new(ws),
+			keys,
 			writeset_bloom,
-			min_key,
-			max_key,
 		}
 	}
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -26,14 +26,15 @@ use tracing::debug;
 pub struct Commit {
 	/// The unique id of this commit attempt
 	pub(crate) id: u64,
-	/// The local set of updates and deletes
-	pub(crate) writeset: Arc<BTreeMap<Bytes, Option<Bytes>>>,
+	/// The sorted keys of the local updates and deletes. Conflict
+	/// detection only ever inspects keys, so the values are
+	/// intentionally not stored here: a commit queue entry outlives
+	/// the corresponding merge queue entry (it is only trimmed later
+	/// by the cleanup worker), and holding the values would pin them
+	/// in memory for that entire window.
+	pub(crate) keys: Vec<Bytes>,
 	/// Bloom filter over writeset keys for fast conflict pre-checks
 	pub(crate) writeset_bloom: BloomFilter,
-	/// The smallest key in the writeset (for range overlap checks)
-	pub(crate) min_key: Bytes,
-	/// The largest key in the writeset (for range overlap checks)
-	pub(crate) max_key: Bytes,
 }
 
 /// A transaction entry in the transaction merge queue
@@ -45,6 +46,24 @@ pub struct Merge {
 }
 
 impl Commit {
+	/// The smallest key in the writeset (for range overlap checks)
+	#[inline]
+	fn min_key(&self) -> Option<&Bytes> {
+		self.keys.first()
+	}
+
+	/// The largest key in the writeset (for range overlap checks)
+	#[inline]
+	fn max_key(&self) -> Option<&Bytes> {
+		self.keys.last()
+	}
+
+	/// Returns true if the writeset contains the specified key
+	#[inline]
+	fn contains_key(&self, key: &Bytes) -> bool {
+		self.keys.binary_search(key).is_ok()
+	}
+
 	/// Returns true if self has no elements in common with other.
 	/// Uses a bloom filter for a fast pre-check before the exact intersection.
 	pub fn is_disjoint_readset_bloom(&self, other: &HashSet<Bytes>, bloom: &BloomFilter) -> bool {
@@ -54,7 +73,7 @@ impl Commit {
 		}
 		// Check writeset keys against the bloom filter first
 		let mut any_possible = false;
-		for key in self.writeset.keys() {
+		for key in self.keys.iter() {
 			if bloom.may_contain(key) {
 				any_possible = true;
 				break;
@@ -75,10 +94,10 @@ impl Commit {
 		// Check if the readset is not empty
 		if !other.is_empty() {
 			// Choose iteration direction based on size to minimize iterations
-			if other.len() < self.writeset.len() {
+			if other.len() < self.keys.len() {
 				// Check if any key in readset exists in the writeset
 				for key in other.iter() {
-					if self.writeset.contains_key(key) {
+					if self.contains_key(key) {
 						// Log the error for debug purposes
 						#[cfg(debug_assertions)]
 						debug!(target: LOG_TARGET_CONFLICTS, "KeyReadConflict involving {:?}", key);
@@ -87,7 +106,7 @@ impl Commit {
 				}
 			} else {
 				// Check if any key in writeset exists in the readset
-				for key in self.writeset.keys() {
+				for key in self.keys.iter() {
 					if other.contains(key) {
 						// Log the error for debug purposes
 						#[cfg(debug_assertions)]
@@ -106,12 +125,18 @@ impl Commit {
 	/// exact sorted merge.
 	pub fn is_disjoint_writeset_bloom(&self, other: &Arc<Commit>) -> bool {
 		// Fast path: check if the key ranges overlap at all
-		if self.max_key < other.min_key || other.max_key < self.min_key {
-			return true;
+		match (self.min_key(), self.max_key(), other.min_key(), other.max_key()) {
+			(Some(self_min), Some(self_max), Some(other_min), Some(other_max)) => {
+				if self_max < other_min || other_max < self_min {
+					return true;
+				}
+			}
+			// An empty writeset cannot conflict
+			_ => return true,
 		}
 		// Check our writeset keys against the other's bloom filter
 		let mut any_possible = false;
-		for key in self.writeset.keys() {
+		for key in self.keys.iter() {
 			if other.writeset_bloom.may_contain(key) {
 				any_possible = true;
 				break;
@@ -130,14 +155,18 @@ impl Commit {
 	/// check before iterating writeset keys for scan conflict detection.
 	pub fn may_overlap_range(&self, range_start: &Bytes, range_end: &Bytes) -> bool {
 		// Check if the writeset key range overlaps the scan range
-		self.min_key < *range_end && self.max_key >= *range_start
+		match (self.min_key(), self.max_key()) {
+			(Some(min_key), Some(max_key)) => min_key < range_end && max_key >= range_start,
+			// An empty writeset cannot overlap any range
+			_ => false,
+		}
 	}
 
 	/// Returns true if self has no elements in common with other
 	pub fn is_disjoint_writeset(&self, other: &Arc<Commit>) -> bool {
 		// Create a key iterator for each writeset
-		let mut a = self.writeset.keys();
-		let mut b = other.writeset.keys();
+		let mut a = self.keys.iter();
+		let mut b = other.keys.iter();
 		// Move to the next value in each iterator
 		let mut next_a = a.next();
 		let mut next_b = b.next();

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -945,16 +945,16 @@ impl TransactionInner {
 		for key in writeset.keys() {
 			writeset_bloom.insert(key);
 		}
-		// Extract the min and max keys from the writeset
-		let min_key = writeset.keys().next().cloned().unwrap_or_default();
-		let max_key = writeset.keys().next_back().cloned().unwrap_or_default();
+		// Collect the sorted writeset keys for conflict detection. The
+		// commit queue stores keys only: its entries outlive the merge
+		// queue entry (they are trimmed later by the cleanup worker),
+		// and storing the values would pin them in memory until then.
+		let keys = writeset.keys().cloned().collect();
 		// Insert this transaction into the commit queue
 		let (version, entry) = self.atomic_commit(Commit {
-			writeset: writeset.clone(),
+			keys,
 			id: self.database.transaction_queue_id.fetch_add(1, Ordering::AcqRel) + 1,
 			writeset_bloom,
-			min_key,
-			max_key,
 		});
 		// Check wether we should check reads conflicts on commit
 		if self.mode >= IsolationLevel::SnapshotIsolation {
@@ -1010,7 +1010,7 @@ impl TransactionInner {
 					// Only iterate writeset keys if ranges may overlap
 					if scan_overlap {
 						// A previous transaction has conflicts against scans
-						for k in tx.value().writeset.keys() {
+						for k in tx.value().keys.iter() {
 							// Check if this key may be within a scan range
 							if let Some(entry) = self.scanset.range::<Bytes, _>(..=k).next_back() {
 								// Check if the range includes this key (load from ArcSwap)


### PR DESCRIPTION
## Problem

Commit queue entries held the full writeset (`Arc<BTreeMap<Bytes, Option<Bytes>>>`), but conflict detection only ever inspects keys — the bloom filter, the min/max bounds, key iteration, and key membership. The values are only needed by the merge queue entry, which is removed as soon as the commit is applied, while the commit queue entry lives on until the background cleanup worker trims it below the earliest active transaction. Sharing the writeset `Arc` between both queues therefore pinned every committed value buffer (and the `BTreeMap` structure) in memory for the whole trim window.

Under many concurrent transactions, retained memory scales with commit rate × writeset size × trim latency (up to `cleanup_interval` plus the earliest-active-reader lag), which shows up as OOM at smaller dataset sizes than expected when benchmarking with high commit throughput.

## Change

- `Commit` now stores a sorted `Vec<Bytes>` of the writeset keys plus the existing bloom filter, so writeset values and map structure are released as soon as the merge queue entry is removed at the end of commit.
- The stored `min_key`/`max_key` fields are replaced by accessors reading the ends of the sorted key vector.
- Key membership checks use binary search on the sorted vector, and the exact write-write disjointness check merges two sorted slices instead of two `BTreeMap` key iterators — contiguous iteration instead of tree pointer chasing, so conflict checks should be slightly faster as well.
- An empty writeset now reports no overlap in `may_overlap_range`/`is_disjoint_writeset_bloom` (previously the default-empty min/max keys could claim overlap). This case is unreachable in the real commit path, which returns early on an empty writeset — only `bench_internals` could construct one.

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets` are clean
- Full test suite passes (28 suites, including the write/read/scan conflict detection tests)