### PR TITLE
fix: trim commit queue to current commit id when idle

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -207,17 +207,15 @@ impl Database {
 
 	/// Manually perform transaction queue cleanup.
 	///
+	/// This trims commit queue entries below the earliest active
+	/// transaction's commit snapshot — or, when no transaction is
+	/// registered, below the current commit id — so an idle database
+	/// releases the whole queue rather than pinning it at its peak.
+	///
 	/// This should be called when automatic cleanup is disabled via
 	/// [`DatabaseOptions::enable_cleanup`].
 	pub fn run_cleanup(&self) {
-		// Use `u64::MAX` as the "no readers" fallback to preserve the
-		// original semantics (trim nothing when nothing is registered).
-		let oldest = self.earliest_active_commit(u64::MAX);
-		if oldest != u64::MAX {
-			self.transaction_commit_queue.range(..oldest).for_each(|e| {
-				e.remove();
-			});
-		}
+		self.inner.run_cleanup_inner();
 	}
 
 	/// Manually perform garbage collection of stale record versions.
@@ -309,13 +307,7 @@ impl Database {
 						break;
 					}
 					// Clean up the transaction commit queue
-					let oldest = db.earliest_active_commit(u64::MAX);
-					// Ensure the oldest value is not the max
-					if oldest != u64::MAX {
-						db.transaction_commit_queue.range(..oldest).for_each(|e| {
-							e.remove();
-						});
-					}
+					db.run_cleanup_inner();
 				}
 			});
 			// Store and track the thread handle

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -135,6 +135,33 @@ impl Inner {
 		earliest_active(&self.counter_by_commit, fallback)
 	}
 
+	/// Trim the transaction commit queue below the earliest active
+	/// transaction's commit snapshot, or below the current commit id when
+	/// no transaction is registered at all.
+	///
+	/// Commit queue entries are only ever read by conflict detection,
+	/// which scans `(tx.commit, version)` — strictly above the committing
+	/// transaction's registered snapshot — so entries at or below every
+	/// registered snapshot are unreachable.
+	///
+	/// The idle fallback is safe against concurrent registration because
+	/// the fallback is loaded from `transaction_commit_id` *before* the
+	/// counter map is scanned: a registering transaction that the scan
+	/// misses validates `transaction_commit_id` against its snapshot
+	/// *after* publishing its counter (see `register_counter`), so by
+	/// monotonicity of the commit id its snapshot is `>=` our fallback,
+	/// and its conflict window `(snapshot, ..)` is untouched by the trim.
+	pub(crate) fn run_cleanup_inner(&self) {
+		// Load the idle fallback BEFORE scanning the counter map (see above)
+		let fallback = self.transaction_commit_id.load(Ordering::SeqCst);
+		// Find the earliest registered commit snapshot, if any
+		let oldest = self.earliest_active_commit(fallback);
+		// Trim all commit queue entries below the watermark
+		self.transaction_commit_queue.range(..oldest).for_each(|e| {
+			e.remove();
+		});
+	}
+
 	/// Compute the next `cleanup_ts`, publishing it into `gc_floor` so
 	/// concurrent `register_counter` retries any reader whose snapshot
 	/// is below it, then re-scan to bound by any newly-arrived reader.

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -4537,6 +4537,58 @@ mod tests {
 	}
 
 	#[test]
+	fn test_cleanup_trims_commit_queue_when_idle() {
+		use crate::DatabaseOptions;
+
+		// Disable all background workers so the commit queue is only
+		// ever trimmed by the manual cleanup calls in this test
+		let db = Database::new_with_options(DatabaseOptions::default().with_all_workers_disabled());
+
+		// Commit a number of transactions
+		for i in 0..10 {
+			let mut tx = db.transaction(true);
+			tx.set(format!("key_{i}"), "value").unwrap();
+			tx.commit().unwrap();
+		}
+
+		// Every commit is still queued for conflict detection
+		assert_eq!(db.transaction_commit_queue.len(), 10);
+
+		// With no transaction registered, cleanup trims everything below
+		// the current commit id, leaving only the most recent entry
+		db.run_cleanup();
+		assert_eq!(db.transaction_commit_queue.len(), 1);
+
+		// The datastore itself is untouched by the queue trim. Scope the
+		// reader so it is dropped: counters are released on Drop, not on
+		// cancel, and a live reader pins the cleanup watermark below.
+		{
+			let mut tx = db.transaction(false);
+			for i in 0..10 {
+				assert!(tx.exists(format!("key_{i}")).unwrap());
+			}
+			tx.cancel().unwrap();
+		}
+
+		// An active transaction pins the queue at its own commit
+		// snapshot, so entries in its conflict window must survive
+		let pin = db.transaction(false);
+		for i in 0..5 {
+			let mut tx = db.transaction(true);
+			tx.set(format!("extra_{i}"), "value").unwrap();
+			tx.commit().unwrap();
+		}
+		assert_eq!(db.transaction_commit_queue.len(), 6);
+		db.run_cleanup();
+		assert_eq!(db.transaction_commit_queue.len(), 6);
+
+		// Once the pinning transaction is dropped, cleanup trims fully
+		drop(pin);
+		db.run_cleanup();
+		assert_eq!(db.transaction_commit_queue.len(), 1);
+	}
+
+	#[test]
 	fn test_concurrent_write_read_merge_queue_race() {
 		// This test specifically targets the race condition where readers check
 		// is_removed() on merge queue entries and miss data that's being merged.


### PR DESCRIPTION
## Summary

- `run_cleanup()` and the background cleanup worker used `u64::MAX` as the "no active readers" fallback when computing the trim watermark for `transaction_commit_queue`. That preserved the pre-existing behavior of trimming nothing when idle, but it means an idle database never releases the queue below whatever size it peaked at.
- Since inline GC was removed from the commit path (to close a snapshot-registration race — see the comment at `tx.rs` around the commit loop), reclamation now depends more heavily on these cleanup passes, so this stale fallback has a bigger memory impact than before.
- Changed the fallback to `transaction_commit_id` (the current commit id) instead of `u64::MAX`. Conflict detection only ever scans strictly above a transaction's registered commit snapshot, so entries at or below every registered snapshot — or, when nothing is registered, at or below the current commit id — are unreachable and safe to remove.
- Extracted the shared trim logic into `Inner::run_cleanup_inner()` so `Database::run_cleanup()` and the background cleanup worker no longer duplicate it.

## Why it's safe

The fallback is loaded from `transaction_commit_id` *before* the counter map is scanned. A transaction that the scan misses must validate `transaction_commit_id` against its own snapshot *after* publishing its counter (`register_counter`), so by monotonicity of the commit id, any such transaction's snapshot is `>=` our fallback — its conflict window is untouched by the trim. This is documented inline on `run_cleanup_inner`.

## Test plan

- [x] New unit test `test_cleanup_trims_commit_queue_when_idle` in `src/tx.rs`: verifies idle cleanup trims the queue to a single entry, an active transaction pins its conflict window against trimming, and dropping that transaction allows full trimming again.
- [x] `cargo test` — all 28 test binaries pass (130 lib tests + all integration suites, including `tests/gc.rs`).
- [x] `cargo fmt --check` clean, `cargo clippy --all-targets` clean.