### PR TITLE
Add a benchmark for the per-commit watermark slot scan

### DIFF
--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -18,7 +18,7 @@ use rand::{rngs::StdRng, RngExt, SeedableRng};
 use std::hint::black_box;
 use std::sync::Arc;
 use surrealmx::bench_internals::{
-	MergeQueueScenario, ReadsetConflictScenario, WritesetConflictScenario,
+	MergeQueueScenario, ReadsetConflictScenario, WatermarkScanScenario, WritesetConflictScenario,
 };
 use surrealmx::{Database, DatabaseOptions};
 
@@ -1076,6 +1076,21 @@ fn bench_commit_inline_gc(c: &mut Criterion) {
 	group.finish();
 }
 
+// Per-commit inline-GC watermark scan: every commit walks the registered
+// reader slots to find the minimum pinned snapshot. Measures how that
+// walk scales with the number of live transactions, isolated from chain
+// growth and every other commit cost.
+fn bench_watermark_scan(c: &mut Criterion) {
+	let mut group = c.benchmark_group("watermark_scan");
+	for num_readers in [0usize, 10, 100, 1_000, 10_000].iter() {
+		let scenario = WatermarkScanScenario::new(*num_readers);
+		group.bench_function(BenchmarkId::new("live_readers", num_readers), |b| {
+			b.iter(|| scenario.scan())
+		});
+	}
+	group.finish();
+}
+
 // ---------------------------------------------------------------------------
 // Bloom filter impact: direct with-bloom vs without-bloom comparison
 // ---------------------------------------------------------------------------
@@ -1424,6 +1439,7 @@ criterion_group!(
 	bench_keys_for_each,
 	bench_gc_full_scan,
 	bench_commit_inline_gc,
+	bench_watermark_scan,
 	bench_readset_bloom_impact,
 	bench_readset_bloom_conflict_path,
 	bench_writeset_bloom_impact,

--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -193,3 +193,49 @@ impl MergeQueueScenario {
 		.count()
 	}
 }
+
+/// A prepared watermark-scan scenario for benchmarking the per-commit
+/// inline-GC slot scan. Registers `num_readers` pinned slots directly in
+/// the readers map — the exact state a database holds with that many
+/// live transactions — and exposes the watermark computation a committer
+/// performs once per commit.
+pub struct WatermarkScanScenario {
+	db: crate::Database,
+	own_slot: u64,
+}
+
+impl WatermarkScanScenario {
+	/// Build a scenario with `num_readers` live registered slots plus the
+	/// committer's own slot.
+	pub fn new(num_readers: usize) -> Self {
+		use crate::inner::Slot;
+		use std::sync::atomic::Ordering;
+		let db = crate::Database::new_with_options(
+			crate::DatabaseOptions::default().with_all_workers_disabled(),
+		);
+		// Register the reader slots with plausible snapshot values
+		for i in 0..num_readers {
+			let id = db.reader_slot_id.fetch_add(1, Ordering::SeqCst) + 1;
+			let slot = Arc::new(Slot::pinning());
+			slot.version.store(1 + (i as u64 % 16), Ordering::SeqCst);
+			slot.commit.store(1 + (i as u64 % 16), Ordering::SeqCst);
+			db.readers.insert(id, slot);
+		}
+		// Register the committer's own slot, excluded by the scan
+		let own_slot = db.reader_slot_id.fetch_add(1, Ordering::SeqCst) + 1;
+		let slot = Arc::new(Slot::pinning());
+		slot.version.store(32, Ordering::SeqCst);
+		slot.commit.store(32, Ordering::SeqCst);
+		db.readers.insert(own_slot, slot);
+		Self {
+			db,
+			own_slot,
+		}
+	}
+
+	/// Perform one inline-GC watermark computation, exactly as a commit
+	/// does after publishing its merge version.
+	pub fn scan(&self) -> Option<u64> {
+		self.db.inline_gc_watermark(self.own_slot)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #85. The engine redesign made every commit walk the registered reader slots once to compute its inline-GC watermark — an O(live transactions) cost accepted with the note that a cached minimum would be built *only if measurement showed the need*. This PR adds that measurement as a permanent benchmark (`watermark_scan`), backed by a `bench_internals::WatermarkScanScenario` that registers N pinned slots directly, isolating the scan from chain growth and other commit costs.

## Data (M-series laptop)

| Live transactions | Scan cost per commit |
|---|---|
| 0 | 29ns |
| 10 | 185ns |
| 100 | 1.5µs |
| 1,000 | 14.8µs |
| 10,000 | 150µs |

Perfectly linear at ~15ns per slot. Within the transaction pool's design center (512 concurrent transactions ≈ 7µs per commit) the cost is acceptable, so the cached-minimum optimization stays unbuilt — this benchmark is the tripwire for revisiting that decision if workloads with thousands of simultaneously-live transactions appear.