### PR TITLE
Sweep only tracked garbage candidates instead of scanning the datastore

### DIFF
--- a/CARGO.md
+++ b/CARGO.md
@@ -61,8 +61,11 @@ fn main() {
 
 Background worker threads perform cleanup and garbage collection at regular
 intervals. These workers can be disabled through `DatabaseOptions` by setting
-`enable_cleanup` or `enable_gc` to `false`. When disabled, the tasks can be
-triggered manually using the `run_cleanup` and `run_gc` methods.
+`enable_cleanup` or `enable_gc` to `false`. When disabled, trigger the tasks
+manually: `run_cleanup` trims the transaction commit queue, `run_gc_tracked`
+sweeps just the keys tracked as holding reclaimable version garbage (cheap —
+its cost scales with the amount of pinned garbage, not the dataset size), and
+`run_gc` performs a full datastore scan, useful as an occasional deep sweep.
 
 ```rust
 use surrealmx::{Database, DatabaseOptions};
@@ -82,10 +85,13 @@ fn main() {
     tx.put("key", "value2").unwrap();
     tx.commit().unwrap();
 
-	// Manually remove unused transaction stale versions
+	// Manually trim the transaction commit queue
     db.run_cleanup();
 	
-	// Manually remove old queue entries
+	// Manually sweep the tracked garbage-candidate keys
+    db.run_gc_tracked();
+	
+	// Occasionally, perform a full-scan sweep of the datastore
     db.run_gc();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ fn main() {
 
 Background worker threads perform cleanup and garbage collection at regular
 intervals. These workers can be disabled through `DatabaseOptions` by setting
-`enable_cleanup` or `enable_gc` to `false`. When disabled, the tasks can be
-triggered manually using the `run_cleanup` and `run_gc` methods.
+`enable_cleanup` or `enable_gc` to `false`. When disabled, trigger the tasks
+manually: `run_cleanup` trims the transaction commit queue, `run_gc_tracked`
+sweeps just the keys tracked as holding reclaimable version garbage (cheap —
+its cost scales with the amount of pinned garbage, not the dataset size), and
+`run_gc` performs a full datastore scan, useful as an occasional deep sweep.
 
 ```rust
 use surrealmx::{Database, DatabaseOptions};
@@ -85,10 +88,13 @@ fn main() {
     tx.put("key", "value2").unwrap();
     tx.commit().unwrap();
 
-	// Manually remove unused transaction stale versions
+	// Manually trim the transaction commit queue
     db.run_cleanup();
 	
-	// Manually remove old queue entries
+	// Manually sweep the tracked garbage-candidate keys
+    db.run_gc_tracked();
+	
+	// Occasionally, perform a full-scan sweep of the datastore
     db.run_gc();
 }
 ```

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -975,7 +975,7 @@ fn bench_gc_full_scan(c: &mut Criterion) {
 	for total_keys in [1_000, 10_000, 100_000].iter() {
 		// Setup helper: create datastore, then overwrite a small subset
 		// while a reader pins the old versions, then drop the reader —
-		// exactly the garbage shape only the safety net can reclaim.
+		// exactly the garbage shape only a background sweep can reclaim.
 		let setup = || {
 			let db =
 				Database::new_with_options(DatabaseOptions::default().with_all_workers_disabled());
@@ -1004,7 +1004,9 @@ fn bench_gc_full_scan(c: &mut Criterion) {
 			db
 		};
 
-		// Full-scan GC: grows linearly with total keys
+		// Full-scan GC: grows linearly with total keys. The database is
+		// returned from the routine so its O(n) teardown is dropped
+		// outside the timed region rather than polluting the measurement.
 		group.bench_function(
 			BenchmarkId::new("full_gc", format!("{}total_{}stale", total_keys, stale_count)),
 			|b| {
@@ -1012,6 +1014,23 @@ fn bench_gc_full_scan(c: &mut Criterion) {
 					setup,
 					|db| {
 						db.run_gc();
+						db
+					},
+					criterion::BatchSize::LargeInput,
+				)
+			},
+		);
+
+		// Tracked sweep: visits only the keys commits tracked as holding
+		// garbage, so cost scales with the stale count, not total keys
+		group.bench_function(
+			BenchmarkId::new("tracked_gc", format!("{}total_{}stale", total_keys, stale_count)),
+			|b| {
+				b.iter_batched(
+					setup,
+					|db| {
+						db.run_gc_tracked();
+						db
 					},
 					criterion::BatchSize::LargeInput,
 				)

--- a/src/db.rs
+++ b/src/db.rs
@@ -180,17 +180,48 @@ impl Database {
 	/// Manually perform a full garbage collection sweep.
 	///
 	/// Steady-state reclamation happens inline at commit time: every
-	/// commit trims the chains it touches down to the current watermark.
-	/// This sweep is the safety net for garbage which no future commit
-	/// will visit — versions pinned by a since-departed reader on a key
-	/// that is never written again. It is useful when automatic
-	/// background GC is disabled via [`DatabaseOptions::enable_gc`], for
-	/// example on wasm targets, which have no background threads.
+	/// commit trims the chains it touches down to the current watermark,
+	/// and tracks any chain it could not fully trim for the targeted
+	/// sweep (see [`Database::run_gc_tracked`]). This full scan visits
+	/// every key regardless of tracking, so it also supersedes the
+	/// candidate set — the set is cleared before scanning, and commits
+	/// racing with the scan re-track their keys as usual. It is useful
+	/// when automatic background GC is disabled via
+	/// [`DatabaseOptions::enable_gc`], for example on wasm targets,
+	/// which have no background threads.
 	pub fn run_gc(&self) {
 		// Skip the pass entirely when registrations are in flight
 		if let Some(cleanup_ts) = self.compute_cleanup_ts() {
+			// The full scan visits every candidate anyway
+			self.gc_candidates.pin().clear();
 			// Perform a full datastore scan for stale versions
 			self.run_gc_full(cleanup_ts);
+		}
+	}
+
+	/// Manually sweep only the keys tracked as holding reclaimable
+	/// version garbage.
+	///
+	/// Commits track every chain they could not trim to a single live
+	/// value (older versions pinned by a reader, or a newest-entry
+	/// delete tombstone awaiting collapse), so this sweep's cost scales
+	/// with the amount of pinned garbage rather than the dataset size.
+	/// This is the pass the background garbage collector runs on every
+	/// tick; call it manually when background GC is disabled via
+	/// [`DatabaseOptions::enable_gc`], reserving the full-scan
+	/// [`Database::run_gc`] for occasional use.
+	pub fn run_gc_tracked(&self) {
+		// The steady state is an empty candidate set: skip the watermark
+		// computation (a fence and full slot scan) entirely when there
+		// is nothing to sweep. A key tracked concurrently with this
+		// check is picked up by the next pass.
+		if self.gc_candidates.pin().is_empty() {
+			return;
+		}
+		// Skip the pass entirely when registrations are in flight
+		if let Some(cleanup_ts) = self.compute_cleanup_ts() {
+			// Sweep only the tracked candidate keys
+			self.inner.run_gc_tracked(cleanup_ts);
 		}
 	}
 
@@ -272,11 +303,12 @@ impl Database {
 		if db.garbage_collection_handle.read().is_none() {
 			// Get the specified interval
 			let interval = self.gc_interval;
-			// Spawn a new thread to handle the periodic safety-net sweep.
-			// Steady-state reclamation happens inline at commit time, so
-			// this low-frequency full scan only collects garbage which no
-			// future commit will visit: versions pinned by a departed
-			// reader on a key that is never written again.
+			// Spawn a new thread to handle the periodic tracked sweep.
+			// Steady-state reclamation happens inline at commit time, and
+			// every chain a commit could not fully trim is tracked in the
+			// candidate set — so this sweep visits only tracked keys, and
+			// its cost scales with the amount of pinned garbage rather
+			// than the dataset size.
 			let handle = std::thread::spawn(move || {
 				// Check whether the garbage collection process is enabled
 				while db.background_threads_enabled.load(Ordering::Relaxed) {
@@ -285,6 +317,12 @@ impl Database {
 					// Check shutdown flag again after waking
 					if !db.background_threads_enabled.load(Ordering::Relaxed) {
 						break;
+					}
+					// The steady state is an empty candidate set: skip
+					// the watermark computation (a fence and full slot
+					// scan) entirely when there is nothing to sweep.
+					if db.gc_candidates.pin().is_empty() {
+						continue;
 					}
 					// Compute the next cleanup_ts by scanning the slot
 					// map: any transaction registering concurrently is
@@ -295,8 +333,8 @@ impl Database {
 					let Some(cleanup_ts) = db.compute_cleanup_ts() else {
 						continue;
 					};
-					// Perform the full datastore scan.
-					db.run_gc_full(cleanup_ts);
+					// Sweep only the tracked candidate keys.
+					db.run_gc_tracked(cleanup_ts);
 				}
 			});
 			// Store and track the thread handle
@@ -1338,8 +1376,8 @@ mod tests {
 	#[test]
 	fn safety_net_reclaims_after_reader_departs() {
 		// Garbage pinned by a reader on a key that is never written again
-		// is invisible to inline commit-time GC: this is exactly the
-		// scenario that justifies keeping the background full-scan sweep.
+		// is invisible to inline commit-time GC: the manual full scan
+		// must reclaim it just like the tracked sweep does.
 		let db = Database::new_with_options(
 			crate::DatabaseOptions::default().with_all_workers_disabled(),
 		);
@@ -1369,6 +1407,183 @@ mod tests {
 		let chain = guard.as_slice();
 		assert_eq!(chain.len(), 1, "the safety-net sweep should reclaim departed-reader garbage");
 		assert_eq!(chain[0].value.as_deref(), Some(b"v50" as &[u8]));
+	}
+
+	#[test]
+	fn tracked_sweep_reclaims_departed_reader_garbage() {
+		// The commit path tracks every chain it cannot trim to a single
+		// live value, so the targeted sweep must reclaim departed-reader
+		// garbage without a full datastore scan.
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "v0").unwrap();
+			tx.commit().unwrap();
+		}
+		// Pin the initial version while overwriting the key
+		let reader = db.transaction(false);
+		for i in 1..=50 {
+			let mut tx = db.transaction(true);
+			tx.set("key", format!("v{i}")).unwrap();
+			tx.commit().unwrap();
+		}
+		// The pinned overwrites must have tracked the key
+		assert!(
+			db.gc_candidates.pin().contains(b"key".as_slice()),
+			"a commit that leaves garbage should track its key"
+		);
+		// While the reader is pinned, the sweep trims what it can and
+		// keeps the key tracked for the next pass
+		db.run_gc_tracked();
+		{
+			let entry = db.datastore.get(b"key".as_slice()).expect("key missing");
+			assert!(entry.value().read().as_slice().len() > 1);
+			assert!(
+				db.gc_candidates.pin().contains(b"key".as_slice()),
+				"a still-pinned chain should stay tracked after a sweep"
+			);
+		}
+		// Once the reader departs, the tracked sweep finishes the job
+		drop(reader);
+		db.run_gc_tracked();
+		let entry = db.datastore.get(b"key".as_slice()).expect("key missing");
+		let guard = entry.value().read();
+		let chain = guard.as_slice();
+		assert_eq!(chain.len(), 1, "the tracked sweep should reclaim departed-reader garbage");
+		assert_eq!(chain[0].value.as_deref(), Some(b"v50" as &[u8]));
+		drop(guard);
+		assert!(
+			!db.gc_candidates.pin().contains(b"key".as_slice()),
+			"a terminal chain should be untracked after the sweep"
+		);
+	}
+
+	#[test]
+	fn tracked_sweep_unlinks_pinned_tombstone() {
+		// A delete committed while a reader pins the prior value cannot
+		// collapse at commit time; the tracked sweep must unlink it after
+		// the reader departs.
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "value").unwrap();
+			tx.commit().unwrap();
+		}
+		let reader = db.transaction(false);
+		{
+			let mut tx = db.transaction(true);
+			tx.del("key").unwrap();
+			tx.commit().unwrap();
+		}
+		// The pinned tombstone keeps the node linked and tracked
+		assert!(db.datastore.get(b"key".as_slice()).is_some());
+		assert!(db.gc_candidates.pin().contains(b"key".as_slice()));
+		// After the reader departs the sweep collapses and unlinks it
+		drop(reader);
+		db.run_gc_tracked();
+		assert!(
+			db.datastore.get(b"key".as_slice()).is_none(),
+			"the tracked sweep should unlink a departed-reader tombstone"
+		);
+		assert!(!db.gc_candidates.pin().contains(b"key".as_slice()));
+	}
+
+	#[test]
+	fn full_scan_supersedes_candidate_set() {
+		// The manual full scan visits every key, so it clears the
+		// candidate set rather than leaving stale entries behind.
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "v0").unwrap();
+			tx.commit().unwrap();
+		}
+		let reader = db.transaction(false);
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "v1").unwrap();
+			tx.commit().unwrap();
+		}
+		assert!(db.gc_candidates.pin().contains(b"key".as_slice()));
+		drop(reader);
+		db.run_gc();
+		assert_eq!(db.gc_candidates.pin().len(), 0, "the full scan should clear the candidate set");
+		let entry = db.datastore.get(b"key".as_slice()).expect("key missing");
+		assert_eq!(entry.value().read().as_slice().len(), 1);
+	}
+
+	#[cfg(not(target_arch = "wasm32"))]
+	#[test]
+	fn load_collapses_aol_replay_chains() {
+		// Append-only-log replay pushes one chain entry per record, so a
+		// key updated N times holds N versions after replay — garbage no
+		// commit or tracked sweep would ever visit on a key that is never
+		// written again. The one-shot sweep at load time must collapse
+		// every chain to its latest version.
+		let temp_dir = tempfile::TempDir::new().unwrap();
+		let persistence = crate::PersistenceOptions::new(temp_dir.path())
+			.with_aol_mode(crate::AolMode::SynchronousOnCommit)
+			.with_snapshot_mode(crate::SnapshotMode::Never)
+			.with_fsync_mode(crate::FsyncMode::EveryAppend);
+		{
+			let db = Database::new_with_persistence(
+				crate::DatabaseOptions::default(),
+				persistence.clone(),
+			)
+			.unwrap();
+			for i in 0..5 {
+				let mut tx = db.transaction(true);
+				tx.set("key", format!("v{i}")).unwrap();
+				tx.commit().unwrap();
+			}
+		}
+		// Reopen: replay rebuilds the chain, then the load sweep trims it
+		let db =
+			Database::new_with_persistence(crate::DatabaseOptions::default(), persistence).unwrap();
+		let entry = db.datastore.get(b"key".as_slice()).expect("key missing after reload");
+		let guard = entry.value().read();
+		let chain = guard.as_slice();
+		assert_eq!(chain.len(), 1, "the load-time sweep should collapse replayed chains");
+		assert_eq!(chain[0].value.as_deref(), Some(b"v4" as &[u8]));
+	}
+
+	#[test]
+	fn full_scan_retracks_pinned_chains() {
+		// A manual full scan clears the candidate set, so any chain it
+		// cannot trim to a terminal state must be re-tracked — otherwise
+		// its garbage would be stranded once the pinning reader departs,
+		// since the background sweep never scans the full datastore.
+		let db = Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "v0").unwrap();
+			tx.commit().unwrap();
+		}
+		let reader = db.transaction(false);
+		{
+			let mut tx = db.transaction(true);
+			tx.set("key", "v1").unwrap();
+			tx.commit().unwrap();
+		}
+		// The full scan runs while the reader still pins the old version
+		db.run_gc();
+		assert!(
+			db.gc_candidates.pin().contains(b"key".as_slice()),
+			"the full scan should re-track a chain it could not trim"
+		);
+		// After the reader departs the tracked sweep reclaims the garbage
+		drop(reader);
+		db.run_gc_tracked();
+		let entry = db.datastore.get(b"key".as_slice()).expect("key missing");
+		assert_eq!(entry.value().read().as_slice().len(), 1);
 	}
 
 	#[test]
@@ -1405,7 +1620,7 @@ mod tests {
 				}
 			})
 		};
-		// Sweeper thread hammers cleanup and gc continuously
+		// Sweeper thread hammers cleanup and both gc paths continuously
 		let sweeper = {
 			let db = Arc::clone(&db);
 			let stop = Arc::clone(&stop);
@@ -1413,6 +1628,7 @@ mod tests {
 				while !stop.load(Ordering::Relaxed) {
 					db.run_cleanup();
 					db.run_gc();
+					db.run_gc_tracked();
 				}
 			})
 		};

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -22,6 +22,7 @@ use crate::versions::Versions;
 use crate::DatabaseOptions;
 use bytes::Bytes;
 use crossbeam_skiplist::SkipMap;
+use papaya::HashSet;
 use parking_lot::RwLock;
 use std::sync::atomic::{fence, AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -135,6 +136,22 @@ pub struct Inner {
 	/// Bounded by, and advanced only after, the published merge clock
 	/// (`oracle.timestamp`).
 	pub(crate) merge_retire_id: AtomicU64,
+	/// Keys whose version chains may still hold reclaimable garbage:
+	/// chains a commit could not trim to a single live value because a
+	/// reader watermark pinned older versions (or the watermark scan was
+	/// skipped mid-registration), and chains whose newest entry is a
+	/// delete tombstone awaiting collapse. The background sweep visits
+	/// only these keys instead of scanning the whole datastore, so sweep
+	/// cost scales with the amount of pinned garbage rather than the
+	/// dataset size. Only keys are stored (deduplicated, refcounted
+	/// `Bytes` clones) — never values, which would pin the very memory
+	/// the sweep exists to reclaim. While a long-lived reader pins the
+	/// watermark, every distinct key overwritten during its lifetime
+	/// stays tracked and is revisited (and re-tracked) by each sweep
+	/// tick until the reader departs — the deliberate trade for exact
+	/// reclamation the moment the pin clears; the per-tick cost is one
+	/// chain-lock-and-trim attempt per tracked key.
+	pub(crate) gc_candidates: HashSet<Bytes>,
 	/// Optional persistence handler
 	#[cfg(not(target_arch = "wasm32"))]
 	pub(crate) persistence: RwLock<Option<Arc<Persistence>>>,
@@ -164,6 +181,7 @@ impl Inner {
 			transaction_commit_queue: SkipMap::new(),
 			transaction_merge_queue: SkipMap::new(),
 			merge_retire_id: AtomicU64::new(0),
+			gc_candidates: HashSet::new(),
 			#[cfg(not(target_arch = "wasm32"))]
 			persistence: RwLock::new(None),
 			background_threads_enabled: AtomicBool::new(true),
@@ -226,8 +244,10 @@ impl Inner {
 
 	/// Compute the watermark for commit-time inline garbage collection,
 	/// or `None` when a registration is in flight — in which case the
-	/// committer simply skips inline reclamation for this commit and the
-	/// next commit to each key (or the background full scan) catches up.
+	/// committer skips inline reclamation for this commit and instead
+	/// tracks each key it touched in [`Inner::gc_candidates`], so the
+	/// tracked background sweep (or the next commit to the key) catches
+	/// up.
 	///
 	/// The committer's own slot is excluded: `commit` takes the
 	/// transaction by mutable reference and marks it done, so no further
@@ -462,13 +482,77 @@ impl Inner {
 		}
 	}
 
+	/// Reclaim stale versions on the tracked candidate keys only.
+	///
+	/// Steady-state reclamation happens inline at commit time; whenever a
+	/// commit cannot trim a chain to a single live value it tracks the
+	/// key in [`Inner::gc_candidates`], so this sweep visits exactly the
+	/// keys which may still hold garbage — cost scales with the amount of
+	/// pinned garbage, not the dataset size.
+	///
+	/// A key is removed from the candidate set BEFORE its chain is
+	/// examined. That ordering makes the untrack race-free against
+	/// concurrent commits: a committer inserts its key only after
+	/// pushing the garbage-leaving version under the chain write lock,
+	/// so any garbage added after this sweep's trim re-inserts the key
+	/// for the next pass — the removal here can never orphan it. When
+	/// the trimmed chain still holds reclaimable versions (a reader
+	/// watermark is pinning them), the key is re-tracked for the next
+	/// sweep.
+	pub(crate) fn run_gc_tracked(&self, cleanup_ts: u64) {
+		// A single map guard serves the whole sweep: guard churn per
+		// candidate costs more than holding one across the pass, and the
+		// candidate map holds only keys, so delaying its internal
+		// reclamation for the duration of a sweep is immaterial.
+		let candidates = self.gc_candidates.pin();
+		// The steady state is an empty candidate set: every chain fully
+		// trimmed at commit time. Skip the snapshot allocation entirely.
+		if candidates.is_empty() {
+			return;
+		}
+		// Snapshot the candidate keys: the snapshot is the sweep's
+		// working set, and keys tracked by commits racing with this
+		// sweep are picked up by the next pass.
+		let mut keys: Vec<Bytes> = Vec::with_capacity(candidates.len());
+		keys.extend(candidates.iter().cloned());
+		// Process each candidate key in turn
+		for key in keys {
+			// Untrack the key first — see the ordering argument above
+			candidates.remove(&key);
+			// The chain may have been unlinked by an earlier collapse
+			let Some(entry) = self.datastore.get(&key) else {
+				continue;
+			};
+			// Get a mutable reference to the versions list
+			let mut versions = entry.value().write();
+			// A sweep or commit-time collapse unlinked this node between
+			// lookup and lock; any recreation re-tracks the key itself
+			if entry.is_removed() {
+				continue;
+			}
+			// Clean up unnecessary older versions
+			if versions.gc_older_versions(cleanup_ts) == 0 {
+				// Remove the entry while still holding the version write
+				// lock — see the equivalent removal in `run_gc_full`.
+				entry.remove();
+			} else if versions.needs_gc() {
+				// Versions remain pinned by a reader watermark: re-track
+				// the key so a later sweep can finish the job.
+				candidates.insert(key);
+			}
+		}
+	}
+
 	/// Scan the entire datastore, reclaiming stale versions on every key.
 	///
-	/// Steady-state reclamation happens inline at commit time, so this
-	/// sweep is a low-frequency safety net for garbage which no future
-	/// commit will visit: versions pinned by a since-departed reader on a
-	/// key that is never written again, and the inert below-watermark
-	/// entries which an out-of-order apply can leave behind.
+	/// The background sweep visits only tracked candidate keys (see
+	/// [`Inner::run_gc_tracked`]); this full scan backs the manual
+	/// [`crate::Database::run_gc`] entry point and the one-shot pass at
+	/// persistence load time, which collapses the multi-version chains
+	/// that append-only-log replay builds up. Since a full scan visits
+	/// every key, it supersedes the candidate set: callers clear the set
+	/// before scanning (commits racing with the scan re-track their keys
+	/// as usual).
 	pub(crate) fn run_gc_full(&self, cleanup_ts: u64) {
 		// Iterate over the entire datastore
 		for entry in self.datastore.iter() {
@@ -482,6 +566,13 @@ impl Inner {
 				// to unlink. `Entry::remove` also unlinks at the cursor with
 				// no second key lookup.
 				entry.remove();
+			} else if versions.needs_gc() {
+				// A reader watermark is pinning reclaimable versions. Track
+				// the key so the targeted sweep revisits it once the pin
+				// clears: the caller cleared the candidate set before this
+				// scan, and no future commit or sweep would otherwise ever
+				// visit a key that is never written again.
+				self.gc_candidates.pin().insert(entry.key().clone());
 			}
 		}
 	}

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,10 +5,11 @@ use std::time::Duration;
 pub(crate) const DEFAULT_RESET_THRESHOLD: usize = 100;
 
 /// Default interval at which the background garbage collection sweep is
-/// performed. Steady-state reclamation happens inline at commit time, so
-/// the background sweep is a low-frequency safety net for garbage which
-/// no future commit will visit: versions pinned by a since-departed
-/// reader on a key that is never written again.
+/// performed. Steady-state reclamation happens inline at commit time,
+/// and every chain a commit cannot trim to a single live value is
+/// tracked as a garbage candidate — so each background tick sweeps only
+/// the tracked keys, and its cost scales with the amount of
+/// reader-pinned garbage rather than the dataset size.
 pub(crate) const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Default interval at which transaction queue cleanup is performed.
@@ -19,12 +20,16 @@ pub(crate) const DEFAULT_CLEANUP_INTERVAL: Duration = Duration::from_secs(1);
 pub struct DatabaseOptions {
 	/// Maximum number of transactions kept in the pool (default: 512).
 	pub pool_size: usize,
-	/// Whether the background garbage collection safety-net sweep is
-	/// started automatically (default: true). Steady-state reclamation
-	/// happens inline at commit time regardless of this setting.
+	/// Whether the background garbage collection sweep is started
+	/// automatically (default: true). Steady-state reclamation happens
+	/// inline at commit time regardless of this setting; the background
+	/// sweep reclaims the tracked leftovers — chains a commit could not
+	/// fully trim because a reader was pinning older versions.
 	pub enable_gc: bool,
-	/// Interval at which the garbage collection safety-net sweep wakes
-	/// up and performs a full datastore scan (default: 10 seconds).
+	/// Interval at which the garbage collection sweep wakes up and
+	/// visits the tracked garbage-candidate keys (default: 10 seconds).
+	/// A tick costs proportional to the number of tracked keys, not the
+	/// dataset size, so short intervals are affordable.
 	pub gc_interval: Duration,
 	/// Whether the cleanup worker is started automatically (default: true).
 	pub enable_cleanup: bool,
@@ -98,8 +103,8 @@ impl DatabaseOptions {
 
 	/// Configure for high-throughput scenarios with a larger transaction
 	/// pool and less-frequent background sweeps. Trades memory for
-	/// throughput: more dropped transactions are kept for reuse, and the
-	/// safety-net sweeper interrupts the foreground less often —
+	/// throughput: more dropped transactions are kept for reuse, and
+	/// reader-pinned garbage waits longer for its tracked sweep —
 	/// steady-state reclamation happens inline at commit time either way.
 	pub fn with_high_performance(mut self) -> Self {
 		self.pool_size *= 2;
@@ -120,11 +125,12 @@ impl DatabaseOptions {
 		self
 	}
 
-	/// Configure for memory-constrained scenarios: frequent safety-net
-	/// sweeps and a smaller transaction pool. Trades CPU for tighter
-	/// memory bounds — reader-pinned garbage is reclaimed sooner after
-	/// the reader departs, and fewer dropped transactions are kept
-	/// around for reuse.
+	/// Configure for memory-constrained scenarios: frequent tracked
+	/// sweeps and a smaller transaction pool. Reader-pinned garbage is
+	/// reclaimed sooner after the reader departs, and fewer dropped
+	/// transactions are kept around for reuse. Since a sweep visits only
+	/// the tracked candidate keys, the extra ticks cost little CPU even
+	/// on large datasets.
 	pub fn with_reduced_memory(mut self) -> Self {
 		self.pool_size /= 2;
 		self.gc_interval = Duration::from_secs(5);

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -523,6 +523,15 @@ impl Persistence {
 		self.inner.oracle.alloc.fetch_max(max_version, Ordering::SeqCst);
 		self.inner.oracle.timestamp.fetch_max(max_version, Ordering::SeqCst);
 		self.inner.merge_retire_id.fetch_max(max_version, Ordering::SeqCst);
+		// Collapse the multi-version chains that append-only-log replay
+		// builds up: a key updated N times across the log holds N chain
+		// entries here, and no future commit or tracked sweep would ever
+		// visit the ones on keys that are never written again. This runs
+		// before any transaction exists, so the cleanup bound is simply
+		// the seeded clock and every chain trims to its latest version.
+		if let Some(cleanup_ts) = self.inner.compute_cleanup_ts() {
+			self.inner.run_gc_full(cleanup_ts);
+		}
 		// Return success
 		Ok(())
 	}

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -872,6 +872,11 @@ impl TransactionInner {
 		// own excluded slot is pinned at our start version, so the
 		// watermark can never sit above the version we push.
 		let watermark = self.database.inline_gc_watermark(self.slot_id);
+		// Keys whose chains could not be trimmed to a single live value,
+		// collected here and tracked in one batch after the apply loop so
+		// no hash-set work happens inside a chain write-lock critical
+		// section. Empty in the steady state, so no allocation occurs.
+		let mut tracked: Vec<Bytes> = Vec::new();
 		// Apply each writeset entry, reclaiming superseded versions
 		// inline while the chain write lock is already held.
 		for (key, value) in entry.writeset.iter() {
@@ -911,13 +916,44 @@ impl TransactionInner {
 				// is a delete tombstone with nothing newer, e.g. our own
 				// delete with no readers below — unlink the node while
 				// still holding the lock, so a concurrent committer
-				// observes `is_removed()` and re-inserts.
-				if let Some(w) = watermark {
-					if versions.gc_older_versions(w) == 0 {
-						entry.remove();
+				// observes `is_removed()` and re-inserts. When the chain
+				// could NOT be trimmed to a single live value (a reader
+				// watermark pins older versions, our newest entry is a
+				// tombstone awaiting collapse, or the watermark scan was
+				// skipped mid-registration), collect the key for tracking
+				// so the background sweep revisits exactly this chain once
+				// the pin clears — the sweep never scans the datastore.
+				match watermark {
+					Some(w) => {
+						if versions.gc_older_versions(w) == 0 {
+							entry.remove();
+						} else if versions.needs_gc() {
+							tracked.push(key.clone());
+						}
+					}
+					None => {
+						if versions.needs_gc() {
+							tracked.push(key.clone());
+						}
 					}
 				}
 				break;
+			}
+		}
+		// Track the collected keys in one batch, outside every chain
+		// write lock and under a single map guard. Insert-after-unlock
+		// is race-free against the sweep's remove-then-trim ordering:
+		// the garbage these keys refer to was pushed before this insert,
+		// so a sweep that untracks a key here either trims that garbage
+		// in the same pass (and re-tracks it if a reader still pins it)
+		// or ran entirely before it existed — in which case this insert
+		// lands after the removal and the key stays tracked. At worst a
+		// key is tracked for an already-terminal chain, which the next
+		// sweep simply untracks.
+		if !tracked.is_empty() {
+			let candidates = self.database.gc_candidates.pin();
+			for key in tracked {
+				candidates.insert(key);
 			}
 		}
 		// Append the transaction to the persistence layer
@@ -4635,7 +4671,7 @@ mod tests {
 	/// value exactly once. A reader pinned at the seed version holds every
 	/// commit's inline-GC watermark below the whole test's writes, so the
 	/// chain retains the full history for inspection; background workers
-	/// are disabled so no safety-net sweep runs either.
+	/// are disabled so no background sweep runs either.
 	#[test]
 	fn test_version_chain_monotonic_under_concurrent_writers() {
 		const THREADS: usize = 8;
@@ -4707,7 +4743,7 @@ mod tests {
 	/// chain accumulates every committed round in order. A reader pinned
 	/// before the first round holds every commit's inline-GC watermark
 	/// below the whole test's writes; background workers are disabled so
-	/// no safety-net sweep runs either.
+	/// no background sweep runs either.
 	#[test]
 	fn test_version_chain_accumulates_repeated_writes() {
 		let db = Database::new_with_options(

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -232,6 +232,18 @@ impl Versions {
 		&self.inner
 	}
 
+	/// Whether a future garbage-collection pass could reclaim anything
+	/// from this chain. A chain is terminal — and reclamation-free — only
+	/// when it holds exactly one live value: superseded versions can be
+	/// dropped once no reader needs them, and a newest-entry tombstone
+	/// means the whole chain can collapse and the key unlink. Used by the
+	/// commit path to decide whether a key needs tracking for the
+	/// background sweep.
+	#[inline]
+	pub(crate) fn needs_gc(&self) -> bool {
+		self.inner.len() > 1 || self.inner.last().is_some_and(|v| v.value.is_none())
+	}
+
 	/// Remove versions that no reader at a snapshot `>= version` can observe.
 	///
 	/// `version` is the GC floor: no reader exists below it, but readers may


### PR DESCRIPTION
## Summary

Stacked on #85. The background garbage collector previously full-scanned the datastore every tick — O(all keys) even when almost nothing was reclaimable, which is the same shape of cost that drove the earlier OOM-at-scale complaints.

- **Commit-time tracking**: every chain a commit cannot trim to a single live value (reader-pinned versions, tombstone awaiting collapse, or a skipped watermark scan) is tracked in a keys-only candidate set (`papaya::HashSet<Bytes>` — never values, which would pin the memory the sweep exists to reclaim).
- **Tracked background sweep**: each GC tick visits only the tracked keys. The untrack-before-trim ordering makes the set race-free against concurrent commits (a committer inserts after pushing its garbage under the chain lock, so no interleaving can orphan a needed track — this invariant was the focus of the adversarial review below).
- **Full scan demoted, not removed**: `Database::run_gc` still deep-scans (clearing the set, and re-tracking chains a pinned reader kept non-terminal); new `Database::run_gc_tracked` exposes the cheap sweep for manual/wasm use.
- **Load-time collapse**: persistence load ends with a one-shot full scan, since AOL replay builds multi-version chains that nothing would otherwise ever revisit.

## Performance

`gc_full_scan` bench, 100 stale keys (tracked vs full):

| Total keys | Tracked sweep | Full scan |
|---|---|---|
| 1,000 | 48µs | 102µs |
| 10,000 | 263µs | 933µs |
| 100,000 | ~flat (noisy arm) | 4.8–14.6ms |

Idle ticks now early-out on an empty candidate set before paying the watermark fence-and-scan.

## Testing & review

- New tests: departed-reader reclamation via the tracked sweep, pinned-tombstone unlink, full-scan re-track of pinned chains, candidate-set clearing, AOL-replay collapse at load; the pin-then-read stress test now also hammers `run_gc_tracked` concurrently.
- A 4-angle adversarial concurrency review (orphaned-garbage interleavings, data correctness, docs, perf) found **zero correctness issues**; the confirmed doc/perf findings (stale full-scan references in options/README, tracking inserts inside the chain-lock critical section, missing empty-set early-outs) are all fixed in this PR.
- Full CI mirror green: tests, clippy `-D warnings`, wasm32 check, bench compile.