### PR TITLE
Shrink the version chain inline capacity to one entry

### DIFF
--- a/src/versions.rs
+++ b/src/versions.rs
@@ -11,8 +11,21 @@ pub(crate) enum IndexOrUpdate<'a> {
 	Update(&'a mut Version),
 }
 
+/// A key's MVCC version chain, ordered oldest to newest.
+///
+/// The inline capacity is one entry: eager commit-time garbage
+/// collection keeps every chain at a single live value except while a
+/// reader watermark briefly pins superseded versions, and in a large
+/// dataset the overwhelming majority of keys are cold — written once
+/// and holding exactly one version forever. Sizing the inline buffer
+/// for the steady state keeps every cold key at ~a third of the memory
+/// a four-slot buffer costs, which dominates total datastore footprint
+/// by key count. Keys that do grow a chain under a pinned reader spill
+/// to a small heap buffer once (SmallVec retains it thereafter), and
+/// even a spilled two-entry chain occupies no more total memory than
+/// the old four-slot inline layout.
 pub struct Versions {
-	inner: SmallVec<[Version; 4]>,
+	inner: SmallVec<[Version; 1]>,
 }
 
 impl From<Version> for Versions {
@@ -893,5 +906,18 @@ mod tests {
 		}
 		assert_eq!(versions.inner.len(), 1);
 		assert_eq!(versions.fetch_version(10), Some(Bytes::from("v99".to_string())));
+	}
+	#[test]
+	fn versions_inline_footprint_is_small() {
+		// The datastore holds one `Versions` per key, so its inline size
+		// directly scales total memory by key count. One inline entry plus
+		// SmallVec bookkeeping must stay within 56 bytes — sizing the
+		// buffer for the steady state (eager commit-time GC keeps chains
+		// at a single live value) rather than for transient growth.
+		assert!(
+			std::mem::size_of::<Versions>() <= 56,
+			"Versions grew to {} bytes; the per-key inline footprint is load-bearing for large datasets",
+			std::mem::size_of::<Versions>()
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Stacked on #85. The per-key `Versions` chain carried a four-entry inline `SmallVec` buffer sized for the removed history-retention model. With eager commit-time GC (from #85) keeping chains at a single live value, that buffer is dead weight on every cold key — and cold keys dominate large datasets by count, which is exactly where the OOM pressure lives.

- `SmallVec<[Version; 4]>` → `SmallVec<[Version; 1]>`: `size_of::<Versions>()` drops **168 → 48 bytes**, cutting the fixed per-key datastore footprint to under a third (~1.2GB saved per 10M keys before values).
- A footprint regression test (`versions_inline_footprint_is_small`) locks the size in at ≤56 bytes.

## Measurement basis

Chain-length distribution measured under a saturated mixed workload (4 writers at ~93k commits/s over 10k keys, 6 continuous short-lived readers):

| Chain length | Keys (mid-flight) |
|---|---|
| 1 | 1.6% |
| 2 | 78% |
| 3 | 17% |
| 4–6 | 3.8% |

Actively-churning keys sit at length 2 (the watermark lags one commit behind), so they spill to a small heap buffer — but the spill happens **once per key** (SmallVec retains the buffer), and even a spilled two-entry chain totals less memory than the old four-slot inline layout. Cold keys — absent from this saturated measurement but the overwhelming majority of any real dataset — stay at length 1 inline forever and collect the full 3× saving.

## Performance vs parent commit

64 benchmark comparisons: **13 improved, 0 regressed**, rest unchanged. Puts 1.5–7.5% faster, gets 3–4.4% faster — the smaller struct densifies skip-list nodes.

Full CI mirror green: tests, clippy `-D warnings`, wasm32 check.