### PR TITLE
Redesign the MVCC engine around a logical clock with eager commit-time GC

### DIFF
--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -964,17 +964,18 @@ fn bench_keys_for_each(c: &mut Criterion) {
 // GC benchmarks: incremental dirty-key GC vs full scan
 // ---------------------------------------------------------------------------
 
-// Sparse dirty keys: large datastore, only a small number of keys updated.
-// Dirty-key GC should be much faster than a full scan because it only visits
-// the keys that were modified, while the full scan iterates the entire
-// datastore.
-fn bench_gc_sparse_dirty(c: &mut Criterion) {
-	let mut group = c.benchmark_group("gc_sparse_dirty");
-	// Fixed number of dirty keys
-	let dirty_count = 100;
+// Safety-net full scan: large datastore with a departed reader's pinned
+// garbage on a subset of keys. Measures the cost of the periodic sweep,
+// which grows linearly with total keys regardless of garbage volume.
+fn bench_gc_full_scan(c: &mut Criterion) {
+	let mut group = c.benchmark_group("gc_full_scan");
+	// Fixed number of keys carrying stale versions
+	let stale_count = 100;
 
 	for total_keys in [1_000, 10_000, 100_000].iter() {
 		// Setup helper: create datastore, then overwrite a small subset
+		// while a reader pins the old versions, then drop the reader —
+		// exactly the garbage shape only the safety net can reclaim.
 		let setup = || {
 			let db =
 				Database::new_with_options(DatabaseOptions::default().with_all_workers_disabled());
@@ -988,36 +989,24 @@ fn bench_gc_sparse_dirty(c: &mut Criterion) {
 				}
 				tx.commit().unwrap();
 			}
-			// Overwrite a small fixed number of keys to create stale versions
+			// Pin the initial versions with a reader while overwriting
 			{
+				let reader = db.transaction(false);
 				let mut tx = db.transaction(true);
-				for i in 0..dirty_count {
+				for i in 0..stale_count {
 					let key = generate_sequential_key(i);
 					let value = Bytes::from(format!("updated_{:08}", i).into_bytes());
 					tx.set(key, value).unwrap();
 				}
 				tx.commit().unwrap();
+				drop(reader);
 			}
 			db
 		};
 
-		// Dirty-key GC: should stay roughly constant regardless of total keys
+		// Full-scan GC: grows linearly with total keys
 		group.bench_function(
-			BenchmarkId::new("dirty_gc", format!("{}total_{}dirty", total_keys, dirty_count)),
-			|b| {
-				b.iter_batched(
-					setup,
-					|db| {
-						db.run_gc_dirty();
-					},
-					criterion::BatchSize::LargeInput,
-				)
-			},
-		);
-
-		// Full-scan GC: should grow linearly with total keys
-		group.bench_function(
-			BenchmarkId::new("full_gc", format!("{}total_{}dirty", total_keys, dirty_count)),
+			BenchmarkId::new("full_gc", format!("{}total_{}stale", total_keys, stale_count)),
 			|b| {
 				b.iter_batched(
 					setup,
@@ -1032,69 +1021,39 @@ fn bench_gc_sparse_dirty(c: &mut Criterion) {
 	group.finish();
 }
 
-// Scaling with dirty ratio: fixed datastore size, varying the fraction of
-// keys that have been updated. Dirty-key GC should scale proportionally to
-// the number of dirty keys, while full scan stays constant.
-fn bench_gc_dirty_ratio(c: &mut Criterion) {
-	let mut group = c.benchmark_group("gc_dirty_ratio");
-	// Fixed datastore size
-	let total_keys = 10_000;
+// Inline commit-time GC overhead: the per-commit cost of the watermark
+// slot scan plus the chain trim under the already-held write lock. The
+// hot-key arm overwrites a single key per commit (worst-case relative
+// overhead); the wide arm amortises the scan across a large writeset.
+fn bench_commit_inline_gc(c: &mut Criterion) {
+	let mut group = c.benchmark_group("commit_inline_gc");
 
-	for dirty_pct in [1, 10, 50].iter() {
-		let dirty_count = total_keys * dirty_pct / 100;
+	// Hot key: repeated single-key overwrite commits
+	group.bench_function("hot_key_overwrite", |b| {
+		let db = Database::new_with_options(DatabaseOptions::default().with_all_workers_disabled());
+		let key = generate_sequential_key(0);
+		let value = generate_sequential_value(0, 100);
+		b.iter(|| {
+			let mut tx = db.transaction(true);
+			tx.set(key.clone(), value.clone()).unwrap();
+			tx.commit().unwrap();
+		})
+	});
 
-		// Setup helper
-		let setup = || {
-			let db =
-				Database::new_with_options(DatabaseOptions::default().with_all_workers_disabled());
-			// Insert initial data
-			{
-				let mut tx = db.transaction(true);
-				for i in 0..total_keys {
-					let key = generate_sequential_key(i);
-					let value = generate_sequential_value(i, 100);
-					tx.put(key, value).unwrap();
-				}
-				tx.commit().unwrap();
+	// Wide writeset: one commit overwriting many keys
+	group.bench_function("wide_writeset_1000", |b| {
+		let db = Database::new_with_options(DatabaseOptions::default().with_all_workers_disabled());
+		let keys: Vec<Bytes> = (0..1_000).map(generate_sequential_key).collect();
+		let value = generate_sequential_value(0, 100);
+		b.iter(|| {
+			let mut tx = db.transaction(true);
+			for key in keys.iter() {
+				tx.set(key.clone(), value.clone()).unwrap();
 			}
-			// Overwrite a percentage of keys
-			{
-				let mut tx = db.transaction(true);
-				for i in 0..dirty_count {
-					let key = generate_sequential_key(i);
-					let value = Bytes::from(format!("updated_{:08}", i).into_bytes());
-					tx.set(key, value).unwrap();
-				}
-				tx.commit().unwrap();
-			}
-			db
-		};
+			tx.commit().unwrap();
+		})
+	});
 
-		// Dirty-key GC
-		group.bench_function(
-			BenchmarkId::new("dirty_gc", format!("{}pct_dirty", dirty_pct)),
-			|b| {
-				b.iter_batched(
-					setup,
-					|db| {
-						db.run_gc_dirty();
-					},
-					criterion::BatchSize::LargeInput,
-				)
-			},
-		);
-
-		// Full-scan GC
-		group.bench_function(BenchmarkId::new("full_gc", format!("{}pct_dirty", dirty_pct)), |b| {
-			b.iter_batched(
-				setup,
-				|db| {
-					db.run_gc();
-				},
-				criterion::BatchSize::LargeInput,
-			)
-		});
-	}
 	group.finish();
 }
 
@@ -1444,8 +1403,8 @@ criterion_group!(
 	optimization_benchmarks,
 	bench_scan_for_each,
 	bench_keys_for_each,
-	bench_gc_sparse_dirty,
-	bench_gc_dirty_ratio,
+	bench_gc_full_scan,
+	bench_commit_inline_gc,
 	bench_readset_bloom_impact,
 	bench_readset_bloom_conflict_path,
 	bench_writeset_bloom_impact,

--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -22,6 +22,7 @@ use crate::queue::{Commit, Merge};
 use bytes::Bytes;
 use papaya::HashSet;
 use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 /// A prepared readset conflict scenario for benchmarking
@@ -52,6 +53,7 @@ impl ReadsetConflictScenario {
 			id: 1,
 			keys,
 			writeset_bloom,
+			merge_version: AtomicU64::new(0),
 		});
 		// Build the readset and bloom filter
 		let readset = HashSet::new();
@@ -125,6 +127,7 @@ impl WritesetConflictScenario {
 			id,
 			keys,
 			writeset_bloom,
+			merge_version: AtomicU64::new(0),
 		}
 	}
 }

--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -37,10 +37,11 @@ pub struct ReadsetConflictScenario {
 impl ReadsetConflictScenario {
 	/// Build a scenario with the given writeset and readset keys
 	pub fn new(writeset_keys: &[Bytes], readset_keys: &[Bytes]) -> Self {
-		// Build the sorted writeset keys
-		let mut keys = writeset_keys.to_vec();
-		keys.sort();
-		keys.dedup();
+		// Build the sorted writeset key list (inputs may be unsorted)
+		let mut ws: Vec<Bytes> = writeset_keys.to_vec();
+		ws.sort();
+		ws.dedup();
+		let keys: Arc<[Bytes]> = ws.into();
 		// Build the writeset bloom filter
 		let mut writeset_bloom = BloomFilter::new();
 		for k in keys.iter() {
@@ -108,11 +109,12 @@ impl WritesetConflictScenario {
 	}
 
 	/// Build a Commit entry from a set of keys
-	fn build_commit(keys: &[Bytes], id: u64) -> Commit {
-		// Build the sorted writeset keys
-		let mut keys = keys.to_vec();
-		keys.sort();
-		keys.dedup();
+	fn build_commit(input: &[Bytes], id: u64) -> Commit {
+		// Build the sorted writeset key list (inputs may be unsorted)
+		let mut ws: Vec<Bytes> = input.to_vec();
+		ws.sort();
+		ws.dedup();
+		let keys: Arc<[Bytes]> = ws.into();
 		// Build the writeset bloom filter
 		let mut writeset_bloom = BloomFilter::new();
 		for k in keys.iter() {

--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -153,7 +153,6 @@ impl MergeQueueScenario {
 				ws.insert(key, Some(Bytes::from_static(b"v")));
 			}
 			sources.push(Arc::new(Merge {
-				id: i as u64,
 				writeset: Arc::new(ws),
 			}));
 		}

--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -22,7 +22,7 @@ use crate::queue::{Commit, Merge};
 use bytes::Bytes;
 use papaya::HashSet;
 use std::collections::BTreeMap;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
 
 /// A prepared readset conflict scenario for benchmarking
@@ -50,7 +50,6 @@ impl ReadsetConflictScenario {
 		}
 		// Build the commit entry
 		let commit = Arc::new(Commit {
-			id: 1,
 			keys,
 			writeset_bloom,
 			merge_version: AtomicU64::new(0),
@@ -95,8 +94,8 @@ impl WritesetConflictScenario {
 	/// Build a scenario with two writesets
 	pub fn new(committed_keys: &[Bytes], current_keys: &[Bytes]) -> Self {
 		Self {
-			committed: Arc::new(Self::build_commit(committed_keys, 1)),
-			current: Arc::new(Self::build_commit(current_keys, 2)),
+			committed: Arc::new(Self::build_commit(committed_keys)),
+			current: Arc::new(Self::build_commit(current_keys)),
 		}
 	}
 
@@ -111,7 +110,7 @@ impl WritesetConflictScenario {
 	}
 
 	/// Build a Commit entry from a set of keys
-	fn build_commit(input: &[Bytes], id: u64) -> Commit {
+	fn build_commit(input: &[Bytes]) -> Commit {
 		// Build the sorted writeset key list (inputs may be unsorted)
 		let mut ws: Vec<Bytes> = input.to_vec();
 		ws.sort();
@@ -124,7 +123,6 @@ impl WritesetConflictScenario {
 		}
 		// Build the commit entry
 		Commit {
-			id,
 			keys,
 			writeset_bloom,
 			merge_version: AtomicU64::new(0),
@@ -157,6 +155,7 @@ impl MergeQueueScenario {
 			}
 			sources.push(Arc::new(Merge {
 				writeset: Arc::new(ws),
+				applied: AtomicBool::new(false),
 			}));
 		}
 		let beg = Bytes::from(b"key_00000000".to_vec());

--- a/src/db.rs
+++ b/src/db.rs
@@ -17,9 +17,7 @@
 use crate::inner::Inner;
 use crate::options::DatabaseOptions;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::options::{
-	DEFAULT_CLEANUP_INTERVAL, DEFAULT_GC_FULL_SCAN_FREQUENCY, DEFAULT_GC_INTERVAL,
-};
+use crate::options::{DEFAULT_CLEANUP_INTERVAL, DEFAULT_GC_INTERVAL};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::persistence::Persistence;
 use crate::pool::Pool;
@@ -47,9 +45,6 @@ pub struct Database {
 	/// Interval used by the garbage collector thread
 	#[cfg(not(target_arch = "wasm32"))]
 	gc_interval: Duration,
-	/// Number of gc wake-ups between full datastore scans
-	#[cfg(not(target_arch = "wasm32"))]
-	gc_full_scan_frequency: u64,
 	/// Interval used by the cleanup thread
 	#[cfg(not(target_arch = "wasm32"))]
 	cleanup_interval: Duration,
@@ -66,8 +61,6 @@ impl Default for Database {
 			persistence: None,
 			#[cfg(not(target_arch = "wasm32"))]
 			gc_interval: DEFAULT_GC_INTERVAL,
-			#[cfg(not(target_arch = "wasm32"))]
-			gc_full_scan_frequency: DEFAULT_GC_FULL_SCAN_FREQUENCY,
 			#[cfg(not(target_arch = "wasm32"))]
 			cleanup_interval: DEFAULT_CLEANUP_INTERVAL,
 		}
@@ -109,8 +102,6 @@ impl Database {
 			#[cfg(not(target_arch = "wasm32"))]
 			gc_interval: opts.gc_interval,
 			#[cfg(not(target_arch = "wasm32"))]
-			gc_full_scan_frequency: opts.gc_full_scan_frequency,
-			#[cfg(not(target_arch = "wasm32"))]
 			cleanup_interval: opts.cleanup_interval,
 		};
 		// Start background tasks when enabled
@@ -149,7 +140,6 @@ impl Database {
 			pool,
 			persistence: Some(persist),
 			gc_interval: opts.gc_interval,
-			gc_full_scan_frequency: opts.gc_full_scan_frequency,
 			cleanup_interval: opts.cleanup_interval,
 		};
 		// Start background tasks when enabled
@@ -187,35 +177,20 @@ impl Database {
 		self.inner.cleanup_commit_queue();
 	}
 
-	/// Manually perform garbage collection of stale record versions.
+	/// Manually perform a full garbage collection sweep.
 	///
-	/// This function first processes keys that are known to have stale
-	/// versions (tracked during transaction commits), then performs a full
-	/// datastore scan to clean up any remaining old versions. Note that
-	/// inline garbage collection happens automatically during transaction
-	/// commits, but only for keys being modified. This function is useful
-	/// for cleaning up stale versions on keys that haven't been recently
-	/// modified, or when automatic background GC is disabled via
-	/// [`DatabaseOptions::enable_gc`].
+	/// Steady-state reclamation happens inline at commit time: every
+	/// commit trims the chains it touches down to the current watermark.
+	/// This sweep is the safety net for garbage which no future commit
+	/// will visit — versions pinned by a since-departed reader on a key
+	/// that is never written again. It is useful when automatic
+	/// background GC is disabled via [`DatabaseOptions::enable_gc`], for
+	/// example on wasm targets, which have no background threads.
 	pub fn run_gc(&self) {
 		// Skip the pass entirely when registrations are in flight
 		if let Some(cleanup_ts) = self.compute_cleanup_ts() {
-			// First, process keys known to have stale versions
-			self.run_gc_dirty_inner(cleanup_ts);
-			// Then perform a full datastore scan for any remaining stale versions
+			// Perform a full datastore scan for stale versions
 			self.run_gc_full(cleanup_ts);
-		}
-	}
-
-	/// Process only dirty keys that are known to have stale versions.
-	///
-	/// This is a lightweight alternative to a full datastore scan, useful
-	/// for frequent incremental cleanup between full GC passes.
-	pub fn run_gc_dirty(&self) {
-		// Skip the pass entirely when registrations are in flight
-		if let Some(cleanup_ts) = self.compute_cleanup_ts() {
-			// Process dirty keys
-			self.run_gc_dirty_inner(cleanup_ts);
 		}
 	}
 
@@ -297,11 +272,12 @@ impl Database {
 		if db.garbage_collection_handle.read().is_none() {
 			// Get the specified interval
 			let interval = self.gc_interval;
-			// Full scan runs every Nth wake cycle; dirty-key pass runs every cycle
-			let full_scan_frequency = self.gc_full_scan_frequency.max(1);
-			// Spawn a new thread to handle periodic garbage collection
+			// Spawn a new thread to handle the periodic safety-net sweep.
+			// Steady-state reclamation happens inline at commit time, so
+			// this low-frequency full scan only collects garbage which no
+			// future commit will visit: versions pinned by a departed
+			// reader on a key that is never written again.
 			let handle = std::thread::spawn(move || {
-				let mut cycle: u64 = 0;
 				// Check whether the garbage collection process is enabled
 				while db.background_threads_enabled.load(Ordering::Relaxed) {
 					// Wait for a specified time interval
@@ -319,13 +295,8 @@ impl Database {
 					let Some(cleanup_ts) = db.compute_cleanup_ts() else {
 						continue;
 					};
-					// Drain the dirty-key queue every cycle (incremental GC).
-					db.run_gc_dirty_inner(cleanup_ts);
-					// Periodically do a full datastore scan.
-					cycle += 1;
-					if cycle.is_multiple_of(full_scan_frequency) {
-						db.run_gc_full(cleanup_ts);
-					}
+					// Perform the full datastore scan.
+					db.run_gc_full(cleanup_ts);
 				}
 			});
 			// Store and track the thread handle
@@ -1309,6 +1280,89 @@ mod tests {
 			db.commit_watermark.load(Ordering::SeqCst),
 			db.transaction_commit_id.load(Ordering::SeqCst)
 		);
+	}
+
+	#[test]
+	fn inline_gc_trims_hot_key_at_commit() {
+		// The deterministic memory bound: with no readers pinning older
+		// versions, every commit trims the chain it touches down to the
+		// latest version — no background worker, no sleeps, and the same
+		// behaviour on wasm targets which have no threads at all.
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		for i in 0..100 {
+			let mut tx = db.transaction(true);
+			tx.set("hotkey", format!("v{i}")).unwrap();
+			tx.commit().unwrap();
+		}
+		let entry = db.datastore.get(b"hotkey".as_slice()).expect("hotkey missing");
+		let guard = entry.value().read();
+		let chain = guard.as_slice();
+		assert_eq!(chain.len(), 1, "inline GC should trim superseded versions at commit");
+		assert_eq!(chain[0].value.as_deref(), Some(b"v99" as &[u8]));
+	}
+
+	#[test]
+	fn inline_gc_unlinks_deleted_key_at_commit() {
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		// Scoped: a shadowed-but-live transaction would keep its slot
+		// registered and pin the delete's watermark below the tombstone
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "value").unwrap();
+			tx.commit().unwrap();
+		}
+		assert!(db.datastore.get(b"key".as_slice()).is_some());
+		// With no readers below the delete, the tombstone collapses the
+		// chain at commit time and the node is unlinked immediately.
+		{
+			let mut tx = db.transaction(true);
+			tx.del("key").unwrap();
+			tx.commit().unwrap();
+		}
+		assert!(
+			db.datastore.get(b"key".as_slice()).is_none(),
+			"a delete with no readers should unlink the node at commit"
+		);
+	}
+
+	#[test]
+	fn safety_net_reclaims_after_reader_departs() {
+		// Garbage pinned by a reader on a key that is never written again
+		// is invisible to inline commit-time GC: this is exactly the
+		// scenario that justifies keeping the background full-scan sweep.
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "v0").unwrap();
+			tx.commit().unwrap();
+		}
+		// Pin the initial version while overwriting the key
+		let reader = db.transaction(false);
+		for i in 1..=50 {
+			let mut tx = db.transaction(true);
+			tx.set("key", format!("v{i}")).unwrap();
+			tx.commit().unwrap();
+		}
+		{
+			let entry = db.datastore.get(b"key".as_slice()).expect("key missing");
+			let guard = entry.value().read();
+			assert!(guard.as_slice().len() > 1, "the pinned reader should retain history");
+		}
+		// Drop the reader; no further commits touch the key, so only the
+		// manual (or background) full sweep can reclaim the garbage
+		drop(reader);
+		db.run_gc();
+		let entry = db.datastore.get(b"key".as_slice()).expect("key missing");
+		let guard = entry.value().read();
+		let chain = guard.as_slice();
+		assert_eq!(chain.len(), 1, "the safety-net sweep should reclaim departed-reader garbage");
+		assert_eq!(chain[0].value.as_deref(), Some(b"v50" as &[u8]));
 	}
 
 	#[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1189,10 +1189,16 @@ mod tests {
 			crate::DatabaseOptions::default().with_all_workers_disabled(),
 		);
 		// Simulate a datastore seeded from files written by a release
-		// which minted wall-clock nanosecond versions.
+		// which minted wall-clock nanosecond versions. Real persistence
+		// load seeds all three counters together (see
+		// `Persistence::load`); seeding only the clock and leaving
+		// `merge_retire_id` at its unseeded default would make the
+		// opportunistic retirement walk cross an astronomical gap one
+		// step at a time.
 		let seed = 1_700_000_000_000_000_000u64;
 		db.oracle.alloc.store(seed, std::sync::atomic::Ordering::SeqCst);
 		db.oracle.timestamp.store(seed, std::sync::atomic::Ordering::SeqCst);
+		db.merge_retire_id.store(seed, std::sync::atomic::Ordering::SeqCst);
 		let mut tx = db.transaction(true);
 		tx.set("key", "value").unwrap();
 		tx.commit().unwrap();

--- a/src/db.rs
+++ b/src/db.rs
@@ -198,11 +198,13 @@ impl Database {
 	/// modified, or when automatic background GC is disabled via
 	/// [`DatabaseOptions::enable_gc`].
 	pub fn run_gc(&self) {
-		let cleanup_ts = self.compute_cleanup_ts();
-		// First, process keys known to have stale versions
-		self.run_gc_dirty_inner(cleanup_ts);
-		// Then perform a full datastore scan for any remaining stale versions
-		self.run_gc_full(cleanup_ts);
+		// Skip the pass entirely when registrations are in flight
+		if let Some(cleanup_ts) = self.compute_cleanup_ts() {
+			// First, process keys known to have stale versions
+			self.run_gc_dirty_inner(cleanup_ts);
+			// Then perform a full datastore scan for any remaining stale versions
+			self.run_gc_full(cleanup_ts);
+		}
 	}
 
 	/// Process only dirty keys that are known to have stale versions.
@@ -210,9 +212,11 @@ impl Database {
 	/// This is a lightweight alternative to a full datastore scan, useful
 	/// for frequent incremental cleanup between full GC passes.
 	pub fn run_gc_dirty(&self) {
-		let cleanup_ts = self.compute_cleanup_ts();
-		// Process dirty keys
-		self.run_gc_dirty_inner(cleanup_ts);
+		// Skip the pass entirely when registrations are in flight
+		if let Some(cleanup_ts) = self.compute_cleanup_ts() {
+			// Process dirty keys
+			self.run_gc_dirty_inner(cleanup_ts);
+		}
 	}
 
 	/// Shutdown the datastore, waiting for background threads to exit
@@ -306,15 +310,15 @@ impl Database {
 					if !db.background_threads_enabled.load(Ordering::Relaxed) {
 						break;
 					}
-					// Compute the next cleanup_ts. This publishes the
-					// proposed value to `gc_floor` and re-scans the
-					// counter map so any reader landing in the
-					// publish-and-scan window is either visible to us
-					// (and bounds the final cleanup_ts) or retries from
-					// a fresh clock read above the floor. The proposed
-					// value is bounded by the published logical clock,
-					// so an idle database can never lock readers out.
-					let cleanup_ts = db.compute_cleanup_ts();
+					// Compute the next cleanup_ts by scanning the slot
+					// map: any transaction registering concurrently is
+					// either visible to the scan (and bounds the final
+					// cleanup_ts) or pins after it (and takes a snapshot
+					// at or above the clock bound). A pass is skipped
+					// entirely while a registration is pinning.
+					let Some(cleanup_ts) = db.compute_cleanup_ts() else {
+						continue;
+					};
 					// Drain the dirty-key queue every cycle (incremental GC).
 					db.run_gc_dirty_inner(cleanup_ts);
 					// Periodically do a full datastore scan.
@@ -1229,5 +1233,165 @@ mod tests {
 		let mut tx = db.transaction(false);
 		assert_eq!(tx.get("key").unwrap().as_deref(), Some(b"value" as &[u8]));
 		tx.cancel().unwrap();
+	}
+
+	#[test]
+	fn slot_lifecycle() {
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		assert_eq!(db.readers.len(), 0);
+		let tx = db.transaction(false);
+		assert_eq!(db.readers.len(), 1);
+		let first_id = *db.readers.front().unwrap().key();
+		drop(tx);
+		assert_eq!(db.readers.len(), 0);
+		// Pool reuse re-pins the retained slot under a fresh id
+		let tx = db.transaction(false);
+		assert_eq!(db.readers.len(), 1);
+		let second_id = *db.readers.front().unwrap().key();
+		assert!(second_id > first_id);
+		drop(tx);
+		assert_eq!(db.readers.len(), 0);
+	}
+
+	#[test]
+	fn watermark_conservative_while_pinning() {
+		use crate::inner::Slot;
+		use std::sync::Arc;
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		// Commit some entries which would otherwise be trimmed
+		for i in 0..5 {
+			let mut tx = db.transaction(true);
+			tx.set(format!("key{i}"), "value").unwrap();
+			tx.commit().unwrap();
+		}
+		// Insert a slot stuck in the pinning state, simulating a
+		// transaction mid-registration
+		db.readers.insert(u64::MAX, Arc::new(Slot::pinning()));
+		// Every sweep must treat the watermark as unknown and skip
+		assert_eq!(db.compute_cleanup_ts(), None);
+		let before = db.transaction_commit_queue.len();
+		db.run_cleanup();
+		assert_eq!(db.transaction_commit_queue.len(), before);
+		// Remove the pinning slot; sweeps proceed again
+		db.readers.remove(&u64::MAX);
+		assert!(db.compute_cleanup_ts().is_some());
+		db.run_cleanup();
+		assert_eq!(db.transaction_commit_queue.len(), 1);
+	}
+
+	#[test]
+	fn commit_watermark_tracks_commits() {
+		use std::sync::atomic::Ordering;
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		for i in 0..5 {
+			let mut tx = db.transaction(true);
+			tx.set(format!("key{i}"), "value").unwrap();
+			tx.commit().unwrap();
+		}
+		// Every commit completed, so the watermark covers all claimed ids
+		assert_eq!(db.commit_watermark.load(Ordering::SeqCst), 5);
+		assert_eq!(db.transaction_commit_id.load(Ordering::SeqCst), 5);
+		// An aborted commit removes its entry, which also counts as
+		// complete: the watermark must still cover the aborted id.
+		let mut tx1 = db.transaction(true);
+		let mut tx2 = db.transaction(true);
+		tx1.set("clash", "one").unwrap();
+		tx2.set("clash", "two").unwrap();
+		tx1.commit().unwrap();
+		assert!(tx2.commit().is_err());
+		assert_eq!(
+			db.commit_watermark.load(Ordering::SeqCst),
+			db.transaction_commit_id.load(Ordering::SeqCst)
+		);
+	}
+
+	#[test]
+	fn pin_then_read_stress() {
+		use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+		use std::sync::Arc;
+		use std::thread;
+		use std::time::{Duration, Instant};
+		// Workers are disabled; a dedicated thread hammers the manual
+		// sweep entry points instead, maximising sweep frequency against
+		// the pin-then-read registration protocol.
+		let db = Arc::new(Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		));
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "v0").unwrap();
+			tx.commit().unwrap();
+		}
+		let stop = Arc::new(AtomicBool::new(false));
+		let none_reads = Arc::new(AtomicUsize::new(0));
+		let total_reads = Arc::new(AtomicUsize::new(0));
+		// Single writer thread keeps overwriting the same key
+		let writer = {
+			let db = Arc::clone(&db);
+			let stop = Arc::clone(&stop);
+			thread::spawn(move || {
+				let mut counter: u64 = 0;
+				while !stop.load(Ordering::Relaxed) {
+					let mut tx = db.transaction(true);
+					tx.set("key", format!("v{counter}")).unwrap();
+					tx.commit().unwrap();
+					counter = counter.wrapping_add(1);
+				}
+			})
+		};
+		// Sweeper thread hammers cleanup and gc continuously
+		let sweeper = {
+			let db = Arc::clone(&db);
+			let stop = Arc::clone(&stop);
+			thread::spawn(move || {
+				while !stop.load(Ordering::Relaxed) {
+					db.run_cleanup();
+					db.run_gc();
+				}
+			})
+		};
+		// Reader threads open many short-lived snapshots
+		let mut readers = Vec::new();
+		for _ in 0..6 {
+			let db = Arc::clone(&db);
+			let stop = Arc::clone(&stop);
+			let none_reads = Arc::clone(&none_reads);
+			let total_reads = Arc::clone(&total_reads);
+			readers.push(thread::spawn(move || {
+				while !stop.load(Ordering::Relaxed) {
+					let mut tx = db.transaction(false);
+					let value = tx.get("key").unwrap();
+					total_reads.fetch_add(1, Ordering::Relaxed);
+					if value.is_none() {
+						none_reads.fetch_add(1, Ordering::Relaxed);
+					}
+					tx.cancel().unwrap();
+				}
+			}));
+		}
+		let started = Instant::now();
+		while started.elapsed() < Duration::from_millis(500) {
+			thread::sleep(Duration::from_millis(10));
+		}
+		stop.store(true, Ordering::Relaxed);
+		writer.join().unwrap();
+		sweeper.join().unwrap();
+		for r in readers {
+			r.join().unwrap();
+		}
+		let nones = none_reads.load(Ordering::Relaxed);
+		let total = total_reads.load(Ordering::Relaxed);
+		assert_eq!(
+			nones, 0,
+			"reader observed `None` for a key that always has a committed \
+			 value ({nones} of {total} reads): the pin-then-read protocol \
+			 failed to protect a registering reader from a sweep"
+		);
 	}
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -311,9 +311,9 @@ impl Database {
 					// counter map so any reader landing in the
 					// publish-and-scan window is either visible to us
 					// (and bounds the final cleanup_ts) or retries from
-					// a fresh oracle read above the floor. The proposed
-					// value is capped at the current oracle so an idle
-					// database does not lock readers out forever.
+					// a fresh clock read above the floor. The proposed
+					// value is bounded by the published logical clock,
+					// so an idle database can never lock readers out.
 					let cleanup_ts = db.compute_cleanup_ts();
 					// Drain the dirty-key queue every cycle (incremental GC).
 					db.run_gc_dirty_inner(cleanup_ts);
@@ -1185,5 +1185,49 @@ mod tests {
 		db.run_cleanup();
 		// With the reader gone the idle fallback applies again
 		assert_eq!(db.transaction_commit_queue.len(), 1);
+	}
+
+	#[test]
+	fn logical_clock_is_dense() {
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		for i in 0..10 {
+			let mut tx = db.transaction(true);
+			tx.set(format!("key{i}"), "value").unwrap();
+			tx.commit().unwrap();
+		}
+		// Merge versions are dense sequential integers: ten commits
+		// publish exactly versions 1 through 10.
+		assert_eq!(db.oracle.timestamp.load(std::sync::atomic::Ordering::SeqCst), 10);
+		let entry = db.datastore.get(b"key0".as_slice()).expect("key0 missing");
+		let guard = entry.value().read();
+		assert_eq!(guard.as_slice()[0].version, 1);
+		let entry = db.datastore.get(b"key9".as_slice()).expect("key9 missing");
+		let guard = entry.value().read();
+		assert_eq!(guard.as_slice()[0].version, 10);
+	}
+
+	#[test]
+	fn logical_clock_continues_above_seed() {
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		// Simulate a datastore seeded from files written by a release
+		// which minted wall-clock nanosecond versions.
+		let seed = 1_700_000_000_000_000_000u64;
+		db.oracle.alloc.store(seed, std::sync::atomic::Ordering::SeqCst);
+		db.oracle.timestamp.store(seed, std::sync::atomic::Ordering::SeqCst);
+		let mut tx = db.transaction(true);
+		tx.set("key", "value").unwrap();
+		tx.commit().unwrap();
+		// The next minted version continues strictly above the seed
+		let entry = db.datastore.get(b"key".as_slice()).expect("key missing");
+		let guard = entry.value().read();
+		assert_eq!(guard.as_slice()[0].version, seed + 1);
+		// And the write is visible to a fresh reader
+		let mut tx = db.transaction(false);
+		assert_eq!(tx.get("key").unwrap().as_deref(), Some(b"value" as &[u8]));
+		tx.cancel().unwrap();
 	}
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -184,7 +184,7 @@ impl Database {
 	/// This should be called when automatic cleanup is disabled via
 	/// [`DatabaseOptions::enable_cleanup`].
 	pub fn run_cleanup(&self) {
-		self.inner.run_cleanup_inner();
+		self.inner.cleanup_commit_queue();
 	}
 
 	/// Manually perform garbage collection of stale record versions.
@@ -276,7 +276,7 @@ impl Database {
 						break;
 					}
 					// Clean up the transaction commit queue
-					db.run_cleanup_inner();
+					db.cleanup_commit_queue();
 				}
 			});
 			// Store and track the thread handle
@@ -1133,5 +1133,57 @@ mod tests {
 		assert_eq!(keys[1].as_ref(), b"c");
 		let res = tx.cancel();
 		assert!(res.is_ok());
+	}
+
+	#[test]
+	fn cleanup_trims_commit_queue_when_idle() {
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		for i in 0..10 {
+			let mut tx = db.transaction(true);
+			tx.set(format!("key{i}"), "value").unwrap();
+			tx.commit().unwrap();
+		}
+		assert_eq!(db.transaction_commit_queue.len(), 10);
+		db.run_cleanup();
+		// With no registered readers the trim bound falls back to the
+		// current commit id: everything below it is unreachable by any
+		// future transaction's conflict window, which starts strictly
+		// above the commit id the transaction registers at. The exclusive
+		// bound leaves exactly the entry at the current commit id.
+		assert_eq!(db.transaction_commit_queue.len(), 1);
+	}
+
+	#[test]
+	fn cleanup_respects_active_reader() {
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		// Commit five transactions before the reader starts
+		for i in 0..5 {
+			let mut tx = db.transaction(true);
+			tx.set(format!("pre{i}"), "value").unwrap();
+			tx.commit().unwrap();
+		}
+		// Register a reader pinned at the current commit id
+		let reader = db.transaction(false);
+		// Commit five more transactions after the reader registered
+		for i in 0..5 {
+			let mut tx = db.transaction(true);
+			tx.set(format!("post{i}"), "value").unwrap();
+			tx.commit().unwrap();
+		}
+		assert_eq!(db.transaction_commit_queue.len(), 10);
+		db.run_cleanup();
+		// Entries above the reader's snapshot commit id must survive:
+		// they sit inside its potential conflict window. Entries at ids
+		// 1-4 are trimmed; the entry at the reader's snapshot (5) and
+		// everything above remain.
+		assert_eq!(db.transaction_commit_queue.len(), 6);
+		drop(reader);
+		db.run_cleanup();
+		// With the reader gone the idle fallback applies again
+		assert_eq!(db.transaction_commit_queue.len(), 1);
 	}
 }

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -50,8 +50,6 @@ pub struct Inner {
 	pub(crate) transaction_queue_id: AtomicU64,
 	/// The transaction commit queue success sequence number
 	pub(crate) transaction_commit_id: AtomicU64,
-	/// The transaction merge queue attempt sequence number
-	pub(crate) transaction_merge_id: AtomicU64,
 	/// The transaction commit queue list of modifications
 	pub(crate) transaction_commit_queue: SkipMap<u64, Arc<Commit>>,
 	/// Transaction updates which are committed but not yet applied
@@ -87,16 +85,15 @@ pub struct Inner {
 }
 
 impl Inner {
-	/// Create a new [`Inner`] structure with the given oracle resync interval.
+	/// Create a new [`Inner`] structure with the given options.
 	pub fn new(opts: &DatabaseOptions) -> Self {
 		Self {
-			oracle: Oracle::new(opts.resync_interval),
+			oracle: Oracle::new(),
 			datastore: SkipMap::new(),
 			counter_by_oracle: SkipMap::new(),
 			counter_by_commit: SkipMap::new(),
 			transaction_queue_id: AtomicU64::new(0),
 			transaction_commit_id: AtomicU64::new(0),
-			transaction_merge_id: AtomicU64::new(0),
 			transaction_commit_queue: SkipMap::new(),
 			transaction_merge_queue: SkipMap::new(),
 			#[cfg(not(target_arch = "wasm32"))]
@@ -159,22 +156,15 @@ impl Inner {
 	/// concurrent `register_counter` retries any reader whose snapshot
 	/// is below it, then re-scan to bound by any newly-arrived reader.
 	///
-	/// The proposed value is capped at the current oracle timestamp.
-	/// Without that cap, an idle database (oracle frozen while wall
-	/// clock advances) would push `gc_floor` above any value a future
-	/// reader could load — causing `register_counter` to spin forever
-	/// retrying.
+	/// The proposed value is bounded by the published logical clock: a
+	/// future reader's snapshot load returns at least the value we load
+	/// here, so the floor can never exceed what a future reader can
+	/// observe — the frozen-clock hazard the old wall-clock cap guarded
+	/// against is now inherent to the single monotonic counter.
 	pub(crate) fn compute_cleanup_ts(&self) -> u64 {
-		let now = self.oracle.current_time_ns();
+		let now = self.oracle.timestamp.load(Ordering::SeqCst);
 		let earliest_tx = self.earliest_active_version(now);
-		let oracle_now = self.oracle.inner.timestamp.load(Ordering::SeqCst);
-		// `gc_floor` must stay <= oracle so any future reader's load
-		// (which returns >= current oracle) satisfies the floor check.
-		// `now` participates in the min: under same-nanosecond commit
-		// bursts the oracle timestamp is minted as `last_ts + 1` and can
-		// run ahead of the estimated wall clock, so the wall-clock bound
-		// keeps reclamation from advancing past real time.
-		let proposed = now.min(earliest_tx).min(oracle_now);
+		let proposed = now.min(earliest_tx);
 		// Publish proposed cleanup_ts via `gc_floor` BEFORE reclaiming.
 		// A `register_counter` that fences after CAS-publish will see
 		// either the old floor (and its publish becomes visible to our

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -131,28 +131,25 @@ impl Inner {
 		earliest_active(&self.counter_by_commit, fallback)
 	}
 
-	/// Trim the transaction commit queue below the earliest active
-	/// transaction's commit snapshot, or below the current commit id when
-	/// no transaction is registered at all.
+	/// Trim commit-queue entries which no active or future transaction can
+	/// need for conflict detection.
 	///
-	/// Commit queue entries are only ever read by conflict detection,
-	/// which scans `(tx.commit, version)` — strictly above the committing
-	/// transaction's registered snapshot — so entries at or below every
-	/// registered snapshot are unreachable.
-	///
-	/// The idle fallback is safe against concurrent registration because
-	/// the fallback is loaded from `transaction_commit_id` *before* the
-	/// counter map is scanned: a registering transaction that the scan
-	/// misses validates `transaction_commit_id` against its snapshot
-	/// *after* publishing its counter (see `register_counter`), so by
-	/// monotonicity of the commit id its snapshot is `>=` our fallback,
-	/// and its conflict window `(snapshot, ..)` is untouched by the trim.
-	pub(crate) fn run_cleanup_inner(&self) {
-		// Load the idle fallback BEFORE scanning the counter map (see above)
+	/// The fallback bound for an idle database is the current commit id,
+	/// loaded BEFORE the fence-and-scan inside `earliest_active_commit`.
+	/// This ordering is load-bearing: a reader missed by the scan has its
+	/// registration revalidation load of `transaction_commit_id` ordered
+	/// after our bound load in the SeqCst total order, so (the counter
+	/// being monotonic) its snapshot is at least our bound, and its
+	/// conflict window `snapshot + 1 ..` sits strictly above everything
+	/// we trim. A reader seen by the scan bounds the trim directly. A
+	/// writer mid-commit holds its own registration until drop, so its
+	/// conflict-check iteration is protected identically.
+	pub(crate) fn cleanup_commit_queue(&self) {
+		// Load the idle-database bound before the fence-and-scan
 		let fallback = self.transaction_commit_id.load(Ordering::SeqCst);
-		// Find the earliest registered commit snapshot, if any
+		// Bound by the earliest registered reader, if any
 		let oldest = self.earliest_active_commit(fallback);
-		// Trim all commit queue entries below the watermark
+		// Remove all entries below the bound
 		self.transaction_commit_queue.range(..oldest).for_each(|e| {
 			e.remove();
 		});

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -21,10 +21,8 @@ use crate::queue::{Commit, Merge};
 use crate::versions::Versions;
 use crate::DatabaseOptions;
 use bytes::Bytes;
-use crossbeam_queue::SegQueue;
 use crossbeam_skiplist::SkipMap;
 use parking_lot::RwLock;
-use std::collections::HashSet;
 use std::sync::atomic::{fence, AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
@@ -109,8 +107,6 @@ pub struct Inner {
 	/// Stores a handle to the current garbage collection background thread
 	#[cfg(not(target_arch = "wasm32"))]
 	pub(crate) garbage_collection_handle: RwLock<Option<JoinHandle<()>>>,
-	/// Keys with stale versions pending incremental garbage collection
-	pub(crate) gc_dirty_keys: SegQueue<Bytes>,
 	/// Threshold after which transaction state is reset
 	pub(crate) reset_threshold: usize,
 }
@@ -135,7 +131,6 @@ impl Inner {
 			transaction_cleanup_handle: RwLock::new(None),
 			#[cfg(not(target_arch = "wasm32"))]
 			garbage_collection_handle: RwLock::new(None),
-			gc_dirty_keys: SegQueue::new(),
 			reset_threshold: opts.reset_threshold,
 		}
 	}
@@ -182,6 +177,27 @@ impl Inner {
 				e.remove();
 			});
 		}
+	}
+
+	/// Compute the watermark for commit-time inline garbage collection,
+	/// or `None` when a registration is in flight — in which case the
+	/// committer simply skips inline reclamation for this commit and the
+	/// next commit to each key (or the background full scan) catches up.
+	///
+	/// The committer's own slot is excluded: `commit` takes the
+	/// transaction by mutable reference and marks it done, so no further
+	/// reads can occur at its snapshot. Excluding ANY other slot is
+	/// forbidden — in particular a concurrent committer's slot (pinned at
+	/// its start version, strictly below its merge version) is what
+	/// prevents a delete-collapse from unlinking a chain that a slower
+	/// committer is still about to push an earlier version into, which
+	/// would otherwise resurrect deleted data through the
+	/// `get_or_insert_with` re-seed path.
+	pub(crate) fn inline_gc_watermark(&self, own_slot: u64) -> Option<u64> {
+		// Load the clock bound before the fence-and-scan
+		let now = self.oracle.timestamp.load(Ordering::SeqCst);
+		// Bound by every other registered transaction
+		earliest_pinned(&self.readers, |s| &s.version, now, Some(own_slot))
 	}
 
 	/// Compute the next `cleanup_ts` below which no live or future
@@ -250,48 +266,16 @@ impl Inner {
 		}
 	}
 
-	/// Drain the dirty-key queue, reclaiming stale versions on each key and
-	/// unlinking any whose version chain becomes empty.
-	///
-	/// Keys are de-duplicated within a pass: a hot key committed many times
-	/// between gc cycles is enqueued once per commit, but reclaiming it more
-	/// than once under a fixed `cleanup_ts` is wasted lock traffic — every
-	/// pass after the first is a no-op. A version added by a commit that
-	/// re-dirties the key mid-drain is newer than `cleanup_ts` and so not
-	/// reclaimable this pass anyway; it is caught on the next commit or the
-	/// periodic full scan.
-	pub(crate) fn run_gc_dirty_inner(&self, cleanup_ts: u64) {
-		let mut seen = HashSet::new();
-		// Drain all keys from the dirty queue
-		while let Some(key) = self.gc_dirty_keys.pop() {
-			// Skip keys already reclaimed in this pass
-			if !seen.insert(key.clone()) {
-				continue;
-			}
-			// Reclaim stale versions on this key
-			self.gc_key(&key, cleanup_ts);
-		}
-	}
-
 	/// Scan the entire datastore, reclaiming stale versions on every key.
+	///
+	/// Steady-state reclamation happens inline at commit time, so this
+	/// sweep is a low-frequency safety net for garbage which no future
+	/// commit will visit: versions pinned by a since-departed reader on a
+	/// key that is never written again, and the inert below-watermark
+	/// entries which an out-of-order apply can leave behind.
 	pub(crate) fn run_gc_full(&self, cleanup_ts: u64) {
 		// Iterate over the entire datastore
 		for entry in self.datastore.iter() {
-			// Get a mutable reference to the versions list
-			let mut versions = entry.value().write();
-			// Clean up unnecessary older versions
-			if versions.gc_older_versions(cleanup_ts) == 0 {
-				// Remove under the version write lock (see `gc_key`).
-				entry.remove();
-			}
-		}
-	}
-
-	/// Reclaim stale versions on a single key, unlinking the entry if its
-	/// version chain becomes empty.
-	fn gc_key(&self, key: &Bytes, cleanup_ts: u64) {
-		// Look the key up in the datastore
-		if let Some(entry) = self.datastore.get(key) {
 			// Get a mutable reference to the versions list
 			let mut versions = entry.value().write();
 			// Clean up unnecessary older versions

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -34,6 +34,14 @@ use std::thread::JoinHandle;
 /// can never reach this value.
 pub(crate) const SLOT_PINNING: u64 = u64::MAX;
 
+/// Sentinel stored in a commit-queue entry's `merge_version` when the
+/// owning transaction unwound without completing its commit. An aborted
+/// entry counts as complete for the commit-watermark advance (its writes
+/// will never be published) and is skipped by the conflict loop. Real
+/// merge versions are guarded at load time and can never reach this
+/// value.
+pub(crate) const COMMIT_ABORTED: u64 = u64::MAX;
+
 /// A pinned transaction registration.
 ///
 /// A slot is inserted into [`Inner::readers`] with both fields holding
@@ -87,15 +95,46 @@ pub struct Inner {
 	/// watermark published its merge version before the watermark
 	/// advanced past it, so a reader's version snapshot (loaded after
 	/// its commit snapshot) always covers its entire excluded prefix.
+	/// Bounded by, and advanced only after, `transaction_commit_id`.
 	pub(crate) commit_watermark: AtomicU64,
-	/// The transaction commit queue attempt sequence number
+	/// The commit-queue slot allocation counter. Slots are claimed from
+	/// here (dense and never re-used) rather than by probing queue
+	/// membership, because commit entries are removed on conflict aborts
+	/// and by cleanup, and a re-claimed vacated slot could sit below the
+	/// completed watermark with an unpublished merge version.
 	pub(crate) transaction_queue_id: AtomicU64,
-	/// The transaction commit queue success sequence number
+	/// The contiguous inserted prefix of the commit queue: every slot at
+	/// or below this value has definitely been inserted into
+	/// `transaction_commit_queue`. Advanced opportunistically by
+	/// [`Inner::try_advance_commit_prefix`] — no committer waits for it
+	/// to reach their own slot, they merely try to help it along after
+	/// their own insert. This is safe only because a commit-queue entry
+	/// is never physically removed before this bound has confirmably
+	/// passed it: a missing entry at the very next unadvanced slot can
+	/// therefore only mean "not yet inserted", never "removed early" —
+	/// see the conflict-abort branches in `TransactionInner::commit`,
+	/// which mark an aborted entry rather than removing it, leaving
+	/// physical removal to `cleanup_commit_queue` once the entry is
+	/// safely below this bound.
 	pub(crate) transaction_commit_id: AtomicU64,
 	/// The transaction commit queue list of modifications
 	pub(crate) transaction_commit_queue: SkipMap<u64, Arc<Commit>>,
 	/// Transaction updates which are committed but not yet applied
 	pub(crate) transaction_merge_queue: SkipMap<u64, Arc<Merge>>,
+	/// The contiguous retired prefix of the merge queue: every merge
+	/// version at or below this watermark has been fully applied to the
+	/// datastore and its queue entry removed. Merge entries are retired
+	/// strictly in version order — never individually on completion —
+	/// because reads resolve the queue overlay with priority over the
+	/// datastore chain: if a newer version's entry were removed while an
+	/// older version was still applying, a reader would find the older
+	/// surviving entry and return a stale value for a snapshot that
+	/// should see the newer one. In-order retirement guarantees every
+	/// version above the watermark is still present in the queue, so the
+	/// newest overlay hit at or below a snapshot is the newest write.
+	/// Bounded by, and advanced only after, the published merge clock
+	/// (`oracle.timestamp`).
+	pub(crate) merge_retire_id: AtomicU64,
 	/// Optional persistence handler
 	#[cfg(not(target_arch = "wasm32"))]
 	pub(crate) persistence: RwLock<Option<Arc<Persistence>>>,
@@ -124,6 +163,7 @@ impl Inner {
 			transaction_commit_id: AtomicU64::new(0),
 			transaction_commit_queue: SkipMap::new(),
 			transaction_merge_queue: SkipMap::new(),
+			merge_retire_id: AtomicU64::new(0),
 			#[cfg(not(target_arch = "wasm32"))]
 			persistence: RwLock::new(None),
 			background_threads_enabled: AtomicBool::new(true),
@@ -168,6 +208,11 @@ impl Inner {
 	/// its own slot until drop, so its conflict-check iteration is
 	/// protected identically.
 	pub(crate) fn cleanup_commit_queue(&self) {
+		// Give the opportunistic watermarks a chance to catch up before
+		// computing the trim bound: this call is infrequent (background
+		// worker or manual), so the extra freshness is cheap here even
+		// though it is deliberately skipped on the hot commit path.
+		self.refresh_commit_watermark();
 		// Load the idle-database bound before the fence-and-scan
 		let fallback = self.transaction_commit_id.load(Ordering::SeqCst);
 		// Bound by the earliest registered transaction, if any
@@ -212,6 +257,12 @@ impl Inner {
 	/// A bounded number of retries absorbs the nanosecond-scale window
 	/// in which a registering transaction is still pinning.
 	pub(crate) fn compute_cleanup_ts(&self) -> Option<u64> {
+		// Retire whatever merge-queue entries are already fully applied
+		// before computing the bound; see the equivalent call in
+		// `cleanup_commit_queue`. The publish step itself is no longer
+		// opportunistic (see `TransactionInner::atomic_merge`), so this
+		// exists to free retired entries, not to advance the clock.
+		self.refresh_merge_watermark();
 		// Retry a bounded number of times while registrations are pinning
 		for _ in 0..3 {
 			// Load the clock bound before the fence-and-scan
@@ -227,23 +278,134 @@ impl Inner {
 		None
 	}
 
+	/// Opportunistically advance the contiguous inserted prefix of the
+	/// commit queue as far as currently possible.
+	///
+	/// Non-blocking: unlike a claim-order publish barrier that makes a
+	/// committer wait for its predecessor, this never waits for a
+	/// specific slot to be inserted — it walks forward while the next
+	/// slot is present, and stops the instant it finds a gap (a slot
+	/// that has been claimed via `transaction_queue_id` but not yet
+	/// inserted), leaving that gap for a later call — from the slow
+	/// claimant's own insert, from another committer's courtesy call, or
+	/// from cleanup's/GC's opportunistic refresh — to close. The caller
+	/// never needs its own slot reflected in this bound before
+	/// proceeding: see the doc comment on `transaction_commit_id` for
+	/// why "absent" unambiguously means "not yet inserted" here, and why
+	/// every downstream consumer of a lagging value stays safe (
+	/// `cleanup_commit_queue`'s idle fallback only trims less;
+	/// `advance_commit_watermark`'s loop bound only holds
+	/// `commit_watermark` back, never advances it past an unconfirmed
+	/// slot).
+	pub(crate) fn try_advance_commit_prefix(&self) {
+		let mut spins = 0;
+		loop {
+			// Load the current bound and the claimed-slot ceiling
+			let cur = self.transaction_commit_id.load(Ordering::SeqCst);
+			let next = cur + 1;
+			// Nothing has claimed this slot yet
+			if next > self.transaction_queue_id.load(Ordering::SeqCst) {
+				break;
+			}
+			// Claimed but not yet inserted: stop, don't wait for it
+			if self.transaction_commit_queue.get(&next).is_none() {
+				break;
+			}
+			// Advance by one step; on CAS failure another caller advanced
+			// past us, so reload and continue from the fresh bound. Back
+			// off on contention: a caller of this function (e.g. a
+			// cleanup sweep with no delay between iterations) can end up
+			// calling it far more often than intended, and an
+			// unconditional `continue` here would otherwise hammer this
+			// cache line against every other thread doing the same.
+			if self
+				.transaction_commit_id
+				.compare_exchange_weak(cur, next, Ordering::SeqCst, Ordering::SeqCst)
+				.is_err()
+			{
+				crate::tx::backoff(spins);
+				spins += 1;
+				continue;
+			}
+		}
+	}
+
+	/// Opportunistically advance the published merge clock as far as
+	/// currently possible. See [`Inner::try_advance_commit_prefix`] for
+	/// the non-blocking shape; the same safety argument applies with
+	/// `oracle.alloc` in place of `transaction_queue_id` and
+	/// `transaction_merge_queue` in place of the commit queue — a merge
+	/// entry is likewise never physically removed (by ordinary
+	/// retirement, which is bounded by this very clock, or by the
+	/// persistence-failure path, which marks rather than removes) before
+	/// the clock has confirmably passed it.
+	pub(crate) fn try_advance_merge_clock(&self) {
+		let mut spins = 0;
+		loop {
+			let cur = self.oracle.timestamp.load(Ordering::SeqCst);
+			let next = cur + 1;
+			if next > self.oracle.alloc.load(Ordering::SeqCst) {
+				break;
+			}
+			if self.transaction_merge_queue.get(&next).is_none() {
+				break;
+			}
+			// Back off on contention — see the equivalent comment in
+			// `try_advance_commit_prefix`.
+			if self
+				.oracle
+				.timestamp
+				.compare_exchange_weak(cur, next, Ordering::SeqCst, Ordering::SeqCst)
+				.is_err()
+			{
+				crate::tx::backoff(spins);
+				spins += 1;
+				continue;
+			}
+		}
+	}
+
+	/// Opportunistically advance both the inserted-prefix bound and the
+	/// completed-prefix watermark of the commit queue as far as
+	/// currently possible. Called by writers after their own commit-slot
+	/// insert to help other in-flight committers make progress, and by
+	/// the cleanup path before computing its trim bound, for freshness.
+	pub(crate) fn refresh_commit_watermark(&self) {
+		self.try_advance_commit_prefix();
+		self.advance_commit_watermark();
+	}
+
+	/// Opportunistically advance both the published merge clock and the
+	/// retired prefix of the merge queue as far as currently possible.
+	/// Called by writers after their own merge insert, and by the
+	/// garbage-collection path before computing its cleanup bound.
+	pub(crate) fn refresh_merge_watermark(&self) {
+		self.try_advance_merge_clock();
+		self.advance_merge_retirement();
+	}
+
 	/// Advance the contiguous completed prefix of the commit queue.
 	///
 	/// Called by every committer once its commit-queue entry completes:
-	/// either its merge version has been published, or it aborted and
-	/// removed its entry (a missing entry at or below the current commit
-	/// id therefore counts as complete — aborted-and-removed, or already
-	/// trimmed by cleanup). The watermark is the value readers snapshot
-	/// as their conflict-window base, so it must only ever cover commits
-	/// whose merge versions are already published. Amortised O(1): every
-	/// slot is stepped over exactly once across all callers, and the CAS
-	/// simply resolves which caller performs each step.
+	/// its merge version has been published, it aborted on a conflict and
+	/// removed its entry, or it unwound and its guard marked the entry
+	/// [`COMMIT_ABORTED`]. Commit slots are claimed from a dense allocator
+	/// and `transaction_commit_id` is published strictly in claim order
+	/// once the entry is inserted, so every slot at or below it was
+	/// inserted exactly once and can never be re-claimed — a missing
+	/// entry therefore only ever means aborted-and-removed or already
+	/// trimmed by cleanup, both of which count as complete. The watermark
+	/// is the value readers snapshot as their conflict-window base, so it
+	/// must only ever cover commits whose merge versions are published or
+	/// which will never publish one. Amortised O(1): every slot is
+	/// stepped over exactly once across all callers, and the CAS simply
+	/// resolves which caller performs each step.
 	pub(crate) fn advance_commit_watermark(&self) {
 		loop {
-			// Load the current watermark and the claimed commit ids
+			// Load the current watermark and the inserted prefix bound
 			let wm = self.commit_watermark.load(Ordering::SeqCst);
 			let next = wm + 1;
-			// Stop at the end of the claimed commit id range
+			// Stop at the end of the inserted commit slot prefix
 			if next > self.transaction_commit_id.load(Ordering::SeqCst) {
 				break;
 			}
@@ -263,6 +425,40 @@ impl Inner {
 				Ordering::SeqCst,
 				Ordering::SeqCst,
 			);
+		}
+	}
+
+	/// Advance the contiguous retired prefix of the merge queue, removing
+	/// entries as the watermark passes them.
+	///
+	/// Called by every committer once its merge entry is fully applied to
+	/// the datastore. Entries are removed strictly in version order (see
+	/// the `merge_retire_id` field documentation): the bound is the
+	/// published clock, below which every version's entry was inserted,
+	/// and a missing entry means it was already retired by a racer or
+	/// removed early on the persistence-failure path — in either case its
+	/// data is in the datastore chains, so the watermark may pass it.
+	pub(crate) fn advance_merge_retirement(&self) {
+		loop {
+			// Load the current watermark and the published prefix bound
+			let wm = self.merge_retire_id.load(Ordering::SeqCst);
+			let next = wm + 1;
+			// Stop at the end of the published merge version prefix
+			if next > self.oracle.timestamp.load(Ordering::SeqCst) {
+				break;
+			}
+			// Check whether the next merge in sequence has been applied
+			if let Some(entry) = self.transaction_merge_queue.get(&next) {
+				if !entry.value().applied.load(Ordering::SeqCst) {
+					break;
+				}
+				// Remove the applied entry as the watermark passes it
+				entry.remove();
+			}
+			// Advance by one step; on CAS failure another caller advanced
+			// past us, so reload and continue from the fresh watermark
+			let _ =
+				self.merge_retire_id.compare_exchange(wm, next, Ordering::SeqCst, Ordering::SeqCst);
 		}
 	}
 

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -30,11 +30,40 @@ use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use std::thread::JoinHandle;
 
-/// Sentinel value stored in a counter entry while its owning [`Inner`]
-/// SkipMap entry is being removed by [`crate::tx::Transaction::drop`]. A
-/// concurrent `register_counter` will observe this marker and retry with a
-/// fresh entry rather than incrementing a detached counter.
-pub(crate) const COUNTER_TOMBSTONE: u64 = u64::MAX;
+/// Sentinel published in a slot field while its owning transaction is
+/// choosing its snapshot. Merge versions and commit ids are logical
+/// counters seeded from persisted data and guarded at load time, so they
+/// can never reach this value.
+pub(crate) const SLOT_PINNING: u64 = u64::MAX;
+
+/// A pinned transaction registration.
+///
+/// A slot is inserted into [`Inner::readers`] with both fields holding
+/// [`SLOT_PINNING`] BEFORE the owning transaction loads its snapshot
+/// (pin-then-read), so every watermark scan either observes the final
+/// snapshot values or the sentinel — and a sentinel forces the sweeper
+/// to treat the watermark as unknown and skip reclamation for that pass.
+/// Each field independently carries the sentinel: a sweeper can scan
+/// between the two value stores, so neither field may be interpreted
+/// before it has left the pinning state. One slot exists per live
+/// transaction and is exclusively owned by it, so state transitions are
+/// plain stores — no CAS protocol is required.
+pub(crate) struct Slot {
+	/// The owner's snapshot merge version, or SLOT_PINNING
+	pub(crate) version: AtomicU64,
+	/// The owner's snapshot commit id, or SLOT_PINNING
+	pub(crate) commit: AtomicU64,
+}
+
+impl Slot {
+	/// Create a new slot in the pinning state
+	pub(crate) fn pinning() -> Self {
+		Self {
+			version: AtomicU64::new(SLOT_PINNING),
+			commit: AtomicU64::new(SLOT_PINNING),
+		}
+	}
+}
 
 /// The inner structure of the transactional in-memory database
 pub struct Inner {
@@ -42,10 +71,25 @@ pub struct Inner {
 	pub(crate) oracle: Arc<Oracle>,
 	/// The underlying lock-free skip-list datastructure
 	pub(crate) datastore: SkipMap<Bytes, RwLock<Versions>>,
-	/// A count of total transactions grouped by oracle version
-	pub(crate) counter_by_oracle: SkipMap<u64, Arc<AtomicU64>>,
-	/// A count of total transactions grouped by commit id
-	pub(crate) counter_by_commit: SkipMap<u64, Arc<AtomicU64>>,
+	/// Registered transaction snapshot slots, keyed by allocation order.
+	/// Contains exactly the live transactions: slots are inserted at
+	/// registration and removed on transaction drop, so watermark scans
+	/// walk a map sized by concurrency, not by the transaction pool.
+	pub(crate) readers: SkipMap<u64, Arc<Slot>>,
+	/// Monotonic slot id allocator for the readers map
+	pub(crate) reader_slot_id: AtomicU64,
+	/// The contiguous completed prefix of the commit queue: every commit
+	/// with an id at or below this watermark has either published its
+	/// merge version or aborted. Readers take their commit snapshot from
+	/// here rather than from `transaction_commit_id`, which closes a
+	/// lost-update anomaly: a commit id becomes visible before its merge
+	/// version is published, so a reader snapshotting the raw commit id
+	/// could exclude a commit from its conflict window while also being
+	/// unable to see that commit's writes. Every commit at or below the
+	/// watermark published its merge version before the watermark
+	/// advanced past it, so a reader's version snapshot (loaded after
+	/// its commit snapshot) always covers its entire excluded prefix.
+	pub(crate) commit_watermark: AtomicU64,
 	/// The transaction commit queue attempt sequence number
 	pub(crate) transaction_queue_id: AtomicU64,
 	/// The transaction commit queue success sequence number
@@ -67,19 +111,6 @@ pub struct Inner {
 	pub(crate) garbage_collection_handle: RwLock<Option<JoinHandle<()>>>,
 	/// Keys with stale versions pending incremental garbage collection
 	pub(crate) gc_dirty_keys: SegQueue<Bytes>,
-	/// Watermark below which versions are about to be (or have been)
-	/// reclaimed by the garbage collector. The GC sweeper publishes its
-	/// intended `cleanup_ts` here with a SeqCst `fetch_max` *before*
-	/// actually reclaiming any versions. `register_counter` validates
-	/// `v_r >= gc_floor` after publishing its counter; if a reader
-	/// finds `gc_floor > v_r`, it rolls back and reloads the oracle,
-	/// landing on a fresh snapshot above the floor. This closes the
-	/// scan/gc race in the BG sweeper: a sweeper that misses an
-	/// in-flight reader on its first scan publishes `gc_floor`, fences,
-	/// then re-scans — and either the reader saw the new floor and
-	/// retried, or its publish is now visible to the re-scan so the
-	/// sweeper's final cleanup_ts is bounded by it.
-	pub(crate) gc_floor: AtomicU64,
 	/// Threshold after which transaction state is reset
 	pub(crate) reset_threshold: usize,
 }
@@ -90,8 +121,9 @@ impl Inner {
 		Self {
 			oracle: Oracle::new(),
 			datastore: SkipMap::new(),
-			counter_by_oracle: SkipMap::new(),
-			counter_by_commit: SkipMap::new(),
+			readers: SkipMap::new(),
+			reader_slot_id: AtomicU64::new(0),
+			commit_watermark: AtomicU64::new(0),
 			transaction_queue_id: AtomicU64::new(0),
 			transaction_commit_id: AtomicU64::new(0),
 			transaction_commit_queue: SkipMap::new(),
@@ -104,76 +136,118 @@ impl Inner {
 			#[cfg(not(target_arch = "wasm32"))]
 			garbage_collection_handle: RwLock::new(None),
 			gc_dirty_keys: SegQueue::new(),
-			gc_floor: AtomicU64::new(0),
 			reset_threshold: opts.reset_threshold,
 		}
 	}
 }
 
 impl Inner {
-	/// Returns the earliest active reader's snapshot version, or `fallback`
-	/// if no reader is currently registered. Pairs with the SeqCst
-	/// load-and-fence in `register_counter` to give writers a watermark
-	/// that observes every reader whose registration is totally ordered
-	/// before the fence below.
+	/// Returns the minimum snapshot merge version across all pinned
+	/// transaction slots, bounded by `fallback`, or `None` when any slot
+	/// is mid-registration. See [`earliest_pinned`].
 	#[inline]
-	pub(crate) fn earliest_active_version(&self, fallback: u64) -> u64 {
-		earliest_active(&self.counter_by_oracle, fallback)
+	pub(crate) fn earliest_active_version(&self, fallback: u64) -> Option<u64> {
+		earliest_pinned(&self.readers, |s| &s.version, fallback, None)
 	}
 
-	/// Returns the earliest active reader's start commit id, or `fallback`
-	/// if no reader is currently registered. See `earliest_active_version`.
+	/// Returns the minimum snapshot commit id across all pinned
+	/// transaction slots, bounded by `fallback`, or `None` when any slot
+	/// is mid-registration. See [`earliest_pinned`].
 	#[inline]
-	pub(crate) fn earliest_active_commit(&self, fallback: u64) -> u64 {
-		earliest_active(&self.counter_by_commit, fallback)
+	pub(crate) fn earliest_active_commit(&self, fallback: u64) -> Option<u64> {
+		earliest_pinned(&self.readers, |s| &s.commit, fallback, None)
 	}
 
 	/// Trim commit-queue entries which no active or future transaction can
 	/// need for conflict detection.
 	///
 	/// The fallback bound for an idle database is the current commit id,
-	/// loaded BEFORE the fence-and-scan inside `earliest_active_commit`.
-	/// This ordering is load-bearing: a reader missed by the scan has its
-	/// registration revalidation load of `transaction_commit_id` ordered
-	/// after our bound load in the SeqCst total order, so (the counter
-	/// being monotonic) its snapshot is at least our bound, and its
-	/// conflict window `snapshot + 1 ..` sits strictly above everything
-	/// we trim. A reader seen by the scan bounds the trim directly. A
-	/// writer mid-commit holds its own registration until drop, so its
-	/// conflict-check iteration is protected identically.
+	/// loaded BEFORE the fence-and-scan over the slots. This ordering is
+	/// load-bearing: a transaction missed by the scan pinned its slot
+	/// after the scan, so its subsequent commit-snapshot load is ordered
+	/// after our bound load in the SeqCst total order and (the watermark
+	/// being monotonic) returns at least our bound — its conflict window
+	/// `snapshot + 1 ..` sits strictly above everything we trim. A
+	/// transaction seen by the scan bounds the trim directly, and a slot
+	/// still pinning aborts the pass entirely. A writer mid-commit holds
+	/// its own slot until drop, so its conflict-check iteration is
+	/// protected identically.
 	pub(crate) fn cleanup_commit_queue(&self) {
 		// Load the idle-database bound before the fence-and-scan
 		let fallback = self.transaction_commit_id.load(Ordering::SeqCst);
-		// Bound by the earliest registered reader, if any
-		let oldest = self.earliest_active_commit(fallback);
-		// Remove all entries below the bound
-		self.transaction_commit_queue.range(..oldest).for_each(|e| {
-			e.remove();
-		});
+		// Bound by the earliest registered transaction, if any
+		if let Some(oldest) = self.earliest_active_commit(fallback) {
+			// Remove all entries below the bound
+			self.transaction_commit_queue.range(..oldest).for_each(|e| {
+				e.remove();
+			});
+		}
 	}
 
-	/// Compute the next `cleanup_ts`, publishing it into `gc_floor` so
-	/// concurrent `register_counter` retries any reader whose snapshot
-	/// is below it, then re-scan to bound by any newly-arrived reader.
+	/// Compute the next `cleanup_ts` below which no live or future
+	/// transaction can observe a version, or `None` when registrations
+	/// are in flight and the watermark cannot be established.
 	///
-	/// The proposed value is bounded by the published logical clock: a
-	/// future reader's snapshot load returns at least the value we load
-	/// here, so the floor can never exceed what a future reader can
-	/// observe — the frozen-clock hazard the old wall-clock cap guarded
-	/// against is now inherent to the single monotonic counter.
-	pub(crate) fn compute_cleanup_ts(&self) -> u64 {
-		let now = self.oracle.timestamp.load(Ordering::SeqCst);
-		let earliest_tx = self.earliest_active_version(now);
-		let proposed = now.min(earliest_tx);
-		// Publish proposed cleanup_ts via `gc_floor` BEFORE reclaiming.
-		// A `register_counter` that fences after CAS-publish will see
-		// either the old floor (and its publish becomes visible to our
-		// re-scan below via fence-fence SC ordering) or the new floor
-		// (and will retry to a fresh snapshot above it).
-		self.gc_floor.fetch_max(proposed, Ordering::SeqCst);
-		fence(Ordering::SeqCst);
-		let earliest_after = self.earliest_active_version(now);
-		proposed.min(earliest_after)
+	/// The proposed value is bounded by the published logical clock,
+	/// loaded BEFORE the fence-and-scan over the slots: a transaction
+	/// missed by the scan pinned after the scan, so its snapshot load
+	/// returns at least the clock value we load here, and version
+	/// reclamation always retains the entry visible at the watermark.
+	/// A bounded number of retries absorbs the nanosecond-scale window
+	/// in which a registering transaction is still pinning.
+	pub(crate) fn compute_cleanup_ts(&self) -> Option<u64> {
+		// Retry a bounded number of times while registrations are pinning
+		for _ in 0..3 {
+			// Load the clock bound before the fence-and-scan
+			let now = self.oracle.timestamp.load(Ordering::SeqCst);
+			// Bound by the earliest registered transaction, if any
+			if let Some(earliest) = self.earliest_active_version(now) {
+				return Some(earliest.min(now));
+			}
+			// A registration is mid-pin; give it a beat and retry
+			std::hint::spin_loop();
+		}
+		// Registrations kept arriving; skip this reclamation pass
+		None
+	}
+
+	/// Advance the contiguous completed prefix of the commit queue.
+	///
+	/// Called by every committer once its commit-queue entry completes:
+	/// either its merge version has been published, or it aborted and
+	/// removed its entry (a missing entry at or below the current commit
+	/// id therefore counts as complete — aborted-and-removed, or already
+	/// trimmed by cleanup). The watermark is the value readers snapshot
+	/// as their conflict-window base, so it must only ever cover commits
+	/// whose merge versions are already published. Amortised O(1): every
+	/// slot is stepped over exactly once across all callers, and the CAS
+	/// simply resolves which caller performs each step.
+	pub(crate) fn advance_commit_watermark(&self) {
+		loop {
+			// Load the current watermark and the claimed commit ids
+			let wm = self.commit_watermark.load(Ordering::SeqCst);
+			let next = wm + 1;
+			// Stop at the end of the claimed commit id range
+			if next > self.transaction_commit_id.load(Ordering::SeqCst) {
+				break;
+			}
+			// Check whether the next commit in sequence has completed
+			let complete = match self.transaction_commit_queue.get(&next) {
+				Some(entry) => entry.value().merge_version.load(Ordering::SeqCst) != 0,
+				None => true,
+			};
+			if !complete {
+				break;
+			}
+			// Advance by one step; on CAS failure another caller advanced
+			// past us, so reload and continue from the fresh watermark
+			let _ = self.commit_watermark.compare_exchange(
+				wm,
+				next,
+				Ordering::SeqCst,
+				Ordering::SeqCst,
+			);
+		}
 	}
 
 	/// Drain the dirty-key queue, reclaiming stale versions on each key and
@@ -233,16 +307,37 @@ impl Inner {
 	}
 }
 
+/// Returns the minimum value of one slot dimension across all pinned
+/// slots, bounded by `fallback`, or `None` when any scanned slot still
+/// holds [`SLOT_PINNING`] in that dimension.
+///
+/// The fence pairs with the fence in the pin-then-read registration
+/// protocol: a transaction whose pin-fence precedes ours in the SeqCst
+/// total order is visible to this scan (as a value or as the sentinel);
+/// a transaction whose pin-fence follows ours performs its snapshot
+/// loads after the caller's bound load, so its snapshot is at least the
+/// caller's fallback bound. `exclude` skips a single slot id — used by
+/// a committer to exclude its own slot, which is safe only because a
+/// committing transaction performs no further reads.
 #[inline]
-fn earliest_active(map: &SkipMap<u64, Arc<AtomicU64>>, fallback: u64) -> u64 {
+pub(crate) fn earliest_pinned(
+	map: &SkipMap<u64, Arc<Slot>>,
+	dim: impl Fn(&Slot) -> &AtomicU64,
+	fallback: u64,
+	exclude: Option<u64>,
+) -> Option<u64> {
 	fence(Ordering::SeqCst);
+	let mut min = fallback;
 	for entry in map.iter() {
-		let c = entry.value().load(Ordering::Acquire);
-		if c != 0 && c != COUNTER_TOMBSTONE {
-			return *entry.key();
+		if Some(*entry.key()) == exclude {
+			continue;
+		}
+		match dim(entry.value()).load(Ordering::SeqCst) {
+			SLOT_PINNING => return None,
+			v => min = min.min(v),
 		}
 	}
-	fallback
+	Some(min)
 }
 
 impl Default for Inner {

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 pub(crate) const DEFAULT_RESET_THRESHOLD: usize = 100;
 
 /// Default interval at which garbage collection is performed. With the
-/// `gc_floor` barrier in `register_counter`, the sweeper is race-free
+/// pin-then-read slot registration protocol, the sweeper is race-free
 /// against concurrent reader registration, so we can run it frequently
 /// to keep memory bounded.
 pub(crate) const DEFAULT_GC_INTERVAL: Duration = Duration::from_millis(500);

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,17 +4,12 @@ use std::time::Duration;
 /// Default threshold at which transaction state is fully reset.
 pub(crate) const DEFAULT_RESET_THRESHOLD: usize = 100;
 
-/// Default interval at which garbage collection is performed. With the
-/// pin-then-read slot registration protocol, the sweeper is race-free
-/// against concurrent reader registration, so we can run it frequently
-/// to keep memory bounded.
-pub(crate) const DEFAULT_GC_INTERVAL: Duration = Duration::from_millis(500);
-
-/// Default number of garbage collector wake-ups between full datastore
-/// scans. Each wake-up always drains the dirty-key queue; the full scan
-/// runs every Nth wake-up (`1` = every tick, `4` = every fourth tick).
-/// With a 500ms `gc_interval` this is one full scan per 10s.
-pub(crate) const DEFAULT_GC_FULL_SCAN_FREQUENCY: u64 = 20;
+/// Default interval at which the background garbage collection sweep is
+/// performed. Steady-state reclamation happens inline at commit time, so
+/// the background sweep is a low-frequency safety net for garbage which
+/// no future commit will visit: versions pinned by a since-departed
+/// reader on a key that is never written again.
+pub(crate) const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Default interval at which transaction queue cleanup is performed.
 pub(crate) const DEFAULT_CLEANUP_INTERVAL: Duration = Duration::from_secs(1);
@@ -24,16 +19,13 @@ pub(crate) const DEFAULT_CLEANUP_INTERVAL: Duration = Duration::from_secs(1);
 pub struct DatabaseOptions {
 	/// Maximum number of transactions kept in the pool (default: 512).
 	pub pool_size: usize,
-	/// Whether the garbage collector is started automatically (default: true).
+	/// Whether the background garbage collection safety-net sweep is
+	/// started automatically (default: true). Steady-state reclamation
+	/// happens inline at commit time regardless of this setting.
 	pub enable_gc: bool,
-	/// Interval at which the garbage collector wakes up (default: 500ms).
+	/// Interval at which the garbage collection safety-net sweep wakes
+	/// up and performs a full datastore scan (default: 10 seconds).
 	pub gc_interval: Duration,
-	/// Number of garbage collector wake-ups between full datastore scans
-	/// (default: 20, i.e. one full scan per 10 seconds at the default
-	/// `gc_interval`). Each wake-up always drains the dirty-key queue;
-	/// every Nth wake-up additionally walks the whole tree to reclaim
-	/// versions on keys that haven't been touched recently.
-	pub gc_full_scan_frequency: u64,
 	/// Whether the cleanup worker is started automatically (default: true).
 	pub enable_cleanup: bool,
 	/// Interval at which the cleanup worker wakes up (default: 1 second).
@@ -48,7 +40,6 @@ impl Default for DatabaseOptions {
 			pool_size: DEFAULT_POOL_SIZE,
 			enable_gc: true,
 			gc_interval: DEFAULT_GC_INTERVAL,
-			gc_full_scan_frequency: DEFAULT_GC_FULL_SCAN_FREQUENCY,
 			enable_cleanup: true,
 			cleanup_interval: DEFAULT_CLEANUP_INTERVAL,
 			reset_threshold: DEFAULT_RESET_THRESHOLD,
@@ -80,14 +71,6 @@ impl DatabaseOptions {
 		self
 	}
 
-	/// Set how many garbage collector wake-ups elapse between full
-	/// datastore scans. `1` runs a full scan every tick; higher values
-	/// scan less often but rely more on the dirty-key queue.
-	pub fn with_gc_full_scan_frequency(mut self, frequency: u64) -> Self {
-		self.gc_full_scan_frequency = frequency.max(1);
-		self
-	}
-
 	/// Set whether the cleanup worker thread is started automatically.
 	pub fn with_enable_cleanup(mut self, enable: bool) -> Self {
 		self.enable_cleanup = enable;
@@ -114,13 +97,13 @@ impl DatabaseOptions {
 	}
 
 	/// Configure for high-throughput scenarios with a larger transaction
-	/// pool and less-frequent background garbage collection. Trades
-	/// memory for throughput: more dropped transactions are kept for
-	/// reuse, and the gc sweeper interrupts the foreground less often.
+	/// pool and less-frequent background sweeps. Trades memory for
+	/// throughput: more dropped transactions are kept for reuse, and the
+	/// safety-net sweeper interrupts the foreground less often —
+	/// steady-state reclamation happens inline at commit time either way.
 	pub fn with_high_performance(mut self) -> Self {
 		self.pool_size *= 2;
-		self.gc_interval = Duration::from_secs(1);
-		self.gc_full_scan_frequency = 30;
+		self.gc_interval = Duration::from_secs(30);
 		self.cleanup_interval = Duration::from_millis(100);
 		self.reset_threshold *= 2;
 		self
@@ -131,22 +114,20 @@ impl DatabaseOptions {
 	/// latency for minimal background CPU.
 	pub fn with_low_resource(mut self) -> Self {
 		self.pool_size /= 2;
-		self.gc_interval = Duration::from_secs(5);
-		self.gc_full_scan_frequency = 12;
+		self.gc_interval = Duration::from_secs(60);
 		self.cleanup_interval = Duration::from_millis(500);
 		self.reset_threshold /= 2;
 		self
 	}
 
-	/// Configure for memory-constrained scenarios: aggressive garbage
-	/// collection and a smaller transaction pool. Trades CPU for tighter
-	/// memory bounds — version reclamation runs more often, full
-	/// datastore scans happen more often, and fewer dropped transactions
-	/// are kept around for reuse.
+	/// Configure for memory-constrained scenarios: frequent safety-net
+	/// sweeps and a smaller transaction pool. Trades CPU for tighter
+	/// memory bounds — reader-pinned garbage is reclaimed sooner after
+	/// the reader departs, and fewer dropped transactions are kept
+	/// around for reuse.
 	pub fn with_reduced_memory(mut self) -> Self {
 		self.pool_size /= 2;
-		self.gc_interval = Duration::from_millis(100);
-		self.gc_full_scan_frequency = 5;
+		self.gc_interval = Duration::from_secs(5);
 		self.cleanup_interval = Duration::from_millis(100);
 		self.reset_threshold /= 2;
 		self

--- a/src/options.rs
+++ b/src/options.rs
@@ -19,10 +19,6 @@ pub(crate) const DEFAULT_GC_FULL_SCAN_FREQUENCY: u64 = 20;
 /// Default interval at which transaction queue cleanup is performed.
 pub(crate) const DEFAULT_CLEANUP_INTERVAL: Duration = Duration::from_secs(1);
 
-/// Default interval at which the timestamp oracle resyncs with the system
-/// clock.
-pub(crate) const DEFAULT_RESYNC_INTERVAL: Duration = Duration::from_secs(5);
-
 /// Configuration options for [`crate::Database`].
 #[derive(Debug, Clone)]
 pub struct DatabaseOptions {
@@ -44,9 +40,6 @@ pub struct DatabaseOptions {
 	pub cleanup_interval: Duration,
 	/// Threshold after which transaction state maps are reset (default: 100).
 	pub reset_threshold: usize,
-	/// Interval at which the timestamp oracle resyncs with the system clock
-	/// (default: 5 seconds).
-	pub resync_interval: Duration,
 }
 
 impl Default for DatabaseOptions {
@@ -59,7 +52,6 @@ impl Default for DatabaseOptions {
 			enable_cleanup: true,
 			cleanup_interval: DEFAULT_CLEANUP_INTERVAL,
 			reset_threshold: DEFAULT_RESET_THRESHOLD,
-			resync_interval: DEFAULT_RESYNC_INTERVAL,
 		}
 	}
 }
@@ -114,13 +106,6 @@ impl DatabaseOptions {
 		self
 	}
 
-	/// Set the interval at which the timestamp oracle resyncs with the system
-	/// clock.
-	pub fn with_resync_interval(mut self, interval: Duration) -> Self {
-		self.resync_interval = interval;
-		self
-	}
-
 	/// Disable all background worker threads (gc and cleanup).
 	pub fn with_all_workers_disabled(mut self) -> Self {
 		self.enable_gc = false;
@@ -138,7 +123,6 @@ impl DatabaseOptions {
 		self.gc_full_scan_frequency = 30;
 		self.cleanup_interval = Duration::from_millis(100);
 		self.reset_threshold *= 2;
-		self.resync_interval = Duration::from_secs(2);
 		self
 	}
 
@@ -151,7 +135,6 @@ impl DatabaseOptions {
 		self.gc_full_scan_frequency = 12;
 		self.cleanup_interval = Duration::from_millis(500);
 		self.reset_threshold /= 2;
-		self.resync_interval = Duration::from_secs(10);
 		self
 	}
 

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -1,117 +1,54 @@
-use arc_swap::ArcSwap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+// Copyright © SurrealDB Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module stores the monotonic logical clock for merge versions.
+
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
-#[cfg(not(target_arch = "wasm32"))]
-use std::sync::Mutex;
-#[cfg(not(target_arch = "wasm32"))]
-use std::thread::JoinHandle;
-use web_time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-/// A timestamp oracle for monotonically increasing time
+/// A monotonic logical clock minting merge versions.
+///
+/// Merge versions are claimed from `alloc`, a dense allocation counter,
+/// and published to `timestamp` strictly in claim order once the claimed
+/// version's merge-queue entry has been inserted. The two counters must
+/// be separate: claiming by merge-queue slot insertion alone is unsound,
+/// because a committer removes its merge entry once applied, and a slow
+/// concurrent committer that loaded the clock before the publish could
+/// then re-claim the vacated slot — minting the same version twice and
+/// silently overwriting a committed value in the version chain.
+///
+/// `timestamp` holds the latest *published* merge version (`0` when no
+/// merge has happened yet). Readers snapshot it directly, and in-order
+/// publication guarantees that a snapshot at `v` sees every merge
+/// `<= v` — still in the merge queue or already applied. On persistent
+/// databases both counters are seeded at load time with the maximum
+/// version found across the snapshot file and the append-only log, so
+/// newly minted versions always continue strictly above every persisted
+/// version.
 pub(crate) struct Oracle {
-	// The inner strcuture of an Oracle
-	pub(crate) inner: Arc<Inner>,
-}
-
-impl Drop for Oracle {
-	fn drop(&mut self) {
-		self.shutdown();
-	}
-}
-
-/// The inner structure of the timestamp oracle
-pub(crate) struct Inner {
-	/// The latest monotonic counter for this oracle
+	/// The merge version allocation counter
+	pub(crate) alloc: AtomicU64,
+	/// The latest published merge version
 	pub(crate) timestamp: AtomicU64,
-	/// The reference time when this Oracle was synced
-	pub(crate) reference: ArcSwap<(u64, Instant)>,
-	/// Specifies whether timestamp syncing is enabled in the background
-	pub(crate) resync_enabled: AtomicBool,
-	/// Stores a handle to the current timestamp syncing background thread
-	#[cfg(not(target_arch = "wasm32"))]
-	pub(crate) resync_handle: Mutex<Option<JoinHandle<()>>>,
-	/// Interval at which the oracle resyncs with the system clock
-	#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-	pub(crate) resync_interval: Duration,
 }
 
 impl Oracle {
-	/// Creates a new timestamp oracle with the specified resync interval
-	pub fn new(resync_interval: Duration) -> Arc<Self> {
-		// Get the current unix time in nanoseconds
-		let reference_unix = Self::current_unix_ns();
-		// Get a new monotonically increasing clock
-		let reference_time = Instant::now();
-		// Return the current timestamp oracle
-		let oracle = Self {
-			inner: Arc::new(Inner {
-				timestamp: AtomicU64::new(reference_unix),
-				reference: ArcSwap::new(Arc::new((reference_unix, reference_time))),
-				resync_enabled: AtomicBool::new(true),
-				#[cfg(not(target_arch = "wasm32"))]
-				resync_handle: Mutex::new(None),
-				resync_interval,
-			}),
-		};
-		// Start up the resyncing thread
-		#[cfg(not(target_arch = "wasm32"))]
-		oracle.worker_resync();
-		// Return the oracle
-		Arc::new(oracle)
-	}
-
-	/// Gets the current system time in nanoseconds since the Unix epoch
-	#[inline]
-	pub(crate) fn current_unix_ns() -> u64 {
-		// Get the current system time
-		let timestamp = SystemTime::now().duration_since(UNIX_EPOCH);
-		// Count the nanoseconds since the Unix epoch
-		timestamp.unwrap_or_default().as_nanos() as u64
-	}
-
-	/// Gets the current estimated time in nanoseconds since the Unix epoch
-	#[inline]
-	pub(crate) fn current_time_ns(&self) -> u64 {
-		// Get the current reference time
-		let reference = self.inner.reference.load();
-		// Calculate the nanoseconds since the Unix epoch
-		reference.0 + reference.1.elapsed().as_nanos() as u64
-	}
-
-	/// Shutdown the oracle resync, waiting for background threads to exit
-	fn shutdown(&self) {
-		// Disable timestamp resyncing
-		self.inner.resync_enabled.store(false, Ordering::Release);
-		// Wait for the timestamp resyncing thread to exit
-		#[cfg(not(target_arch = "wasm32"))]
-		if let Some(handle) = self.inner.resync_handle.lock().unwrap().take() {
-			handle.thread().unpark();
-			handle.join().unwrap();
-		}
-	}
-
-	/// Start the resyncing thread after creating the oracle
-	#[cfg(not(target_arch = "wasm32"))]
-	fn worker_resync(&self) {
-		// Clone the underlying oracle inner
-		let oracle = self.inner.clone();
-		// Store the resync interval for the thread
-		let interval = oracle.resync_interval;
-		// Spawn a new thread to handle timestamp resyncing
-		let handle = std::thread::spawn(move || {
-			// Check whether the timestamp resync process is enabled
-			while oracle.resync_enabled.load(Ordering::Acquire) {
-				// Wait for a specified time interval
-				std::thread::park_timeout(interval);
-				// Get the current unix time in nanoseconds
-				let reference_unix = Self::current_unix_ns();
-				// Get a new monotonically increasing clock
-				let reference_time = Instant::now();
-				// Store the timestamp and monotonic instant
-				oracle.reference.store(Arc::new((reference_unix, reference_time)));
-			}
-		});
-		// Store and track the thread handle
-		*self.inner.resync_handle.lock().unwrap() = Some(handle);
+	/// Creates a new logical clock starting at version zero
+	pub fn new() -> Arc<Self> {
+		Arc::new(Self {
+			alloc: AtomicU64::new(0),
+			timestamp: AtomicU64::new(0),
+		})
 	}
 }

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 /// A monotonic logical clock minting merge versions.
 ///
 /// Merge versions are claimed from `alloc`, a dense allocation counter,
-/// and published to `timestamp` strictly in claim order once the claimed
+/// and published to `timestamp` opportunistically once the claimed
 /// version's merge-queue entry has been inserted. The two counters must
 /// be separate: claiming by merge-queue slot insertion alone is unsound,
 /// because a committer removes its merge entry once applied, and a slow
@@ -29,13 +29,25 @@ use std::sync::Arc;
 /// silently overwriting a committed value in the version chain.
 ///
 /// `timestamp` holds the latest *published* merge version (`0` when no
-/// merge has happened yet). Readers snapshot it directly, and in-order
-/// publication guarantees that a snapshot at `v` sees every merge
-/// `<= v` — still in the merge queue or already applied. On persistent
-/// databases both counters are seeded at load time with the maximum
-/// version found across the snapshot file and the append-only log, so
-/// newly minted versions always continue strictly above every persisted
-/// version.
+/// merge has happened yet). Readers snapshot it directly. A committer
+/// publishes by waiting for `timestamp` to reach its own claimed
+/// version's predecessor, then advancing it to its own version in one
+/// step (`Inner::atomic_merge`): every publish is in strict claim order,
+/// so a thread always sees its own immediately-prior commit reflected in
+/// `timestamp` before it can start another. `Inner::try_advance_merge_clock`
+/// additionally walks `timestamp` forward opportunistically through
+/// consecutive claimed-and-inserted versions on the cleanup/GC paths,
+/// where no thread is waiting on the result. Either way, a snapshot at
+/// `v` sees every merge `<= v` (in the merge queue or already applied):
+/// `timestamp` only ever crosses a slot once its entry is confirmed
+/// present, and merge entries are never physically removed before the
+/// clock has already passed them (see `Inner::merge_retire_id` and the
+/// persistence-failure path in `TransactionInner::commit`), so "absent"
+/// at the next slot can only mean "not yet inserted", never "removed
+/// early". On persistent databases both counters are seeded at load
+/// time with the maximum version found across the snapshot file and the
+/// append-only log, so newly minted versions always continue strictly
+/// above every persisted version.
 pub(crate) struct Oracle {
 	/// The merge version allocation counter
 	pub(crate) alloc: AtomicU64,

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -514,11 +514,15 @@ impl Persistence {
 		// strictly above every persisted version. Both the allocation
 		// counter and the published clock are seeded: the next claim
 		// takes max_version + 1, and its in-order publication advances
-		// the clock from max_version. This runs before any transaction
-		// or background worker exists; fetch_max is used for safety
-		// under refactoring rather than necessity.
+		// the clock from max_version. The merge retirement watermark is
+		// seeded identically so its in-order advance starts at the first
+		// live merge version rather than walking the persisted range.
+		// This runs before any transaction or background worker exists;
+		// fetch_max is used for safety under refactoring rather than
+		// necessity.
 		self.inner.oracle.alloc.fetch_max(max_version, Ordering::SeqCst);
 		self.inner.oracle.timestamp.fetch_max(max_version, Ordering::SeqCst);
+		self.inner.merge_retire_id.fetch_max(max_version, Ordering::SeqCst);
 		// Return success
 		Ok(())
 	}

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -361,6 +361,16 @@ impl Persistence {
 	/// 1. Loads the latest snapshot if it exists
 	/// 2. Applies any changes from the append-only log
 	fn load(&self) -> Result<(), PersistenceError> {
+		// Track the maximum version seen across EVERY decoded record —
+		// snapshot entries (including keys skipped as tombstone-topped)
+		// and every append-only log record (including deletes). The
+		// logical clock is seeded from this so newly minted merge
+		// versions continue strictly above every persisted version.
+		// Seeding from anything less (the last record, or only entries
+		// carrying values) would let a new write mint a version below a
+		// stale persisted tombstone and silently vanish once the clock
+		// crosses it.
+		let mut max_version: u64 = 0;
 		// Check if snapshot file exists
 		if self.snapshot_path.exists() {
 			// Read and deserialize the snapshot data
@@ -396,6 +406,9 @@ impl Persistence {
 							// entirely - absent and deleted are the same
 							// observable state.
 							if let Some((version, value)) = versions.into_iter().last() {
+								// Count the version towards the clock seed
+								// even when the key itself is skipped
+								max_version = max_version.max(version);
 								// Skip keys which were deleted
 								if value.is_some() {
 									// Create a new versions entry
@@ -450,6 +463,11 @@ impl Persistence {
 					// Detech any end of file errors
 					match result {
 						Ok((k, version, val)) => {
+							// Count the version towards the clock seed. The
+							// append-only log is not version-ordered (async
+							// appends race), so the maximum must be tracked
+							// over every record, not taken from the last.
+							max_version = max_version.max(version);
 							// Check if the key already exists
 							if let Some(entry) = self.inner.datastore.get(&k) {
 								// Update existing key with stored version
@@ -482,6 +500,25 @@ impl Persistence {
 				}
 			}
 		}
+		// Guard against corrupted or pathological persisted versions: the
+		// slot protocol reserves values near u64::MAX as sentinels, and
+		// version minting adds one to the clock. Legitimate versions from
+		// wall-clock releases (~1.7e18 nanoseconds) sit six orders of
+		// magnitude below this bound.
+		if max_version > u64::MAX / 2 {
+			return Err(PersistenceError::SnapshotFailed(format!(
+				"persisted version {max_version} exceeds the maximum supported version"
+			)));
+		}
+		// Seed the logical clock so newly minted merge versions continue
+		// strictly above every persisted version. Both the allocation
+		// counter and the published clock are seeded: the next claim
+		// takes max_version + 1, and its in-order publication advances
+		// the clock from max_version. This runs before any transaction
+		// or background worker exists; fetch_max is used for safety
+		// under refactoring rather than necessity.
+		self.inner.oracle.alloc.fetch_max(max_version, Ordering::SeqCst);
+		self.inner.oracle.timestamp.fetch_max(max_version, Ordering::SeqCst);
 		// Return success
 		Ok(())
 	}

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -26,13 +26,11 @@ use tracing::debug;
 pub struct Commit {
 	/// The unique id of this commit attempt
 	pub(crate) id: u64,
-	/// The sorted keys of the local updates and deletes. Conflict
-	/// detection only ever inspects keys, so the values are
-	/// intentionally not stored here: a commit queue entry outlives
-	/// the corresponding merge queue entry (it is only trimmed later
-	/// by the cleanup worker), and holding the values would pin them
-	/// in memory for that entire window.
-	pub(crate) keys: Vec<Bytes>,
+	/// The sorted writeset keys. Values are never read during conflict
+	/// detection, so they are not retained here: the merge queue holds
+	/// the full writeset only until the commit is applied, while this
+	/// entry survives until queue cleanup without pinning value memory.
+	pub(crate) keys: Arc<[Bytes]>,
 	/// Bloom filter over writeset keys for fast conflict pre-checks
 	pub(crate) writeset_bloom: BloomFilter,
 }
@@ -185,5 +183,83 @@ impl Commit {
 		}
 		// No overlap was found
 		true
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Build a commit entry from an unsorted set of string keys
+	fn commit(input: &[&str]) -> Arc<Commit> {
+		let mut v: Vec<Bytes> = input.iter().map(|k| Bytes::from(k.to_string())).collect();
+		v.sort();
+		v.dedup();
+		let keys: Arc<[Bytes]> = v.into();
+		let mut writeset_bloom = BloomFilter::new();
+		for k in keys.iter() {
+			writeset_bloom.insert(k);
+		}
+		let min_key = keys.first().cloned().unwrap_or_default();
+		let max_key = keys.last().cloned().unwrap_or_default();
+		Arc::new(Commit {
+			id: 1,
+			keys,
+			writeset_bloom,
+			min_key,
+			max_key,
+		})
+	}
+
+	/// Build a readset from a set of string keys
+	fn readset(input: &[&str]) -> HashSet<Bytes> {
+		let set = HashSet::new();
+		{
+			let pin = set.pin();
+			for k in input {
+				pin.insert(Bytes::from(k.to_string()));
+			}
+		}
+		set
+	}
+
+	#[test]
+	fn readset_disjoint_small_readset_probes_keys() {
+		// Readset smaller than the writeset: the binary-search direction
+		let c = commit(&["a", "b", "c", "d", "e"]);
+		assert!(c.is_disjoint_readset(&readset(&["x", "y"])));
+		assert!(!c.is_disjoint_readset(&readset(&["x", "c"])));
+	}
+
+	#[test]
+	fn readset_disjoint_large_readset_iterates_keys() {
+		// Readset larger than the writeset: the writeset-iteration direction
+		let c = commit(&["m"]);
+		assert!(c.is_disjoint_readset(&readset(&["a", "b", "c", "d"])));
+		assert!(!c.is_disjoint_readset(&readset(&["a", "b", "m", "d"])));
+	}
+
+	#[test]
+	fn writeset_disjoint_two_pointer_merge() {
+		let a = commit(&["a", "c", "e"]);
+		let b = commit(&["b", "d", "f"]);
+		assert!(a.is_disjoint_writeset(&b));
+		assert!(b.is_disjoint_writeset(&a));
+		let c = commit(&["e", "g"]);
+		assert!(!a.is_disjoint_writeset(&c));
+		assert!(!c.is_disjoint_writeset(&a));
+	}
+
+	#[test]
+	fn writeset_bloom_pre_checks_agree_with_exact() {
+		let a = commit(&["a", "c", "e"]);
+		let b = commit(&["b", "d", "f"]);
+		assert!(a.is_disjoint_writeset_bloom(&b));
+		let c = commit(&["e", "g"]);
+		assert!(!a.is_disjoint_writeset_bloom(&c));
+		// Non-overlapping key ranges short-circuit on the min/max bounds
+		let lo = commit(&["a", "b"]);
+		let hi = commit(&["x", "y"]);
+		assert!(lo.is_disjoint_writeset_bloom(&hi));
 	}
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -37,8 +37,6 @@ pub struct Commit {
 
 /// A transaction entry in the transaction merge queue
 pub struct Merge {
-	/// The unique id of this commit attempt
-	pub(crate) id: u64,
 	/// The local set of updates and deletes
 	pub(crate) writeset: Arc<BTreeMap<Bytes, Option<Bytes>>>,
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -19,6 +19,7 @@ use crate::LOG_TARGET_CONFLICTS;
 use bytes::Bytes;
 use papaya::HashSet;
 use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tracing::debug;
 
@@ -33,6 +34,17 @@ pub struct Commit {
 	pub(crate) keys: Arc<[Bytes]>,
 	/// Bloom filter over writeset keys for fast conflict pre-checks
 	pub(crate) writeset_bloom: BloomFilter,
+	/// The merge version this commit published, or zero while the commit
+	/// is still in flight. Set by the owning transaction immediately
+	/// after its merge version becomes loadable from the clock. Consumed
+	/// by the commit-watermark advance (readers must never take a
+	/// conflict-window base covering a commit whose merge version they
+	/// cannot yet see) and by the conflict loop, which skips commits
+	/// whose merge version is visible in the checking transaction's
+	/// snapshot: a visible commit happened strictly before the snapshot
+	/// in version order, so it is not concurrent and first-committer-wins
+	/// does not apply to it.
+	pub(crate) merge_version: AtomicU64,
 }
 
 /// A transaction entry in the transaction merge queue
@@ -206,6 +218,7 @@ mod tests {
 			writeset_bloom,
 			min_key,
 			max_key,
+			merge_version: AtomicU64::new(0),
 		})
 	}
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -19,14 +19,12 @@ use crate::LOG_TARGET_CONFLICTS;
 use bytes::Bytes;
 use papaya::HashSet;
 use std::collections::BTreeMap;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
 use tracing::debug;
 
 /// A transaction entry in the transaction commit queue
 pub struct Commit {
-	/// The unique id of this commit attempt
-	pub(crate) id: u64,
 	/// The sorted writeset keys. Values are never read during conflict
 	/// detection, so they are not retained here: the merge queue holds
 	/// the full writeset only until the commit is applied, while this
@@ -34,16 +32,17 @@ pub struct Commit {
 	pub(crate) keys: Arc<[Bytes]>,
 	/// Bloom filter over writeset keys for fast conflict pre-checks
 	pub(crate) writeset_bloom: BloomFilter,
-	/// The merge version this commit published, or zero while the commit
-	/// is still in flight. Set by the owning transaction immediately
-	/// after its merge version becomes loadable from the clock. Consumed
-	/// by the commit-watermark advance (readers must never take a
-	/// conflict-window base covering a commit whose merge version they
-	/// cannot yet see) and by the conflict loop, which skips commits
-	/// whose merge version is visible in the checking transaction's
-	/// snapshot: a visible commit happened strictly before the snapshot
-	/// in version order, so it is not concurrent and first-committer-wins
-	/// does not apply to it.
+	/// The merge version this commit published, zero while the commit is
+	/// still in flight, or [`crate::inner::COMMIT_ABORTED`] when the
+	/// owning transaction unwound without completing. Set by the owning
+	/// transaction immediately after its merge version becomes loadable
+	/// from the clock. Consumed by the commit-watermark advance (readers
+	/// must never take a conflict-window base covering a commit whose
+	/// merge version they cannot yet see) and by the conflict loop, which
+	/// skips aborted commits and commits whose merge version is visible
+	/// in the checking transaction's snapshot: a visible commit happened
+	/// strictly before the snapshot in version order, so it is not
+	/// concurrent and first-committer-wins does not apply to it.
 	pub(crate) merge_version: AtomicU64,
 }
 
@@ -51,6 +50,14 @@ pub struct Commit {
 pub struct Merge {
 	/// The local set of updates and deletes
 	pub(crate) writeset: Arc<BTreeMap<Bytes, Option<Bytes>>>,
+	/// Whether this merge has been fully applied to the datastore.
+	/// Consumed by the in-order retirement advance: merge entries are
+	/// removed from the queue strictly in version order, over the
+	/// contiguous applied prefix, so a surviving queue entry for a key
+	/// is always at least as new as anything the datastore chain holds
+	/// at or below a reader's snapshot — the property that lets reads
+	/// resolve the queue overlay with priority over the chain.
+	pub(crate) applied: AtomicBool,
 }
 
 impl Commit {
@@ -210,14 +217,9 @@ mod tests {
 		for k in keys.iter() {
 			writeset_bloom.insert(k);
 		}
-		let min_key = keys.first().cloned().unwrap_or_default();
-		let max_key = keys.last().cloned().unwrap_or_default();
 		Arc::new(Commit {
-			id: 1,
 			keys,
 			writeset_bloom,
-			min_key,
-			max_key,
 			merge_version: AtomicU64::new(0),
 		})
 	}

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -568,7 +568,7 @@ impl TransactionInner {
 	pub(crate) fn new(db: Arc<Inner>, write: bool) -> Self {
 		// Register against both watermark counters
 		let (version, counter_version) =
-			register_counter(&db.counter_by_oracle, &db.oracle.inner.timestamp, Some(&db.gc_floor));
+			register_counter(&db.counter_by_oracle, &db.oracle.timestamp, Some(&db.gc_floor));
 		let (commit, counter_commit) =
 			register_counter(&db.counter_by_commit, &db.transaction_commit_id, None);
 		// Store the threshold separately before moving db
@@ -601,7 +601,7 @@ impl TransactionInner {
 		// Re-register against both watermark counters
 		let (version, counter_version) = register_counter(
 			&self.database.counter_by_oracle,
-			&self.database.oracle.inner.timestamp,
+			&self.database.oracle.timestamp,
 			Some(&self.database.gc_floor),
 		);
 		let (commit, counter_commit) = register_counter(
@@ -865,7 +865,6 @@ impl TransactionInner {
 		// Insert this transaction into the merge queue
 		let (version, entry) = self.atomic_merge(Merge {
 			writeset,
-			id: self.database.transaction_merge_id.fetch_add(1, Ordering::AcqRel) + 1,
 		});
 		// Apply each writeset entry. Inline gc has intentionally been
 		// removed from this path: the registration race in PR #77 stems
@@ -2226,29 +2225,34 @@ impl TransactionInner {
 	fn atomic_merge(&self, updates: Merge) -> (u64, Arc<Merge>) {
 		// Store the number of spins
 		let mut spins = 0;
-		// Get the commit attempt id
-		let id = updates.id;
 		// Store the commit in an Arc
 		let updates = Arc::new(updates);
-		// Get the database timestamp oracle
+		// Get the database logical clock
 		let oracle = self.database.oracle.clone();
 		// Get the database transaction merge queue
 		let queue = &self.database.transaction_merge_queue;
-		// Loop until we reach the next incremental timestamp
+		// Claim a unique merge version from the allocation counter. The
+		// claim must NOT come from probing merge-queue slots: entries are
+		// removed from the queue once applied, and a slow concurrent
+		// committer could re-claim the vacated slot — minting the same
+		// version twice and overwriting a committed value in the chain.
+		let version = oracle.alloc.fetch_add(1, Ordering::SeqCst) + 1;
+		// Insert the merge entry at the claimed version, before the
+		// version is published: readers snapshot from `timestamp`, so a
+		// published version must imply its merge entry is visible in the
+		// queue (or already applied).
+		let entry = queue.get_or_insert_with(version, || Arc::clone(&updates));
+		// Publish strictly in claim order: wait until every lower version
+		// has been published, then advance the clock to ours. In-order
+		// publication gives readers a complete prefix — a snapshot at `v`
+		// covers every merge `<= v` with no holes.
 		loop {
-			// Get the current nanoseconds since the Unix epoch
-			let mut version = oracle.current_time_ns();
-			// Get the last timestamp for this oracle
-			let last_ts = oracle.inner.timestamp.load(Ordering::Acquire);
-			// Increase the timestamp to ensure monotonicity
-			if version <= last_ts {
-				version = last_ts + 1;
-			}
-			// Insert into the queue if the number is the same
-			let entry = queue.get_or_insert_with(version, || Arc::clone(&updates));
-			// Check if the entry was inserted correctly
-			if id == entry.value().id {
-				oracle.inner.timestamp.fetch_max(version, Ordering::SeqCst);
+			// Attempt to advance the published clock from our predecessor
+			if oracle
+				.timestamp
+				.compare_exchange_weak(version - 1, version, Ordering::SeqCst, Ordering::Acquire)
+				.is_ok()
+			{
 				return (version, entry.value().clone());
 			}
 			// Ensure the thread backs off when under contention
@@ -4452,7 +4456,7 @@ mod tests {
 	fn snapshot_isolation_reader_registration_race_does_not_lose_versions() {
 		// Reproduces a snapshot-isolation registration race in
 		// `TransactionInner::new` and `TransactionInner::reset`:
-		// `oracle.inner.timestamp` is loaded *before* the new
+		// `oracle.timestamp` is loaded *before* the new
 		// transaction's start version is registered in `counter_by_oracle`.
 		//
 		// A committer running in that load-then-register window computes
@@ -4552,7 +4556,7 @@ mod tests {
 			 and never deleted ({nones} of {total} reads returned `None`). \
 			 This is a snapshot-isolation registration race: \
 			 `TransactionInner::new` (and `::reset`) load \
-			 `oracle.inner.timestamp` before registering the \
+			 `oracle.timestamp` before registering the \
 			 transaction's start version in `counter_by_oracle`, so a \
 			 concurrent committer's inline GC can advance `cleanup_ts` \
 			 past the reader's snapshot. The reader then sees no visible \

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -766,16 +766,16 @@ impl TransactionInner {
 		}
 		// Take ownership over the local modifications
 		let writeset = Arc::new(std::mem::take(&mut self.writeset));
+		// Collect the sorted writeset keys for conflict detection. The
+		// commit queue entry retains only these keys: conflict detection
+		// never reads values, and the entry outlives the merge queue's
+		// value-bearing writeset by the whole cleanup window.
+		let keys: Arc<[Bytes]> = writeset.keys().cloned().collect();
 		// Build a bloom filter over the writeset keys
 		let mut writeset_bloom = BloomFilter::new();
-		for key in writeset.keys() {
+		for key in keys.iter() {
 			writeset_bloom.insert(key);
 		}
-		// Collect the sorted writeset keys for conflict detection. The
-		// commit queue stores keys only: its entries outlive the merge
-		// queue entry (they are trimmed later by the cleanup worker),
-		// and storing the values would pin them in memory until then.
-		let keys = writeset.keys().cloned().collect();
 		// Insert this transaction into the commit queue
 		let (version, entry) = self.atomic_commit(Commit {
 			keys,

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -18,7 +18,7 @@ use crate::bloom::BloomFilter;
 use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
-use crate::inner::{Inner, COUNTER_TOMBSTONE};
+use crate::inner::{Inner, Slot, SLOT_PINNING};
 use crate::iter::{MergeIterator, MergeQueueIter};
 use crate::kv::IntoBytes;
 use crate::pool::Pool;
@@ -67,16 +67,12 @@ const _: fn() = || {
 impl Drop for Transaction {
 	fn drop(&mut self) {
 		if let Some(inner) = self.inner.take() {
-			// Release this transaction's reference on each counter. If we
-			// took the last reference, claim removal via a 1->TOMBSTONE
-			// CAS so a fresh `register_counter` cannot increment from
-			// underneath us and end up holding a detached entry.
-			if release_counter(&inner.counter_commit) {
-				inner.database.counter_by_commit.remove(&inner.commit);
-			}
-			if release_counter(&inner.counter_version) {
-				inner.database.counter_by_oracle.remove(&inner.version);
-			}
+			// Unpin: remove this transaction's slot from the readers map.
+			// A sweeper holding the entry mid-scan reads our final
+			// snapshot values, which is only ever conservative. The slot
+			// allocation itself is retained on the pooled transaction and
+			// re-pinned on reuse.
+			inner.database.readers.remove(&inner.slot_id);
 			// Put the transaction in to the pool
 			self.pool.put(inner);
 		}
@@ -452,125 +448,65 @@ pub(crate) struct TransactionInner {
 	pub(crate) writeset: BTreeMap<Bytes, Option<Bytes>>,
 	/// The parent database for this transaction
 	pub(crate) database: Arc<Inner>,
-	/// The reference to the transaction commit counter
-	pub(crate) counter_commit: Arc<AtomicU64>,
-	/// The reference to the transaction version counter
-	pub(crate) counter_version: Arc<AtomicU64>,
+	/// The reference to this transaction's pinned reader slot
+	pub(crate) slot: Arc<Slot>,
+	/// The key of this transaction's slot in the readers map
+	pub(crate) slot_id: u64,
 	/// Threshold after which transaction state is reset
 	reset_threshold: usize,
 	/// Stack of savepoint states for nested partial rollbacks
 	savepoint_stack: Vec<SavepointState>,
 }
 
-/// Register a new transaction against one of the `Inner` counter SkipMaps.
+/// Register a transaction in the readers map and choose its snapshot.
 ///
-/// Two races make this non-trivial and motivate the validate-and-retry
-/// shape:
+/// Pin-then-read: the slot is published (in the pinning state) BEFORE
+/// the snapshot values are loaded, so every watermark scan computed
+/// after our insert either sees the pinning sentinel (and skips
+/// reclamation for that pass) or sees our final snapshot values (and is
+/// bounded by them). A scan computed before our insert loaded its
+/// bounds before our snapshot loads in the SeqCst total order, so our
+/// snapshot is at or above every bound it used — and reclamation always
+/// retains the entry visible at its watermark. This closes the historic
+/// load-then-register race structurally, with no validate/rollback
+/// retry loop and no reclamation floor.
 ///
-/// 1. **load-then-register**: between the reader's load of `atomic` and
-///    its insert into `map`, a writer can advance the watermark and run
-///    inline GC against a `front()` that does not yet see the reader.
-///    The reader's subsequent reads at its snapshot then return `None`.
-/// 2. **drop/register**: a concurrent `Transaction::Drop` that takes the
-///    last reference on the same key removes the entry from the SkipMap.
-///    Without coordination the new registration would land on a detached
-///    counter that no later `front()`/`iter()` can observe.
-///
-/// Closed by:
-///  * `atomic.load(SeqCst)` participates in the same total order as the
-///    writer's SeqCst `fetch_max`/`fetch_add`; a re-load after a SeqCst
-///    fence catches any writer that ran in between.
-///  * Drops claim removal via `1 -> COUNTER_TOMBSTONE` CAS; new
-///    registrations spin past TOMBSTONE-valued counters and retry with a
-///    fresh entry.
+/// The commit snapshot is loaded BEFORE the version snapshot, and from
+/// the contiguous completed watermark rather than the raw commit id: a
+/// commit id becomes visible before its merge version is published, so
+/// snapshotting the raw id could exclude a commit from our conflict
+/// window while its writes are invisible at our version snapshot — a
+/// lost update. Every commit at or below the watermark has published
+/// its merge version, so the version snapshot (loaded after) always
+/// covers the excluded prefix; any commit landing between the two
+/// loads simply falls inside our conflict window, which is at worst a
+/// spurious conflict, never a missed one.
 #[inline]
-fn register_counter(
-	map: &SkipMap<u64, Arc<AtomicU64>>,
-	atomic: &AtomicU64,
-	gc_floor: Option<&AtomicU64>,
-) -> (u64, Arc<AtomicU64>) {
-	loop {
-		let v = atomic.load(Ordering::SeqCst);
-		let counter = map.get_or_insert_with(v, || Arc::new(AtomicU64::new(0))).value().clone();
-		// CAS-increment, skipping the tombstone sentinel.
-		let acquired = loop {
-			let cur = counter.load(Ordering::Acquire);
-			if cur == COUNTER_TOMBSTONE {
-				break false;
-			}
-			if counter
-				.compare_exchange_weak(cur, cur + 1, Ordering::AcqRel, Ordering::Acquire)
-				.is_ok()
-			{
-				break true;
-			}
-		};
-		if !acquired {
-			continue;
-		}
-		fence(Ordering::SeqCst);
-		// Two validations after publishing our counter:
-		// (a) `atomic` must not have advanced — a writer that reads
-		//     `iter()` after this fence (in SC total order) will see our
-		//     positive count, but a `fetch_max` between our load and now
-		//     means our snapshot is stale.
-		// (b) `gc_floor` (if applicable) must be `<= v`. The BG sweeper
-		//     publishes its cleanup_ts to `gc_floor` before reclaiming
-		//     any versions, so a value above ours means the version we
-		//     wanted is about to disappear and we must retry.
-		let oracle_stable = atomic.load(Ordering::SeqCst) == v;
-		let floor_ok = match gc_floor {
-			Some(f) => f.load(Ordering::SeqCst) <= v,
-			None => true,
-		};
-		if oracle_stable && floor_ok {
-			return (v, counter);
-		}
-		// Roll back, mirroring the Drop path so a concurrent register
-		// cannot land on this counter once we tombstone it.
-		if release_counter(&counter) {
-			if let Some(e) = map.get(&v) {
-				if Arc::ptr_eq(e.value(), &counter) {
-					e.remove();
-				}
-			}
-		}
-	}
-}
-
-/// Decrement a counter and try to claim removal of its SkipMap entry.
-/// Returns `true` if the caller should remove the entry from the map.
-#[inline]
-fn release_counter(counter: &AtomicU64) -> bool {
-	loop {
-		let cur = counter.load(Ordering::Acquire);
-		if cur > 1 {
-			if counter
-				.compare_exchange_weak(cur, cur - 1, Ordering::AcqRel, Ordering::Acquire)
-				.is_ok()
-			{
-				return false;
-			}
-			continue;
-		}
-		debug_assert_eq!(cur, 1);
-		if counter
-			.compare_exchange(1, COUNTER_TOMBSTONE, Ordering::AcqRel, Ordering::Acquire)
-			.is_ok()
-		{
-			return true;
-		}
-	}
+fn pin_slot(db: &Inner, slot: &Arc<Slot>) -> (u64, u64, u64) {
+	// Publish the pinning sentinels before the slot becomes visible
+	slot.version.store(SLOT_PINNING, Ordering::SeqCst);
+	slot.commit.store(SLOT_PINNING, Ordering::SeqCst);
+	// Insert the slot into the readers map under a fresh id
+	let slot_id = db.reader_slot_id.fetch_add(1, Ordering::Relaxed) + 1;
+	db.readers.insert(slot_id, slot.clone());
+	// Pair with the fence in every watermark scan
+	fence(Ordering::SeqCst);
+	// Load the commit snapshot, then the version snapshot
+	let commit = db.commit_watermark.load(Ordering::SeqCst);
+	let version = db.oracle.timestamp.load(Ordering::SeqCst);
+	// Publish the chosen snapshot into the slot
+	slot.commit.store(commit, Ordering::SeqCst);
+	slot.version.store(version, Ordering::SeqCst);
+	// Return the slot id and the snapshot
+	(slot_id, commit, version)
 }
 
 impl TransactionInner {
 	/// Create a new read-only or writeable transaction
 	pub(crate) fn new(db: Arc<Inner>, write: bool) -> Self {
-		// Register against both watermark counters
-		let (version, counter_version) =
-			register_counter(&db.counter_by_oracle, &db.oracle.timestamp, Some(&db.gc_floor));
-		let (commit, counter_commit) =
-			register_counter(&db.counter_by_commit, &db.transaction_commit_id, None);
+		// Allocate this transaction's slot and pin it
+		let slot = Arc::new(Slot::pinning());
+		let (slot_id, commit, version) = pin_slot(&db, &slot);
 		// Store the threshold separately before moving db
 		let threshold = db.reset_threshold;
 		// Create the transaction
@@ -585,8 +521,8 @@ impl TransactionInner {
 			scanset: SkipMap::new(),
 			writeset: BTreeMap::new(),
 			database: db,
-			counter_commit,
-			counter_version,
+			slot,
+			slot_id,
 			reset_threshold: threshold,
 			savepoint_stack: Vec::new(),
 		}
@@ -598,17 +534,8 @@ impl TransactionInner {
 		self.mode = IsolationLevel::SerializableSnapshotIsolation;
 		// Update the reset threshold from the database
 		self.reset_threshold = self.database.reset_threshold;
-		// Re-register against both watermark counters
-		let (version, counter_version) = register_counter(
-			&self.database.counter_by_oracle,
-			&self.database.oracle.timestamp,
-			Some(&self.database.gc_floor),
-		);
-		let (commit, counter_commit) = register_counter(
-			&self.database.counter_by_commit,
-			&self.database.transaction_commit_id,
-			None,
-		);
+		// Re-pin the retained slot allocation under a fresh id
+		let (slot_id, commit, version) = pin_slot(&self.database, &self.slot);
 		// Clear savepoint stack
 		self.savepoint_stack.clear();
 		// Clear or completely reset the allocated readset
@@ -633,8 +560,7 @@ impl TransactionInner {
 		self.write = write;
 		self.commit = commit;
 		self.version = version;
-		self.counter_commit = counter_commit;
-		self.counter_version = counter_version;
+		self.slot_id = slot_id;
 	}
 
 	/// Get the starting sequence number of this transaction
@@ -777,19 +703,35 @@ impl TransactionInner {
 			writeset_bloom.insert(key);
 		}
 		// Insert this transaction into the commit queue
-		let (version, entry) = self.atomic_commit(Commit {
+		let (commit_slot, commit_entry) = self.atomic_commit(Commit {
 			keys,
 			id: self.database.transaction_queue_id.fetch_add(1, Ordering::AcqRel) + 1,
 			writeset_bloom,
+			merge_version: AtomicU64::new(0),
 		});
 		// Check wether we should check reads conflicts on commit
 		if self.mode >= IsolationLevel::SnapshotIsolation {
-			// Retrieve all transactions committed since we began
-			for tx in self.database.transaction_commit_queue.range(self.commit + 1..version) {
+			// Retrieve all transactions committed since we began. The
+			// window base is the completed watermark our snapshot was
+			// taken from, which over-approximates concurrency: it can
+			// include commits our version snapshot already sees.
+			for tx in self.database.transaction_commit_queue.range(self.commit + 1..commit_slot) {
+				// Skip commits whose merge version is visible in our
+				// snapshot: a visible commit happened strictly before our
+				// snapshot in version order, so it is not concurrent with
+				// this transaction and first-committer-wins does not
+				// apply — we read its effects rather than raced with it.
+				let merge_version = tx.value().merge_version.load(Ordering::SeqCst);
+				if merge_version != 0 && merge_version <= self.version {
+					continue;
+				}
 				// Check if a previous transaction conflicts against writes
-				if !tx.value().is_disjoint_writeset_bloom(&entry) {
-					// Remove the transaction from the commit queue
-					self.database.transaction_commit_queue.remove(&version);
+				if !tx.value().is_disjoint_writeset_bloom(&commit_entry) {
+					// Remove the transaction from the commit queue, then
+					// advance the completed watermark: a removed entry
+					// counts as complete and may unblock the prefix
+					self.database.transaction_commit_queue.remove(&commit_slot);
+					self.database.advance_commit_watermark();
 					// Clear the transaction state
 					self.scanset.clear();
 					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
@@ -809,8 +751,10 @@ impl TransactionInner {
 						.value()
 						.is_disjoint_readset_bloom(&self.readset, &self.readset_bloom.lock())
 					{
-						// Remove the transaction from the commit queue
-						self.database.transaction_commit_queue.remove(&version);
+						// Remove the transaction from the commit queue, then
+						// advance the completed watermark
+						self.database.transaction_commit_queue.remove(&commit_slot);
+						self.database.advance_commit_watermark();
 						// Clear the transaction state
 						self.scanset.clear();
 						self.readset.pin().clear();
@@ -841,8 +785,10 @@ impl TransactionInner {
 							if let Some(entry) = self.scanset.range::<Bytes, _>(..=k).next_back() {
 								// Check if the range includes this key (load from ArcSwap)
 								if **entry.value().load() > *k {
-									// Remove the transaction from the commit queue
-									self.database.transaction_commit_queue.remove(&version);
+									// Remove the transaction from the commit queue,
+									// then advance the completed watermark
+									self.database.transaction_commit_queue.remove(&commit_slot);
+									self.database.advance_commit_watermark();
 									// Clear the transaction state
 									self.readset.pin().clear();
 									self.readset_bloom.lock().clear();
@@ -866,16 +812,23 @@ impl TransactionInner {
 		let (version, entry) = self.atomic_merge(Merge {
 			writeset,
 		});
+		// Our merge version is now published, so record it on the
+		// commit-queue entry and advance the contiguous completed
+		// watermark: readers snapshotting the watermark from here on may
+		// exclude this commit from their conflict windows, because their
+		// version snapshot (loaded after the watermark) is guaranteed to
+		// cover our merge version — in the queue overlay or applied below.
+		commit_entry.merge_version.store(version, Ordering::SeqCst);
+		self.database.advance_commit_watermark();
 		// Apply each writeset entry. Inline gc has intentionally been
 		// removed from this path: the registration race in PR #77 stems
 		// from the gap between `earliest_active_version` and
 		// `gc_older_versions`, where a reader registering in that window
 		// would have its snapshot version swept by a cleanup_ts computed
 		// without it. We defer all version reclamation to the background
-		// gc worker (bounded by `gc_floor`), which runs far less
-		// frequently and so does not race with the steady-state reader
-		// registration pattern. The commit path now only publishes the
-		// new version and queues the key for later sweeping.
+		// gc worker, which runs far less frequently and so does not race
+		// with the steady-state reader registration pattern. The commit
+		// path publishes the new version and queues the key for sweeping.
 		for (key, value) in entry.writeset.iter() {
 			// Clone the value for insertion
 			let value = value.clone();
@@ -4454,27 +4407,26 @@ mod tests {
 
 	#[test]
 	fn snapshot_isolation_reader_registration_race_does_not_lose_versions() {
-		// Reproduces a snapshot-isolation registration race in
-		// `TransactionInner::new` and `TransactionInner::reset`:
-		// `oracle.timestamp` is loaded *before* the new
-		// transaction's start version is registered in `counter_by_oracle`.
+		// Historic regression test for a snapshot-isolation registration
+		// race: a transaction loaded its snapshot version BEFORE becoming
+		// visible to sweepers, so a concurrently computed `cleanup_ts`
+		// could miss the registering reader and sweep the versions its
+		// snapshot needed — the reader then observed `None` for a key
+		// that was committed before its snapshot.
 		//
-		// A committer running in that load-then-register window computes
-		// `earliest = counter_by_oracle.front()` without seeing the new
-		// reader, so its inline GC in `commit()` advances
-		// `cleanup_ts = history.min(earliest)` past the reader's
-		// `self.version`. With no other live readers, `earliest` defaults
-		// to the committer's own version, so the GC sweeps *every* version
-		// older than the new commit. The pending reader then snapshots at
-		// `self.version`, calls `versions.fetch_version`, and gets `None`
-		// even though a committed value was visible at its snapshot
-		// timestamp.
+		// The pin-then-read slot protocol closes this structurally: a
+		// transaction publishes its pinning slot before loading the
+		// clock, so every sweep either sees the slot (as a sentinel or a
+		// bounding value) or precedes the snapshot load in the SeqCst
+		// total order, in which case the snapshot is at or above the
+		// sweep's clock bound — and reclamation always retains the entry
+		// visible at its watermark. This test remains as the empirical
+		// validator for that protocol.
 		//
-		// In the SurrealDB embedded `memory` backend this surfaces as a
-		// flake on tests that poll `INFO FOR INDEX` while a concurrent
-		// index builder is committing rapid heartbeat updates to the
-		// build-state key (`distributed_*_replays_second_node_update`
-		// in `surrealdb-private`).
+		// In the SurrealDB embedded `memory` backend the original bug
+		// surfaced as a flake on tests that poll `INFO FOR INDEX` while a
+		// concurrent index builder is committing rapid heartbeat updates
+		// to the build-state key.
 		use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 		use std::sync::Arc;
 		use std::thread;
@@ -4513,11 +4465,11 @@ mod tests {
 			})
 		};
 
-		// Reader threads open many short-lived snapshots. The bug
-		// triggers when a reader enters `TransactionInner::new`/`reset`,
-		// loads the oracle timestamp, and is descheduled before it can
-		// register in `counter_by_oracle`. More readers means more
-		// chances to land in that window.
+		// Reader threads open many short-lived snapshots. The original
+		// bug triggered when a reader entered `TransactionInner::new` or
+		// `reset` and was descheduled between choosing its snapshot and
+		// becoming visible to sweepers. More readers means more chances
+		// to land in that window.
 		let mut readers = Vec::new();
 		for _ in 0..6 {
 			let db = Arc::clone(&db);
@@ -4554,13 +4506,11 @@ mod tests {
 			nones, 0,
 			"reader observed `None` for a key that was seeded with a value \
 			 and never deleted ({nones} of {total} reads returned `None`). \
-			 This is a snapshot-isolation registration race: \
-			 `TransactionInner::new` (and `::reset`) load \
-			 `oracle.timestamp` before registering the \
-			 transaction's start version in `counter_by_oracle`, so a \
-			 concurrent committer's inline GC can advance `cleanup_ts` \
-			 past the reader's snapshot. The reader then sees no visible \
-			 version at its snapshot timestamp."
+			 This is a snapshot-isolation registration race: a transaction \
+			 chose its snapshot before its slot was visible to sweepers, \
+			 so a concurrently computed `cleanup_ts` swept the versions \
+			 its snapshot needed. The pin-then-read slot protocol in \
+			 `pin_slot` is supposed to make this impossible."
 		);
 	}
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -18,7 +18,7 @@ use crate::bloom::BloomFilter;
 use crate::cursor::{Cursor, KeyIterator, ScanIterator};
 use crate::direction::Direction;
 use crate::err::Error;
-use crate::inner::{Inner, Slot, SLOT_PINNING};
+use crate::inner::{Inner, Slot, COMMIT_ABORTED, SLOT_PINNING};
 use crate::iter::{MergeIterator, MergeQueueIter};
 use crate::kv::IntoBytes;
 use crate::pool::Pool;
@@ -34,7 +34,7 @@ use parking_lot::{Mutex, RwLock};
 use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::ops::Range;
-use std::sync::atomic::{fence, AtomicU64, Ordering};
+use std::sync::atomic::{fence, AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tracing::debug;
 
@@ -705,10 +705,26 @@ impl TransactionInner {
 		// Insert this transaction into the commit queue
 		let (commit_slot, commit_entry) = self.atomic_commit(Commit {
 			keys,
-			id: self.database.transaction_queue_id.fetch_add(1, Ordering::AcqRel) + 1,
 			writeset_bloom,
 			merge_version: AtomicU64::new(0),
 		});
+		// Unwind guard: if this transaction panics after publishing its
+		// commit slot, mark the entry aborted and advance the completed
+		// watermark, so an abandoned in-flight entry can never wedge the
+		// contiguous prefix that every future reader's conflict window is
+		// based on. The abort-on-conflict paths below also rely on this
+		// guard for their watermark advance after removing the entry.
+		let mut commit_guard = OnUnwind {
+			armed: true,
+			action: {
+				let database = self.database.clone();
+				let entry = commit_entry.clone();
+				move || {
+					entry.merge_version.store(COMMIT_ABORTED, Ordering::SeqCst);
+					database.advance_commit_watermark();
+				}
+			},
+		};
 		// Check wether we should check reads conflicts on commit
 		if self.mode >= IsolationLevel::SnapshotIsolation {
 			// Retrieve all transactions committed since we began. The
@@ -716,22 +732,32 @@ impl TransactionInner {
 			// taken from, which over-approximates concurrency: it can
 			// include commits our version snapshot already sees.
 			for tx in self.database.transaction_commit_queue.range(self.commit + 1..commit_slot) {
+				// Skip aborted commits: their writes will never publish
+				let merge_version = tx.value().merge_version.load(Ordering::SeqCst);
+				if merge_version == COMMIT_ABORTED {
+					continue;
+				}
 				// Skip commits whose merge version is visible in our
 				// snapshot: a visible commit happened strictly before our
 				// snapshot in version order, so it is not concurrent with
 				// this transaction and first-committer-wins does not
 				// apply — we read its effects rather than raced with it.
-				let merge_version = tx.value().merge_version.load(Ordering::SeqCst);
 				if merge_version != 0 && merge_version <= self.version {
 					continue;
 				}
 				// Check if a previous transaction conflicts against writes
 				if !tx.value().is_disjoint_writeset_bloom(&commit_entry) {
-					// Remove the transaction from the commit queue, then
-					// advance the completed watermark: a removed entry
-					// counts as complete and may unblock the prefix
-					self.database.transaction_commit_queue.remove(&commit_slot);
-					self.database.advance_commit_watermark();
+					// Do NOT remove the entry here: the commit-queue
+					// insertion-order watermark is advanced opportunistically
+					// (see `Inner::try_advance_commit_prefix`) rather than
+					// synchronously by this slot's own claim, so an entry
+					// must stay visible until that watermark has confirmably
+					// passed it — otherwise a concurrent advance could
+					// mistake "removed early" for "never inserted" and stall
+					// forever. The unwind guard (dropped below, on return)
+					// marks the entry aborted and advances the completed
+					// watermark; `cleanup_commit_queue` removes it later,
+					// once it is safely below every reader's visibility.
 					// Clear the transaction state
 					self.scanset.clear();
 					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
@@ -751,10 +777,9 @@ impl TransactionInner {
 						.value()
 						.is_disjoint_readset_bloom(&self.readset, &self.readset_bloom.lock())
 					{
-						// Remove the transaction from the commit queue, then
-						// advance the completed watermark
-						self.database.transaction_commit_queue.remove(&commit_slot);
-						self.database.advance_commit_watermark();
+						// Do not remove the entry here — see the comment
+						// on the writeset-conflict branch above. The
+						// unwind guard marks it aborted on return.
 						// Clear the transaction state
 						self.scanset.clear();
 						self.readset.pin().clear();
@@ -785,10 +810,10 @@ impl TransactionInner {
 							if let Some(entry) = self.scanset.range::<Bytes, _>(..=k).next_back() {
 								// Check if the range includes this key (load from ArcSwap)
 								if **entry.value().load() > *k {
-									// Remove the transaction from the commit queue,
-									// then advance the completed watermark
-									self.database.transaction_commit_queue.remove(&commit_slot);
-									self.database.advance_commit_watermark();
+									// Do not remove the entry here — see the
+									// comment on the writeset-conflict branch
+									// above. The unwind guard marks it
+									// aborted on return.
 									// Clear the transaction state
 									self.readset.pin().clear();
 									self.readset_bloom.lock().clear();
@@ -811,15 +836,33 @@ impl TransactionInner {
 		// Insert this transaction into the merge queue
 		let (version, entry) = self.atomic_merge(Merge {
 			writeset,
+			applied: AtomicBool::new(false),
 		});
 		// Our merge version is now published, so record it on the
-		// commit-queue entry and advance the contiguous completed
-		// watermark: readers snapshotting the watermark from here on may
-		// exclude this commit from their conflict windows, because their
-		// version snapshot (loaded after the watermark) is guaranteed to
-		// cover our merge version — in the queue overlay or applied below.
+		// commit-queue entry, disarm the abort guard, and advance the
+		// contiguous completed watermark: readers snapshotting the
+		// watermark from here on may exclude this commit from their
+		// conflict windows, because their version snapshot (loaded after
+		// the watermark) is guaranteed to cover our merge version — in
+		// the queue overlay or applied below.
 		commit_entry.merge_version.store(version, Ordering::SeqCst);
+		commit_guard.armed = false;
 		self.database.advance_commit_watermark();
+		// Unwind guard for the apply phase: a panic mid-apply leaves the
+		// chains partially updated (a pre-existing atomicity limitation),
+		// but must not wedge the in-order merge retirement — mark the
+		// entry applied and advance so later merges can still retire.
+		let mut merge_guard = OnUnwind {
+			armed: true,
+			action: {
+				let database = self.database.clone();
+				let entry = entry.clone();
+				move || {
+					entry.applied.store(true, Ordering::SeqCst);
+					database.advance_merge_retirement();
+				}
+			},
+		};
 		// Compute the inline-GC watermark ONCE for this commit, after our
 		// merge version is published and before the apply loop. The
 		// pin-then-read slot protocol makes this safe where it once was
@@ -827,7 +870,7 @@ impl TransactionInner {
 		// the slot scan or forces a skip, and every future transaction
 		// snapshots at or above the clock bound loaded inside — while our
 		// own excluded slot is pinned at our start version, so the
-		// watermark always sits strictly below the version we push.
+		// watermark can never sit above the version we push.
 		let watermark = self.database.inline_gc_watermark(self.slot_id);
 		// Apply each writeset entry, reclaiming superseded versions
 		// inline while the chain write lock is already held.
@@ -881,8 +924,18 @@ impl TransactionInner {
 		#[cfg(not(target_arch = "wasm32"))]
 		if let Some(p) = self.database.persistence.read().clone() {
 			if let Err(e) = p.append(version, entry.writeset.as_ref()) {
-				// Remove this transaction from the merge queue
-				self.database.transaction_merge_queue.remove(&version);
+				// Do NOT remove the entry here: the merge clock's
+				// insertion-order advance is opportunistic (see
+				// `Inner::try_advance_merge_clock`), so an entry must stay
+				// visible until the clock has confirmably passed it —
+				// removing it early would be indistinguishable from "never
+				// inserted" to a concurrent advance and could stall it
+				// forever. The unwind guard (dropped below, on return)
+				// marks this entry applied and lets retirement remove it
+				// once the clock naturally reaches this version — the
+				// datastore chains already hold this data regardless (the
+				// pre-existing applied-but-unpersisted limitation of this
+				// error path).
 				// Clear the transaction state
 				self.scanset.clear();
 				if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
@@ -896,8 +949,15 @@ impl TransactionInner {
 				return Err(Error::TxCommitNotPersisted(e));
 			}
 		}
-		// Remove this transaction from the merge queue
-		self.database.transaction_merge_queue.remove(&version);
+		// Mark this merge as applied and retire the contiguous applied
+		// prefix of the merge queue. Entries are NEVER removed directly
+		// here: removal out of version order would let a reader find an
+		// older in-flight version's surviving entry in the overlay while
+		// a newer version already sits applied in the chain, returning a
+		// stale value for a snapshot that should see the newer write.
+		entry.applied.store(true, Ordering::SeqCst);
+		merge_guard.armed = false;
+		self.database.advance_merge_retirement();
 		// Clear the transaction state
 		self.scanset.clear();
 		if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
@@ -2159,22 +2219,46 @@ impl TransactionInner {
 	fn atomic_commit(&self, updates: Commit) -> (u64, Arc<Commit>) {
 		// Store the number of spins
 		let mut spins = 0;
-		// Get the commit attempt id
-		let id = updates.id;
 		// Store the commit in an Arc
 		let updates = Arc::new(updates);
-		// Get the database transaction merge queue
+		// Get the database transaction commit queue
 		let queue = &self.database.transaction_commit_queue;
-		// Loop until the atomic operation is successful
+		// Claim a unique commit slot from the allocation counter. A dense
+		// claim is always unique, so no collision retry is needed, unlike
+		// probing a queue whose entries can be removed and (if probed by
+		// value) re-claimed out from under a slow concurrent committer.
+		let slot = self.database.transaction_queue_id.fetch_add(1, Ordering::SeqCst) + 1;
+		// Insert the commit entry at the claimed slot
+		let entry = queue.get_or_insert_with(slot, || Arc::clone(&updates));
+		// Publish strictly in claim order: wait until every lower slot
+		// has been published, then advance the inserted-prefix bound to
+		// cover our own. This is NOT purely a courtesy to others — a
+		// subsequent transaction on this same thread relies on being
+		// able to see this commit's effects via the published bound
+		// alone (it has no other source of "how recent" information),
+		// so our own slot must be reflected before we return.
 		loop {
-			// Get the current commit queue number
-			let version = self.database.transaction_commit_id.load(Ordering::Acquire) + 1;
-			// Insert into the queue if the number is the same
-			let entry = queue.get_or_insert_with(version, || Arc::clone(&updates));
-			// Check if the entry was inserted correctly
-			if id == entry.value().id {
-				self.database.transaction_commit_id.fetch_add(1, Ordering::SeqCst);
-				return (version, entry.value().clone());
+			// Reload the current bound rather than retrying a fixed CAS:
+			// a concurrent opportunistic helper (`try_advance_commit_prefix`,
+			// used by the cleanup/GC paths) can advance this same bound on
+			// our behalf once our entry is inserted, using only presence
+			// in the queue as its criterion. If we kept retrying a stale
+			// `compare_exchange(slot - 1, slot)` after that happens, the
+			// bound can never return to `slot - 1` (it is monotonic), so
+			// our CAS would never succeed again — a livelock. Treat the
+			// bound already having reached our slot as success.
+			let cur = self.database.transaction_commit_id.load(Ordering::SeqCst);
+			if cur >= slot {
+				return (slot, entry.value().clone());
+			}
+			if cur == slot - 1
+				&& self
+					.database
+					.transaction_commit_id
+					.compare_exchange_weak(cur, slot, Ordering::SeqCst, Ordering::Acquire)
+					.is_ok()
+			{
+				return (slot, entry.value().clone());
 			}
 			// Ensure the thread backs off when under contention
 			backoff(spins);
@@ -2194,27 +2278,27 @@ impl TransactionInner {
 		let oracle = self.database.oracle.clone();
 		// Get the database transaction merge queue
 		let queue = &self.database.transaction_merge_queue;
-		// Claim a unique merge version from the allocation counter. The
-		// claim must NOT come from probing merge-queue slots: entries are
-		// removed from the queue once applied, and a slow concurrent
-		// committer could re-claim the vacated slot — minting the same
-		// version twice and overwriting a committed value in the chain.
+		// Claim a unique merge version from the allocation counter. See
+		// the equivalent comment in `atomic_commit`: a dense claim is
+		// always unique, so no collision retry is needed.
 		let version = oracle.alloc.fetch_add(1, Ordering::SeqCst) + 1;
-		// Insert the merge entry at the claimed version, before the
-		// version is published: readers snapshot from `timestamp`, so a
-		// published version must imply its merge entry is visible in the
-		// queue (or already applied).
+		// Insert the merge entry at the claimed version
 		let entry = queue.get_or_insert_with(version, || Arc::clone(&updates));
-		// Publish strictly in claim order: wait until every lower version
-		// has been published, then advance the clock to ours. In-order
-		// publication gives readers a complete prefix — a snapshot at `v`
-		// covers every merge `<= v` with no holes.
+		// Publish strictly in claim order — see the equivalent comment
+		// in `atomic_commit` for why this must cover our own version
+		// before we return, and why we reload rather than retry a fixed
+		// CAS (a concurrent `try_advance_merge_clock` call can publish
+		// our version on our behalf).
 		loop {
-			// Attempt to advance the published clock from our predecessor
-			if oracle
-				.timestamp
-				.compare_exchange_weak(version - 1, version, Ordering::SeqCst, Ordering::Acquire)
-				.is_ok()
+			let cur = oracle.timestamp.load(Ordering::SeqCst);
+			if cur >= version {
+				return (version, entry.value().clone());
+			}
+			if cur == version - 1
+				&& oracle
+					.timestamp
+					.compare_exchange_weak(cur, version, Ordering::SeqCst, Ordering::Acquire)
+					.is_ok()
 			{
 				return (version, entry.value().clone());
 			}
@@ -2228,7 +2312,7 @@ impl TransactionInner {
 
 /// Progressive backoff strategy for contention in atomic queues.
 #[inline(always)]
-fn backoff(spins: usize) {
+pub(crate) fn backoff(spins: usize) {
 	if spins < 10 {
 		std::hint::spin_loop();
 	} else {
@@ -2240,6 +2324,28 @@ fn backoff(spins: usize) {
 		}
 		#[cfg(target_arch = "wasm32")]
 		std::hint::spin_loop();
+	}
+}
+
+/// Runs a completion action when dropped while still armed.
+///
+/// Used by the commit path to guarantee forward progress of the
+/// contiguous commit and merge watermarks when a transaction unwinds
+/// mid-commit: an abandoned in-flight queue entry would otherwise wedge
+/// the prefix forever. Disarmed on the success path once the completion
+/// has been performed explicitly.
+struct OnUnwind<F: FnMut()> {
+	/// The completion action to run on an armed drop
+	action: F,
+	/// Whether the action still needs to run
+	armed: bool,
+}
+
+impl<F: FnMut()> Drop for OnUnwind<F> {
+	fn drop(&mut self) {
+		if self.armed {
+			(self.action)();
+		}
 	}
 }
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -820,29 +820,30 @@ impl TransactionInner {
 		// cover our merge version — in the queue overlay or applied below.
 		commit_entry.merge_version.store(version, Ordering::SeqCst);
 		self.database.advance_commit_watermark();
-		// Apply each writeset entry. Inline gc has intentionally been
-		// removed from this path: the registration race in PR #77 stems
-		// from the gap between `earliest_active_version` and
-		// `gc_older_versions`, where a reader registering in that window
-		// would have its snapshot version swept by a cleanup_ts computed
-		// without it. We defer all version reclamation to the background
-		// gc worker, which runs far less frequently and so does not race
-		// with the steady-state reader registration pattern. The commit
-		// path publishes the new version and queues the key for sweeping.
+		// Compute the inline-GC watermark ONCE for this commit, after our
+		// merge version is published and before the apply loop. The
+		// pin-then-read slot protocol makes this safe where it once was
+		// not (the PR #77 race): every current transaction is visible in
+		// the slot scan or forces a skip, and every future transaction
+		// snapshots at or above the clock bound loaded inside — while our
+		// own excluded slot is pinned at our start version, so the
+		// watermark always sits strictly below the version we push.
+		let watermark = self.database.inline_gc_watermark(self.slot_id);
+		// Apply each writeset entry, reclaiming superseded versions
+		// inline while the chain write lock is already held.
 		for (key, value) in entry.writeset.iter() {
 			// Clone the value for insertion
 			let value = value.clone();
 			// Publish the new version into the datastore, guarding against a
-			// concurrent background gc that may be unlinking this key: the
-			// sweeper calls `Entry::remove` while holding the entry's write
+			// concurrent gc sweep that may be unlinking this key: sweeps
+			// call `Entry::remove` while holding the entry's write
 			// lock, so once we hold that lock `is_removed()` tells us whether
 			// the node is still live. `get_or_insert_with` (unlike `insert`)
 			// never replaces a live node, so a concurrent writer's entry can
-			// never be clobbered; if the sweeper unlinked the node we landed
+			// never be clobbered; if a sweep unlinked the node we landed
 			// on, we retry and get a fresh one. The closure seeds the chain
 			// with this version so a freshly-inserted node is never an empty,
-			// immediately-gc-reclaimable node mid-insert. See
-			// `Inner::run_gc_dirty_inner`.
+			// immediately-gc-reclaimable node mid-insert.
 			loop {
 				let entry = self.database.datastore.get_or_insert_with(key.clone(), || {
 					RwLock::new(Versions::from(Version {
@@ -851,7 +852,7 @@ impl TransactionInner {
 					}))
 				});
 				let mut versions = entry.value().write();
-				// The sweeper unlinked this node between lookup and lock; retry
+				// A sweep unlinked this node between lookup and lock; retry
 				// onto a fresh one rather than writing into a detached node.
 				if entry.is_removed() {
 					continue;
@@ -861,11 +862,20 @@ impl TransactionInner {
 					version,
 					value,
 				});
+				// Reclaim versions no live or future transaction can see,
+				// under the write lock we already hold. When the chain
+				// collapses entirely — the entry visible at the watermark
+				// is a delete tombstone with nothing newer, e.g. our own
+				// delete with no readers below — unlink the node while
+				// still holding the lock, so a concurrent committer
+				// observes `is_removed()` and re-inserts.
+				if let Some(w) = watermark {
+					if versions.gc_older_versions(w) == 0 {
+						entry.remove();
+					}
+				}
 				break;
 			}
-			// Queue the key for background gc. Each commit publishes
-			// fresh stale versions, so every modified key is dirty.
-			self.database.gc_dirty_keys.push(key.clone());
 		}
 		// Append the transaction to the persistence layer
 		#[cfg(not(target_arch = "wasm32"))]
@@ -4516,9 +4526,10 @@ mod tests {
 
 	/// Per-key version chain: many overlapping writers on one key, then
 	/// verify the raw chain is strictly monotonic and holds every committed
-	/// value exactly once. Background workers are disabled so the chain is
-	/// never pruned while the test inspects it: the commit path performs no
-	/// inline GC, so all reclamation happens in the (disabled) worker.
+	/// value exactly once. A reader pinned at the seed version holds every
+	/// commit's inline-GC watermark below the whole test's writes, so the
+	/// chain retains the full history for inspection; background workers
+	/// are disabled so no safety-net sweep runs either.
 	#[test]
 	fn test_version_chain_monotonic_under_concurrent_writers() {
 		const THREADS: usize = 8;
@@ -4532,6 +4543,9 @@ mod tests {
 			tx.set(b"hotkey".to_vec(), b"seed".to_vec()).unwrap();
 			tx.commit().unwrap();
 		}
+		// Pin a reader at the seed version so inline commit-time GC keeps
+		// the seed and every later version alive for the whole test.
+		let pin = db.transaction(false);
 		let barrier = Arc::new(std::sync::Barrier::new(THREADS));
 		let written: Arc<std::sync::Mutex<std::collections::BTreeSet<Vec<u8>>>> =
 			Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
@@ -4579,16 +4593,22 @@ mod tests {
 			chain.iter().filter_map(|v| v.value.as_ref().map(|b| b.to_vec())).collect();
 		got.remove(b"seed".as_slice());
 		assert_eq!(got, committed, "chain values diverge from committed writes");
+		// Release the pinned reader
+		drop(pin);
 	}
 
 	/// Repeated sequential writes to the same keys: each key's raw version
-	/// chain accumulates every committed round in order. Background workers
-	/// are disabled so chains retain all versions during inspection.
+	/// chain accumulates every committed round in order. A reader pinned
+	/// before the first round holds every commit's inline-GC watermark
+	/// below the whole test's writes; background workers are disabled so
+	/// no safety-net sweep runs either.
 	#[test]
 	fn test_version_chain_accumulates_repeated_writes() {
 		let db = Database::new_with_options(
 			crate::DatabaseOptions::default().with_all_workers_disabled(),
 		);
+		// Pin a reader so inline commit-time GC retains every round
+		let pin = db.transaction(false);
 		// Five writes per key, on 200 keys
 		for round in 0..5 {
 			let mut tx = db.transaction(true);
@@ -4619,5 +4639,7 @@ mod tests {
 				);
 			}
 		}
+		// Release the pinned reader
+		drop(pin);
 	}
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -11,8 +11,21 @@ pub(crate) enum IndexOrUpdate<'a> {
 	Update(&'a mut Version),
 }
 
+/// A key's MVCC version chain, ordered oldest to newest.
+///
+/// The inline capacity is one entry: eager commit-time garbage
+/// collection keeps every chain at a single live value except while a
+/// reader watermark briefly pins superseded versions, and in a large
+/// dataset the overwhelming majority of keys are cold — written once
+/// and holding exactly one version forever. Sizing the inline buffer
+/// for the steady state keeps every cold key at ~a third of the memory
+/// a four-slot buffer costs, which dominates total datastore footprint
+/// by key count. Keys that do grow a chain under a pinned reader spill
+/// to a small heap buffer once (SmallVec retains it thereafter), and
+/// even a spilled two-entry chain occupies no more total memory than
+/// the old four-slot inline layout.
 pub struct Versions {
-	inner: SmallVec<[Version; 4]>,
+	inner: SmallVec<[Version; 1]>,
 }
 
 impl From<Version> for Versions {
@@ -893,5 +906,18 @@ mod tests {
 		}
 		assert_eq!(versions.inner.len(), 1);
 		assert_eq!(versions.fetch_version(10), Some(Bytes::from("v99".to_string())));
+	}
+	#[test]
+	fn versions_inline_footprint_is_small() {
+		// The datastore holds one `Versions` per key, so its inline size
+		// directly scales total memory by key count. One inline entry plus
+		// SmallVec bookkeeping must stay within 56 bytes — sizing the
+		// buffer for the steady state (eager commit-time GC keeps chains
+		// at a single live value) rather than for transient growth.
+		assert!(
+			std::mem::size_of::<Versions>() <= 56,
+			"Versions grew to {} bytes; the per-key inline footprint is load-bearing for large datasets",
+			std::mem::size_of::<Versions>()
+		);
 	}
 }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -26,7 +26,9 @@ impl From<Version> for Versions {
 }
 
 impl Versions {
-	/// Create a new versions object.
+	/// Create a new versions object. Only the persistence loader builds
+	/// chains incrementally, so this is unused on wasm targets.
+	#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 	#[inline]
 	pub(crate) fn new() -> Self {
 		Versions {
@@ -35,6 +37,14 @@ impl Versions {
 	}
 
 	/// Appends or inserts an element into its sorted position.
+	///
+	/// Entries are NEVER deduplicated by value across different versions:
+	/// versions can arrive out of order (concurrent commit applies, and
+	/// append-only log replay, both race), so dropping a strictly-newer
+	/// version because its value matches an older neighbour silently loses
+	/// the write once an intermediate version is inserted between them.
+	/// Only pushes of the SAME version are collapsed, which keeps replay
+	/// idempotent.
 	#[inline]
 	pub(crate) fn push(&mut self, value: Version) {
 		// Fast path: check if appending to the end
@@ -42,11 +52,8 @@ impl Versions {
 			// Compare the new value with the last value
 			match value.version.cmp(&last.version) {
 				std::cmp::Ordering::Greater => {
-					// Newer version - append if value is different
-					if value.value != last.value {
-						self.inner.push(value);
-					}
-					// Same value, ignore duplicate
+					// Newer version - append
+					self.inner.push(value);
 					return;
 				}
 				std::cmp::Ordering::Equal => {
@@ -62,7 +69,8 @@ impl Versions {
 				}
 			}
 		} else {
-			// Empty list - push if not a delete
+			// Empty list - push if not a delete. An initial delete is
+			// ignored: an absent prefix already reads as `None`.
 			if value.value.is_some() {
 				self.inner.push(value);
 			}
@@ -91,17 +99,13 @@ impl Versions {
 	///
 	/// This function works in the following way:
 	/// - Return IndexOrUpdate::Ignore if:
-	///   - The latest entry with a version <= value.version has the same value
-	///     as the new value
-	///   - The latest entry with a version <= value.version is a delete and the
-	///     new value is a delete
+	///   - There is no entry with a version <= value.version and the new
+	///     value is a delete (an absent prefix already reads as `None`)
 	/// - Return IndexOrUpdate::Update(version) if:
 	///   - The new value version is the same as an existing version and we
 	///     should update the entry
 	/// - Return IndexOrUpdate::Index(index) if:
-	///   - There is no entry with a version <= value.version
-	///   - The new value version is different to the latest entry with a
-	///     version <= value.version
+	///   - The entry belongs at any other sorted position
 	#[inline]
 	pub(crate) fn fetch_index_or_update(&mut self, value: &Version) -> IndexOrUpdate<'_> {
 		// Find the index of the item where item.version <= value.version
@@ -127,12 +131,8 @@ impl Versions {
 				// Same version, different value - update
 				return IndexOrUpdate::Update(existing);
 			}
-			// Different version - check if values are the same
-			if existing.value == value.value {
-				// Latest entry has the same value - ignore
-				return IndexOrUpdate::Ignore;
-			}
-			// Different version, different value - insert
+			// Different version - insert in sorted position. No value
+			// deduplication here: see the `push` doc comment.
 			return IndexOrUpdate::Index(idx);
 		}
 		// Fallback - should not reach here
@@ -624,15 +624,17 @@ mod tests {
 		// Push first version
 		versions.push(make_version(10, Some("v1")));
 		assert_eq!(versions.inner.len(), 1);
-		// Push same value at newer version - should be skipped
+		// Push same value at newer version - kept: value deduplication
+		// across versions is unsound under out-of-order insertion (a
+		// later insert between the two would silently lose this write)
 		versions.push(make_version(20, Some("v1")));
-		assert_eq!(versions.inner.len(), 1);
+		assert_eq!(versions.inner.len(), 2);
 		// Push different value - should be added
 		versions.push(make_version(30, Some("v2")));
-		assert_eq!(versions.inner.len(), 2);
-		// Push same value again - should be skipped
+		assert_eq!(versions.inner.len(), 3);
+		// Push same value again - kept
 		versions.push(make_version(40, Some("v2")));
-		assert_eq!(versions.inner.len(), 2);
+		assert_eq!(versions.inner.len(), 4);
 	}
 
 	#[test]
@@ -709,9 +711,11 @@ mod tests {
 		let mut versions = Versions::new();
 		versions.push(make_version(10, Some("v1")));
 		versions.push(make_version(20, Some("v2")));
-		// Fast path: append with same value as last - should be ignored
+		// Fast path: append with same value as last - kept as its own
+		// version (cross-version value deduplication is unsound under
+		// out-of-order insertion)
 		versions.push(make_version(30, Some("v2")));
-		assert_eq!(versions.inner.len(), 2);
+		assert_eq!(versions.inner.len(), 3);
 		assert_eq!(versions.fetch_version(30), Some(Bytes::from("v2".to_string())));
 	}
 
@@ -856,11 +860,11 @@ mod tests {
 		versions.push(make_version(10, Some("v1")));
 		// Push delete at version 20
 		versions.push(make_version(20, None));
-		// Push another delete at version 30 (different from last value which is None)
+		// Push another delete at version 30 - kept as its own version
 		versions.push(make_version(30, None));
 
-		// Should only have 2 entries - version 20 and 30 deletes should be separate
-		assert_eq!(versions.inner.len(), 2);
+		// All three entries are retained
+		assert_eq!(versions.inner.len(), 3);
 		assert!(!versions.exists_version(20));
 		assert!(!versions.exists_version(30));
 	}

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -814,6 +814,57 @@ fn test_snapshot_persists_only_latest_version() {
 }
 
 #[test]
+fn test_restart_seeds_version_counter() {
+	// Create a temporary directory for testing
+	let temp_dir = TempDir::new().unwrap();
+	let temp_path = temp_dir.path();
+
+	// Configure synchronous AOL persistence
+	let persistence_opts = || {
+		PersistenceOptions::new(temp_path)
+			.with_aol_mode(AolMode::SynchronousOnCommit)
+			.with_snapshot_mode(SnapshotMode::Never)
+			.with_fsync_mode(FsyncMode::EveryAppend)
+	};
+
+	// Run 1: commit three versions of one key (versions 1..=3)
+	{
+		let db =
+			Database::new_with_persistence(DatabaseOptions::default(), persistence_opts()).unwrap();
+		for val in ["a", "b", "c"] {
+			let mut tx = db.transaction(true);
+			tx.set("key", val).unwrap();
+			tx.commit().unwrap();
+		}
+	}
+
+	// Run 2: the logical clock must be seeded above the persisted
+	// versions, so the new write lands strictly above the reloaded
+	// chain. Without seeding it would mint version 1 and be inserted
+	// BELOW the persisted versions, making the old value win.
+	{
+		let db =
+			Database::new_with_persistence(DatabaseOptions::default(), persistence_opts()).unwrap();
+		let mut tx = db.transaction(true);
+		tx.set("key", "d").unwrap();
+		tx.commit().unwrap();
+		let mut tx = db.transaction(false);
+		assert_eq!(tx.get("key").unwrap(), Some(Bytes::from("d")));
+		tx.cancel().unwrap();
+	}
+
+	// Run 3: replaying the full log after another restart must still
+	// surface the run-2 write as the latest value
+	{
+		let db =
+			Database::new_with_persistence(DatabaseOptions::default(), persistence_opts()).unwrap();
+		let mut tx = db.transaction(false);
+		assert_eq!(tx.get("key").unwrap(), Some(Bytes::from("d")));
+		tx.cancel().unwrap();
+	}
+}
+
+#[test]
 fn test_loads_multiversion_snapshot_files() {
 	// Create a temporary directory for testing
 	let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Follow-up to #84. With historical versioning gone, merge versions no longer need to be wall-clock timestamps — this PR rebuilds the engine's clock, reader registration, and garbage collection around that fact.

- **Logical merge clock**: replaces the wall-clock oracle (and its resync thread) with a dense two-counter logical clock (`alloc` claim counter + `timestamp` published prefix). Deletes `DatabaseOptions::resync_interval`.
- **Pin-then-read reader registration**: a single unified `Slot` per live transaction, published as PINNING before the snapshot is loaded, replacing the `gc_floor` validate/rollback/retry protocol. Closes a pre-existing lost-update window (commit id visible before merge version published) via a contiguous completed-commit watermark that readers snapshot instead of the raw commit id.
- **Eager commit-time GC**: every commit trims the chains it touches down to the exact reader watermark, restoring the pre-#77 memory profile race-free. The dirty-key queue is retired; the background sweep becomes a low-frequency full-scan safety net (default interval 500ms → 10s). Deletes `Database::run_gc_dirty` and `DatabaseOptions::gc_full_scan_frequency`.
- **In-order merge retirement**: merge-queue entries retire strictly in version order over the contiguous applied prefix, so the read overlay can never surface a stale value mid-apply.
- **Commit-path livelock fix**: the publish loops in `atomic_commit`/`atomic_merge` reload rather than retry a fixed CAS, since the opportunistic watermark helpers on the cleanup/GC paths can advance the same atomics on a committer's behalf.

The first two commits re-land the branch's original keys-only commit queue and idle trim on top of the parallel #82/#83 implementations, reconciling to derived `min_key()`/`max_key()` methods (from #82) over an `Arc<[Bytes]>` key list.

## Performance vs main

Measured with criterion, regressions re-checked with a second run:

- Transaction creation (read and write): **~27–28% faster**
- Most put/get combinations: **5–25% faster**
- Writeset bloom conflict path: **18–52% faster**
- No reproducible regressions (9 first-pass regressions all failed to reproduce on re-measurement)

## Breaking changes

- Removed `DatabaseOptions::{resync_interval, with_resync_interval, gc_full_scan_frequency, with_gc_full_scan_frequency}` and `Database::run_gc_dirty`
- `Transaction::version()` now returns small logical sequence numbers instead of wall-clock nanoseconds; persistence files carry logical versions (readable across the boundary in both directions)
- Default `gc_interval` raised from 500ms to 10s (steady-state reclamation is now inline at commit)

## Testing

- Full suite green, including new tests for slot lifecycle, watermark conservatism under PINNING, dense clock, seed continuation, inline GC trim/unlink, safety-net reclamation, and a pin-then-read stress test (6 readers × writer × unthrottled sweeper)
- The PR #77 regression test passes unchanged at every commit
- 15 consecutive stress-test runs + 10 concurrent-delete runs with zero failures after the livelock fix, plus an adversarial audit for the same CAS bug class across the crate