### PR TITLE
Make clippy strict: adopt the surrealdb lint set plus the pedantic group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,28 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      # A second, stricter pass over the library only. These lints are
+      # valuable in the engine but pure noise in tests and benchmarks, which
+      # unwrap and cast freely and correctly. Cargo's `[lints]` table cannot
+      # be scoped per-target, so they are denied here instead of there. The
+      # library is currently clean on all of them, so this is a ratchet: it
+      # keeps new panicking paths and lossy casts out of the engine.
+      - name: Run clippy (library only, stricter)
+        run: |
+          cargo clippy --lib --all-features -- \
+            -D warnings \
+            -D clippy::unwrap_used \
+            -D clippy::get_unwrap \
+            -D clippy::panic \
+            -D clippy::todo \
+            -D clippy::unimplemented \
+            -D clippy::dbg_macro \
+            -D clippy::float_cmp \
+            -D clippy::mem_forget \
+            -D clippy::cast_possible_truncation \
+            -D clippy::cast_sign_loss \
+            -D clippy::cast_possible_wrap
+
   bench:
     name: Benchmark Compilation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,14 +96,10 @@ jobs:
         run: |
           cargo clippy --lib --all-features -- \
             -D warnings \
+            -D missing_docs \
             -D clippy::unwrap_used \
             -D clippy::get_unwrap \
             -D clippy::panic \
-            -D clippy::todo \
-            -D clippy::unimplemented \
-            -D clippy::dbg_macro \
-            -D clippy::float_cmp \
-            -D clippy::mem_forget \
             -D clippy::cast_possible_truncation \
             -D clippy::cast_sign_loss \
             -D clippy::cast_possible_wrap

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,23 @@ inline_always = "allow"
 # ordering arguments documented inline.
 too_many_lines = "allow"
 
+# Fires on natural plural/singular pairs — `keys` next to `key1`, a
+# `writes` counter next to a `writers` thread list. Both readings are
+# correct as written, and renaming to satisfy the lint makes the code
+# worse rather than better.
+similar_names = "allow"
+
+# Every site this fires on is a deliberate convention rather than an
+# oversight, so it costs more than it finds here. The datastore helpers are
+# generic over `K: IntoBytes` and take the key by value so that `K` may
+# itself be a reference type (`&[u8]`) without a double indirection, and
+# `Database::new_with_options` / `new_with_persistence` take their options
+# struct by value because that is the builder convention and because
+# narrowing a published constructor to `&DatabaseOptions` would be a
+# breaking change for dependents. surrealdb/surrealdb enables this lint;
+# its code does not have these two shapes.
+needless_pass_by_value = "allow"
+
 # Numeric casts are checked on the library only, via the `--lib` clippy
 # pass in CI. Test and benchmark code casts loop counters freely and the
 # noise there would bury the two real sites in the engine.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,57 @@ needless_pass_by_value = "allow"
 cast_possible_truncation = "allow"
 cast_sign_loss = "allow"
 
+# It is fine to write `assert_eq!(val, true)` in tests, and often more
+# readable than `assert!(val)`. Matches surrealdb/surrealdb.
+# https://rust-lang.github.io/rust-clippy/master/#bool_assert_comparison
+bool_assert_comparison = "allow"
+
+# --- Parity with the surrealdb/surrealdb lint set -------------------------
+# These are the lints from that workspace's `[workspace.lints.clippy]` that
+# the `pedantic` group above does not already cover. `disallowed_methods`
+# is deliberately omitted: it is a no-op without a `clippy.toml` listing
+# methods to ban, which is why it currently does nothing in that repo
+# either.
+
+# `Arc::clone(&x)` over `x.clone()`, so pointer duplication is obvious
+# rather than looking like a deep copy. This engine is Arc-heavy enough
+# that the distinction matters when reading a hot path.
+# https://rust-lang.github.io/rust-clippy/master/#clone_on_ref_ptr
+clone_on_ref_ptr = "warn"
+
+# `clone_from` / `clone_into` can reuse an existing allocation.
+# https://rust-lang.github.io/rust-clippy/master/#assigning_clones
+assigning_clones = "warn"
+
+# Mutating inside `debug_assert!` behaves differently in release builds,
+# where the macro is compiled out entirely.
+# https://rust-lang.github.io/rust-clippy/master/#debug_assert_with_mut_call
+debug_assert_with_mut_call = "warn"
+
+# A `From` impl that can panic should be `TryFrom`.
+# https://rust-lang.github.io/rust-clippy/master/#fallible_impl_from
+fallible_impl_from = "warn"
+
+# `.get().unwrap()` should be `[]`.
+# https://rust-lang.github.io/rust-clippy/master/#get_unwrap
+get_unwrap = "warn"
+
+# Float literals that cannot be represented exactly in the target type.
+# https://rust-lang.github.io/rust-clippy/master/#lossy_float_literal
+lossy_float_literal = "warn"
+
+# `Mutex<bool>` / `Mutex<usize>` where an atomic would do.
+# https://rust-lang.github.io/rust-clippy/master/#mutex_atomic
+mutex_atomic = "warn"
+
+# `.contains()` then `.insert()` double-looks-up the set.
+# https://rust-lang.github.io/rust-clippy/master/#set_contains_or_insert
+set_contains_or_insert = "warn"
+
+# --- Nursery lints worth the risk here -----------------------------------
+# The nursery group as a whole is not stable enough to enable, but these
+# individually pay for themselves in a lock-free engine.
+
 # Checks for temporaries with a significant `Drop` in `if let`/`match`
 # scrutinees, which live until the end of the whole expression. For a
 # lock-free MVCC engine this is the difference between releasing a lock
@@ -83,6 +134,32 @@ significant_drop_in_scrutinee = "warn"
 # out rather than being "fixed".
 # https://rust-lang.github.io/rust-clippy/master/#significant_drop_tightening
 significant_drop_tightening = "warn"
+
+# Clones whose value is dropped without being read.
+# https://rust-lang.github.io/rust-clippy/master/#redundant_clone
+redundant_clone = "warn"
+
+# NOT enabled. Every site it fires on in this repo is the
+#
+#     let handles: Vec<_> = (0..N).map(|_| thread::spawn(..)).collect();
+#     let results: Vec<_> = handles.into_iter().map(|h| h.join()).collect();
+#
+# pattern in the concurrency tests, and the suggested fix is to fuse the two
+# chains. Because iterators are lazy that would spawn thread i, join it, then
+# spawn thread i+1 — serialising the threads and quietly destroying the
+# concurrency the test exists to exercise. Collecting the handles is what
+# makes all N threads run at once, so it is load-bearing, not needless.
+# https://rust-lang.github.io/rust-clippy/master/#needless_collect
+needless_collect = "allow"
+
+# Functions that could be `const fn`. Free at the call site and lets more
+# of the option//key plumbing be evaluated at compile time.
+# https://rust-lang.github.io/rust-clippy/master/#missing_const_for_fn
+missing_const_for_fn = "warn"
+
+# `Self` over repeating the type name in an impl block.
+# https://rust-lang.github.io/rust-clippy/master/#use_self
+use_self = "warn"
 
 [dependencies]
 arc-swap = "1.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,39 @@ license = "Apache-2.0"
 
 [lints.clippy]
 
+# The `pedantic` group, enabled wholesale. surrealdb/surrealdb hand-picks
+# individual lints instead, because `pedantic` over ~300k LOC is not
+# tractable; surrealmx is ~12k LOC of library code and can afford the whole
+# group. `priority = -1` lets the individual `allow` entries below override
+# the group rather than colliding with it.
+pedantic = { level = "warn", priority = -1 }
+
+# Documenting every `# Errors` and `# Panics` section is prose work, not
+# linting, and would gate this change on writing ~60 doc sections. Left as
+# a follow-up rather than silently unfulfilled.
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+
+# `#[must_use]` on every getter is noise, and adding it to public methods
+# that already return owned values changes the API surface for no benefit.
+must_use_candidate = "allow"
+return_self_not_must_use = "allow"
+
+# `#[inline(always)]` in the hot read/commit paths is a deliberate choice
+# here, not an oversight.
+inline_always = "allow"
+
+# A transaction commit and a version-chain merge are genuinely long
+# functions; splitting them to satisfy a line count would obscure the
+# ordering arguments documented inline.
+too_many_lines = "allow"
+
+# Numeric casts are checked on the library only, via the `--lib` clippy
+# pass in CI. Test and benchmark code casts loop counters freely and the
+# noise there would bury the two real sites in the engine.
+cast_possible_truncation = "allow"
+cast_sign_loss = "allow"
+
 # Checks for temporaries with a significant `Drop` in `if let`/`match`
 # scrutinees, which live until the end of the whole expression. For a
 # lock-free MVCC engine this is the difference between releasing a lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,39 @@ keywords = [
 categories = ["database-implementations", "data-structures", "embedded"]
 license = "Apache-2.0"
 
+[lints.rust]
+
+# This engine contains no `unsafe` at all: every lock-free primitive it uses
+# is encapsulated behind a safe API by `crossbeam-skiplist`, `papaya`, and
+# `arc-swap`. That is a property worth keeping deliberately rather than
+# accidentally, so it is forbidden (which, unlike `deny`, cannot be
+# re-enabled by an inner `#[allow]` further down the tree).
+unsafe_code = "forbid"
+
+# `missing_docs` is enforced on the library only, via the stricter `--lib`
+# clippy pass in CI. Applied crate-wide it would demand a `//!` header on
+# every integration test and benchmark crate too.
+
 [lints.clippy]
+
+# --- Guardrails ----------------------------------------------------------
+# All of these are at zero across every target today, so denying them costs
+# nothing now and stops the pattern from reappearing later.
+
+# Unfinished work must not reach a release.
+todo = "deny"
+unimplemented = "deny"
+
+# Debugging leftovers.
+dbg_macro = "deny"
+
+# `==` on floats. There is no float arithmetic in the engine; keep it that
+# way, and make it a conscious decision if that ever changes.
+float_cmp = "deny"
+
+# Leaking a value rather than dropping it hides resource lifetimes, which in
+# an engine that returns transactions to a pool would be a real bug.
+mem_forget = "deny"
 
 # The `pedantic` group, enabled wholesale. surrealdb/surrealdb hand-picks
 # individual lints instead, because `pedantic` over ~300k LOC is not

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,22 @@ keywords = [
 categories = ["database-implementations", "data-structures", "embedded"]
 license = "Apache-2.0"
 
+[lints.clippy]
+
+# Checks for temporaries with a significant `Drop` in `if let`/`match`
+# scrutinees, which live until the end of the whole expression. For a
+# lock-free MVCC engine this is the difference between releasing a lock
+# before a blocking `join`/fsync and holding it across one.
+# https://rust-lang.github.io/rust-clippy/master/#significant_drop_in_scrutinee
+significant_drop_in_scrutinee = "warn"
+
+# Checks for lock guards held longer than their last use. Flags contention
+# that is invisible when reading the code. Some holds here are deliberate
+# and load-bearing; those carry an `#[expect]` with the invariant spelled
+# out rather than being "fixed".
+# https://rust-lang.github.io/rust-clippy/master/#significant_drop_tightening
+significant_drop_tightening = "warn"
+
 [dependencies]
 arc-swap = "1.9.1"
 bincode = { version = "2.0.1", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,24 @@ similar_names = "allow"
 # its code does not have these two shapes.
 needless_pass_by_value = "allow"
 
-# Numeric casts are checked on the library only, via the `--lib` clippy
-# pass in CI. Test and benchmark code casts loop counters freely and the
-# noise there would bury the two real sites in the engine.
+# Numeric casts are checked on the library only, via the stricter `--lib`
+# clippy pass in CI, along with `unwrap_used` and friends. Test and
+# benchmark code casts loop counters freely and correctly, and the noise
+# there would bury any real site in the engine. Cargo's `[lints]` table
+# cannot be scoped to a single target, hence the split.
 cast_possible_truncation = "allow"
 cast_sign_loss = "allow"
+
+# NOT enabled, in either pass. All 11 sites it flags are indices derived
+# internally and provably in bounds: a `buffer[0..4]` guarded by a
+# `len() >= 4` check directly above it, `heads[i]`/`sources[i]` indices
+# from `enumerate()` over those same vectors, and bloom-filter bits
+# already masked to the filter width. Rewriting them as
+# `.get(i).expect(..)` panics identically while reading worse, and the
+# lint would keep firing on every future internal index. Its value is for
+# indices that come from untrusted input, which this crate does not have.
+# https://rust-lang.github.io/rust-clippy/master/#indexing_slicing
+indexing_slicing = "allow"
 
 # It is fine to write `assert_eq!(val, true)` in tests, and often more
 # readable than `assert!(val)`. Matches surrealdb/surrealdb.

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -43,11 +43,11 @@ fn generate_value(rng: &mut StdRng, size: usize) -> Bytes {
 }
 
 fn generate_sequential_key(index: usize) -> Bytes {
-	Bytes::from(format!("key_{:08}", index).into_bytes())
+	Bytes::from(format!("key_{index:08}").into_bytes())
 }
 
 fn generate_sequential_value(index: usize, size: usize) -> Bytes {
-	let base = format!("value_{:08}", index);
+	let base = format!("value_{index:08}");
 	let mut val = base.into_bytes();
 	val.resize(size, b'x');
 	Bytes::from(val)
@@ -94,22 +94,22 @@ fn bench_transaction_creation(c: &mut Criterion) {
 		b.iter(|| {
 			let tx = db.transaction(false);
 			black_box(tx);
-		})
+		});
 	});
 
 	c.bench_function("transaction_creation_write", |b| {
 		b.iter(|| {
 			let tx = db.transaction(true);
 			black_box(tx);
-		})
+		});
 	});
 }
 
 fn bench_put_operations(c: &mut Criterion) {
 	let mut group = c.benchmark_group("put_operations");
 
-	for data_size in [1, 100, 1000, 10_000].iter() {
-		for entry_count in [100, 1000, 10_000].iter() {
+	for data_size in &[1, 100, 1000, 10_000] {
+		for entry_count in &[100, 1000, 10_000] {
 			let mut rng = StdRng::seed_from_u64(SEED);
 
 			// Pre-generate data for consistent benchmarking
@@ -119,20 +119,20 @@ fn bench_put_operations(c: &mut Criterion) {
 
 			group.throughput(Throughput::Elements(*entry_count as u64));
 			group.bench_with_input(
-				BenchmarkId::new("put", format!("{}b_{}entries", data_size, entry_count)),
+				BenchmarkId::new("put", format!("{data_size}b_{entry_count}entries")),
 				&test_data,
 				|b, data| {
 					b.iter_batched(
 						create_database,
 						|db: Database| {
 							let mut tx = db.transaction(true);
-							for (key, value) in data.iter() {
+							for (key, value) in data {
 								tx.put(key.clone(), value.clone()).unwrap();
 							}
 							tx.commit().unwrap();
 						},
 						criterion::BatchSize::LargeInput,
-					)
+					);
 				},
 			);
 		}
@@ -143,8 +143,8 @@ fn bench_put_operations(c: &mut Criterion) {
 fn bench_get_operations(c: &mut Criterion) {
 	let mut group = c.benchmark_group("get_operations");
 
-	for data_size in [1, 100, 1000, 10_000].iter() {
-		for entry_count in [100, 1000, 10_000].iter() {
+	for data_size in &[1, 100, 1000, 10_000] {
+		for entry_count in &[100, 1000, 10_000] {
 			let db = setup_database_with_data(*entry_count, 16, *data_size);
 			let mut rng = StdRng::seed_from_u64(SEED);
 
@@ -153,7 +153,7 @@ fn bench_get_operations(c: &mut Criterion) {
 
 			group.throughput(Throughput::Elements(lookup_keys.len() as u64));
 			group.bench_with_input(
-				BenchmarkId::new("get", format!("{}b_{}entries", data_size, entry_count)),
+				BenchmarkId::new("get", format!("{data_size}b_{entry_count}entries")),
 				&lookup_keys,
 				|b, keys| {
 					b.iter(|| {
@@ -162,7 +162,7 @@ fn bench_get_operations(c: &mut Criterion) {
 							black_box(tx.get(key.clone()).unwrap());
 						}
 						tx.cancel().unwrap();
-					})
+					});
 				},
 			);
 		}
@@ -173,7 +173,7 @@ fn bench_get_operations(c: &mut Criterion) {
 fn bench_exists_operations(c: &mut Criterion) {
 	let mut group = c.benchmark_group("exists_operations");
 
-	for entry_count in [100, 1000, 10_000].iter() {
+	for entry_count in &[100, 1000, 10_000] {
 		let db = setup_database_with_data(*entry_count, 16, 100);
 		let mut rng = StdRng::seed_from_u64(SEED);
 
@@ -182,7 +182,7 @@ fn bench_exists_operations(c: &mut Criterion) {
 
 		group.throughput(Throughput::Elements(lookup_keys.len() as u64));
 		group.bench_with_input(
-			BenchmarkId::new("exists", format!("{}entries", entry_count)),
+			BenchmarkId::new("exists", format!("{entry_count}entries")),
 			&lookup_keys,
 			|b, keys| {
 				b.iter(|| {
@@ -191,7 +191,7 @@ fn bench_exists_operations(c: &mut Criterion) {
 						black_box(tx.exists(key.clone()).unwrap());
 					}
 					tx.cancel().unwrap();
-				})
+				});
 			},
 		);
 	}
@@ -201,7 +201,7 @@ fn bench_exists_operations(c: &mut Criterion) {
 fn bench_delete_operations(c: &mut Criterion) {
 	let mut group = c.benchmark_group("delete_operations");
 
-	for entry_count in [100, 1000, 10_000].iter() {
+	for entry_count in &[100, 1000, 10_000] {
 		let mut rng = StdRng::seed_from_u64(SEED);
 
 		// Pre-generate keys for deletion
@@ -211,7 +211,7 @@ fn bench_delete_operations(c: &mut Criterion) {
 
 		group.throughput(Throughput::Elements(delete_keys.len() as u64));
 		group.bench_with_input(
-			BenchmarkId::new("del", format!("{}entries", entry_count)),
+			BenchmarkId::new("del", format!("{entry_count}entries")),
 			&delete_keys,
 			|b, keys| {
 				b.iter_batched(
@@ -224,7 +224,7 @@ fn bench_delete_operations(c: &mut Criterion) {
 						tx.commit().unwrap();
 					},
 					criterion::BatchSize::LargeInput,
-				)
+				);
 			},
 		);
 	}
@@ -235,15 +235,15 @@ fn bench_delete_operations(c: &mut Criterion) {
 fn bench_scan_operations(c: &mut Criterion) {
 	let mut group = c.benchmark_group("scan_operations");
 
-	for entry_count in [1000, 10_000, 100_000].iter() {
+	for entry_count in &[1000, 10_000, 100_000] {
 		let db = setup_database_with_sequential_data(*entry_count, 100);
 
-		for scan_limit in [10, 100, 1000].iter() {
+		for scan_limit in &[10, 100, 1000] {
 			let limit = std::cmp::min(*scan_limit, *entry_count);
 
 			group.throughput(Throughput::Elements(limit as u64));
 			group.bench_with_input(
-				BenchmarkId::new("scan", format!("{}entries_limit{}", entry_count, limit)),
+				BenchmarkId::new("scan", format!("{entry_count}entries_limit{limit}")),
 				&limit,
 				|b, &limit| {
 					b.iter(|| {
@@ -253,7 +253,7 @@ fn bench_scan_operations(c: &mut Criterion) {
 						let result = tx.scan(start_key..end_key, None, Some(limit)).unwrap();
 						black_box(result);
 						tx.cancel().unwrap();
-					})
+					});
 				},
 			);
 		}
@@ -264,15 +264,15 @@ fn bench_scan_operations(c: &mut Criterion) {
 fn bench_keys_operations(c: &mut Criterion) {
 	let mut group = c.benchmark_group("keys_operations");
 
-	for entry_count in [1000, 10_000, 100_000].iter() {
+	for entry_count in &[1000, 10_000, 100_000] {
 		let db = setup_database_with_sequential_data(*entry_count, 100);
 
-		for scan_limit in [10, 100, 1000].iter() {
+		for scan_limit in &[10, 100, 1000] {
 			let limit = std::cmp::min(*scan_limit, *entry_count);
 
 			group.throughput(Throughput::Elements(limit as u64));
 			group.bench_with_input(
-				BenchmarkId::new("keys", format!("{}entries_limit{}", entry_count, limit)),
+				BenchmarkId::new("keys", format!("{entry_count}entries_limit{limit}")),
 				&limit,
 				|b, &limit| {
 					b.iter(|| {
@@ -282,7 +282,7 @@ fn bench_keys_operations(c: &mut Criterion) {
 						let result = tx.keys(start_key..end_key, None, Some(limit)).unwrap();
 						black_box(result);
 						tx.cancel().unwrap();
-					})
+					});
 				},
 			);
 		}
@@ -293,11 +293,11 @@ fn bench_keys_operations(c: &mut Criterion) {
 fn bench_total_operations(c: &mut Criterion) {
 	let mut group = c.benchmark_group("total_operations");
 
-	for entry_count in [1000, 10_000, 100_000].iter() {
+	for entry_count in &[1000, 10_000, 100_000] {
 		let db = setup_database_with_sequential_data(*entry_count, 100);
 
 		group.bench_with_input(
-			BenchmarkId::new("total", format!("{}entries", entry_count)),
+			BenchmarkId::new("total", format!("{entry_count}entries")),
 			entry_count,
 			|b, _| {
 				b.iter(|| {
@@ -307,7 +307,7 @@ fn bench_total_operations(c: &mut Criterion) {
 					let result = tx.total(start_key..end_key, None, None).unwrap();
 					black_box(result);
 					tx.cancel().unwrap();
-				})
+				});
 			},
 		);
 	}
@@ -319,16 +319,16 @@ fn bench_total_operations(c: &mut Criterion) {
 fn bench_cursor_scan(c: &mut Criterion) {
 	let mut group = c.benchmark_group("cursor_scan");
 
-	for entry_count in [1000, 10_000, 100_000].iter() {
+	for entry_count in &[1000, 10_000, 100_000] {
 		let db = setup_database_with_sequential_data(*entry_count, 100);
 
-		for scan_limit in [10, 100, 1000].iter() {
+		for scan_limit in &[10, 100, 1000] {
 			let limit = std::cmp::min(*scan_limit, *entry_count);
 
 			group.throughput(Throughput::Elements(limit as u64));
 
 			group.bench_with_input(
-				BenchmarkId::new("cursor_fwd", format!("{}entries_limit{}", entry_count, limit)),
+				BenchmarkId::new("cursor_fwd", format!("{entry_count}entries_limit{limit}")),
 				&limit,
 				|b, &limit| {
 					b.iter(|| {
@@ -351,7 +351,7 @@ fn bench_cursor_scan(c: &mut Criterion) {
 						}
 
 						black_box(count);
-					})
+					});
 				},
 			);
 		}
@@ -364,16 +364,16 @@ fn bench_cursor_scan(c: &mut Criterion) {
 fn bench_scan_iter(c: &mut Criterion) {
 	let mut group = c.benchmark_group("scan_iter_ops");
 
-	for entry_count in [1000, 10_000, 100_000].iter() {
+	for entry_count in &[1000, 10_000, 100_000] {
 		let db = setup_database_with_sequential_data(*entry_count, 100);
 
-		for scan_limit in [10, 100, 1000].iter() {
+		for scan_limit in &[10, 100, 1000] {
 			let limit = std::cmp::min(*scan_limit, *entry_count);
 
 			group.throughput(Throughput::Elements(limit as u64));
 
 			group.bench_with_input(
-				BenchmarkId::new("scan_iter", format!("{}entries_limit{}", entry_count, limit)),
+				BenchmarkId::new("scan_iter", format!("{entry_count}entries_limit{limit}")),
 				&limit,
 				|b, &limit| {
 					b.iter(|| {
@@ -387,7 +387,7 @@ fn bench_scan_iter(c: &mut Criterion) {
 						let result: Vec<_> = iter.take(limit).collect();
 
 						black_box(result);
-					})
+					});
 				},
 			);
 		}
@@ -400,16 +400,16 @@ fn bench_scan_iter(c: &mut Criterion) {
 fn bench_keys_iter(c: &mut Criterion) {
 	let mut group = c.benchmark_group("keys_iter_ops");
 
-	for entry_count in [1000, 10_000, 100_000].iter() {
+	for entry_count in &[1000, 10_000, 100_000] {
 		let db = setup_database_with_sequential_data(*entry_count, 100);
 
-		for scan_limit in [10, 100, 1000].iter() {
+		for scan_limit in &[10, 100, 1000] {
 			let limit = std::cmp::min(*scan_limit, *entry_count);
 
 			group.throughput(Throughput::Elements(limit as u64));
 
 			group.bench_with_input(
-				BenchmarkId::new("keys_iter", format!("{}entries_limit{}", entry_count, limit)),
+				BenchmarkId::new("keys_iter", format!("{entry_count}entries_limit{limit}")),
 				&limit,
 				|b, &limit| {
 					b.iter(|| {
@@ -423,7 +423,7 @@ fn bench_keys_iter(c: &mut Criterion) {
 						let result: Vec<_> = iter.take(limit).collect();
 
 						black_box(result);
-					})
+					});
 				},
 			);
 		}
@@ -437,10 +437,10 @@ fn bench_concurrent_readers(c: &mut Criterion) {
 	let mut group = c.benchmark_group("concurrent_readers");
 
 	// Test with different thread counts: 1, 4, and CPU cores
-	let cpu_cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+	let cpu_cores = std::thread::available_parallelism().map_or(8, std::num::NonZero::get);
 	let thread_counts = [1, 4, cpu_cores];
 
-	for entry_count in [1000, 10_000].iter() {
+	for entry_count in &[1000, 10_000] {
 		let db = Arc::new(setup_database_with_sequential_data(*entry_count, 100));
 		let mut rng = StdRng::seed_from_u64(SEED);
 
@@ -449,12 +449,12 @@ fn bench_concurrent_readers(c: &mut Criterion) {
 		let lookup_keys: Vec<Bytes> =
 			(0..200).map(|_| generate_sequential_key(rng.random_range(0..*entry_count))).collect();
 
-		for &thread_count in thread_counts.iter() {
+		for &thread_count in &thread_counts {
 			group.throughput(Throughput::Elements((lookup_keys.len() * thread_count) as u64));
 			group.bench_with_input(
 				BenchmarkId::new(
 					"concurrent_read",
-					format!("{}entries_{}threads", entry_count, thread_count),
+					format!("{entry_count}entries_{thread_count}threads"),
 				),
 				&(lookup_keys.clone(), thread_count),
 				|b, (keys, num_threads)| {
@@ -478,7 +478,7 @@ fn bench_concurrent_readers(c: &mut Criterion) {
 						let results: Vec<_> =
 							handles.into_iter().map(|h| h.join().unwrap()).collect();
 						black_box(results);
-					})
+					});
 				},
 			);
 		}
@@ -491,18 +491,18 @@ fn bench_concurrent_writers(c: &mut Criterion) {
 	let mut group = c.benchmark_group("concurrent_writers");
 
 	// Test with different thread counts: 1, 4, and CPU cores
-	let cpu_cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+	let cpu_cores = std::thread::available_parallelism().map_or(8, std::num::NonZero::get);
 	let thread_counts = [1, 4, cpu_cores];
 
-	for entry_count in [1000, 10_000].iter() {
-		for &thread_count in thread_counts.iter() {
+	for entry_count in &[1000, 10_000] {
+		for &thread_count in &thread_counts {
 			let operations_per_thread = 50; // Each thread performs 50 operations
 
 			group.throughput(Throughput::Elements((operations_per_thread * thread_count) as u64));
 			group.bench_with_input(
 				BenchmarkId::new(
 					"concurrent_inserts",
-					format!("{}entries_{}threads", entry_count, thread_count),
+					format!("{entry_count}entries_{thread_count}threads"),
 				),
 				&(entry_count, thread_count, operations_per_thread),
 				|b, &(entry_count, num_threads, ops_per_thread)| {
@@ -526,8 +526,7 @@ fn bench_concurrent_writers(c: &mut Criterion) {
 										0 => {
 											// Insert new key
 											let key = Bytes::from(
-												format!("new_key_{}_{}", thread_id, op_id)
-													.into_bytes(),
+												format!("new_key_{thread_id}_{op_id}").into_bytes(),
 											);
 											let value = generate_value(&mut rng, 100);
 											thread_ops.push(("insert", key, value));
@@ -545,7 +544,7 @@ fn bench_concurrent_writers(c: &mut Criterion) {
 												generate_sequential_key(base_key_id % *entry_count) // Existing key
 											} else {
 												Bytes::from(
-													format!("upsert_key_{}_{}", thread_id, op_id)
+													format!("upsert_key_{thread_id}_{op_id}")
 														.into_bytes(),
 												) // New key
 											};
@@ -603,7 +602,7 @@ fn bench_concurrent_writers(c: &mut Criterion) {
 							black_box(results);
 						},
 						criterion::BatchSize::LargeInput,
-					)
+					);
 				},
 			);
 		}
@@ -616,11 +615,11 @@ fn bench_concurrent_mixed(c: &mut Criterion) {
 	let mut group = c.benchmark_group("concurrent_mixed");
 
 	// Test with different thread configurations
-	let cpu_cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+	let cpu_cores = std::thread::available_parallelism().map_or(8, std::num::NonZero::get);
 	let half_cores = (cpu_cores / 2).max(1);
-	let cpu_config_name = format!("{}r_{}w", half_cores, half_cores);
+	let cpu_config_name = format!("{half_cores}r_{half_cores}w");
 
-	for entry_count in [1000, 10_000].iter() {
+	for entry_count in &[1000, 10_000] {
 		let configurations = vec![
 			("2r_2w", 2, 2),
 			("4r_4w", 4, 4),
@@ -633,7 +632,7 @@ fn bench_concurrent_mixed(c: &mut Criterion) {
 
 			group.throughput(Throughput::Elements(total_ops as u64));
 			group.bench_with_input(
-				BenchmarkId::new("mixed", format!("{}entries_{}", entry_count, config_name)),
+				BenchmarkId::new("mixed", format!("{entry_count}entries_{config_name}")),
 				&(entry_count, reader_threads, writer_threads, operations_per_thread),
 				|b, &(entry_count, num_readers, num_writers, ops_per_thread)| {
 					b.iter_batched(
@@ -651,8 +650,7 @@ fn bench_concurrent_mixed(c: &mut Criterion) {
 							// Generate write operations
 							let write_ops: Vec<(Bytes, Bytes)> = (0..ops_per_thread)
 								.map(|i| {
-									let key =
-										Bytes::from(format!("mixed_write_{}", i).into_bytes());
+									let key = Bytes::from(format!("mixed_write_{i}").into_bytes());
 									let value = generate_value(&mut rng, 100);
 									(key, value)
 								})
@@ -711,7 +709,7 @@ fn bench_concurrent_mixed(c: &mut Criterion) {
 							black_box(results);
 						},
 						criterion::BatchSize::LargeInput,
-					)
+					);
 				},
 			);
 		}
@@ -723,7 +721,7 @@ fn bench_concurrent_mixed(c: &mut Criterion) {
 fn bench_mixed_workload(c: &mut Criterion) {
 	let mut group = c.benchmark_group("mixed_workload");
 
-	for entry_count in [1000, 10_000].iter() {
+	for entry_count in &[1000, 10_000] {
 		let mut rng = StdRng::seed_from_u64(SEED);
 
 		// Generate operations mix: 70% reads, 20% writes, 10% deletes
@@ -741,7 +739,7 @@ fn bench_mixed_workload(c: &mut Criterion) {
 
 		group.throughput(Throughput::Elements(operations.len() as u64));
 		group.bench_with_input(
-			BenchmarkId::new("mixed_70r_20w_10d", format!("{}entries", entry_count)),
+			BenchmarkId::new("mixed_70r_20w_10d", format!("{entry_count}entries")),
 			&operations,
 			|b, ops| {
 				b.iter_batched(
@@ -767,7 +765,7 @@ fn bench_mixed_workload(c: &mut Criterion) {
 						tx.commit().unwrap();
 					},
 					criterion::BatchSize::LargeInput,
-				)
+				);
 			},
 		);
 	}
@@ -821,13 +819,13 @@ fn bench_database_options(c: &mut Criterion) {
 					|| Database::new_with_options(options.clone()),
 					|db: Database| {
 						let mut tx = db.transaction(true);
-						for (key, value) in data.iter() {
+						for (key, value) in data {
 							tx.put(key.clone(), value.clone()).unwrap();
 						}
 						tx.commit().unwrap();
 					},
 					criterion::BatchSize::LargeInput,
-				)
+				);
 			},
 		);
 	}
@@ -838,16 +836,16 @@ fn bench_database_options(c: &mut Criterion) {
 fn bench_scan_for_each(c: &mut Criterion) {
 	let mut group = c.benchmark_group("scan_for_each_vs_vec");
 
-	for entry_count in [1000, 10_000, 100_000].iter() {
+	for entry_count in &[1000, 10_000, 100_000] {
 		let db = setup_database_with_sequential_data(*entry_count, 100);
 		let mut seen_limits = std::collections::HashSet::new();
 
-		for scan_limit in [100, 1000, 10_000].iter() {
+		for scan_limit in &[100, 1000, 10_000] {
 			let limit = std::cmp::min(*scan_limit, *entry_count);
 			if !seen_limits.insert(limit) {
 				continue;
 			}
-			let id = format!("{}entries_limit{}", entry_count, limit);
+			let id = format!("{entry_count}entries_limit{limit}");
 
 			group.throughput(Throughput::Elements(limit as u64));
 
@@ -859,7 +857,7 @@ fn bench_scan_for_each(c: &mut Criterion) {
 					let result = tx.scan(start_key..end_key, None, Some(limit)).unwrap();
 					black_box(result);
 					tx.cancel().unwrap();
-				})
+				});
 			});
 
 			group.bench_with_input(BenchmarkId::new("scan_for_each", &id), &limit, |b, &limit| {
@@ -875,7 +873,7 @@ fn bench_scan_for_each(c: &mut Criterion) {
 					})
 					.unwrap();
 					black_box(count);
-				})
+				});
 			});
 
 			group.bench_with_input(
@@ -889,7 +887,7 @@ fn bench_scan_for_each(c: &mut Criterion) {
 						let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
 						tx.scan_into(start_key..end_key, None, Some(limit), &mut buf).unwrap();
 						black_box(buf.len());
-					})
+					});
 				},
 			);
 		}
@@ -901,16 +899,16 @@ fn bench_scan_for_each(c: &mut Criterion) {
 fn bench_keys_for_each(c: &mut Criterion) {
 	let mut group = c.benchmark_group("keys_for_each_vs_vec");
 
-	for entry_count in [1000, 10_000, 100_000].iter() {
+	for entry_count in &[1000, 10_000, 100_000] {
 		let db = setup_database_with_sequential_data(*entry_count, 100);
 		let mut seen_limits = std::collections::HashSet::new();
 
-		for scan_limit in [100, 1000, 10_000].iter() {
+		for scan_limit in &[100, 1000, 10_000] {
 			let limit = std::cmp::min(*scan_limit, *entry_count);
 			if !seen_limits.insert(limit) {
 				continue;
 			}
-			let id = format!("{}entries_limit{}", entry_count, limit);
+			let id = format!("{entry_count}entries_limit{limit}");
 
 			group.throughput(Throughput::Elements(limit as u64));
 
@@ -922,7 +920,7 @@ fn bench_keys_for_each(c: &mut Criterion) {
 					let result = tx.keys(start_key..end_key, None, Some(limit)).unwrap();
 					black_box(result);
 					tx.cancel().unwrap();
-				})
+				});
 			});
 
 			group.bench_with_input(BenchmarkId::new("keys_for_each", &id), &limit, |b, &limit| {
@@ -938,7 +936,7 @@ fn bench_keys_for_each(c: &mut Criterion) {
 					})
 					.unwrap();
 					black_box(count);
-				})
+				});
 			});
 
 			group.bench_with_input(
@@ -952,7 +950,7 @@ fn bench_keys_for_each(c: &mut Criterion) {
 						let end_key = b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF".to_vec();
 						tx.keys_into(start_key..end_key, None, Some(limit), &mut buf).unwrap();
 						black_box(buf.len());
-					})
+					});
 				},
 			);
 		}
@@ -972,7 +970,7 @@ fn bench_gc_full_scan(c: &mut Criterion) {
 	// Fixed number of keys carrying stale versions
 	let stale_count = 100;
 
-	for total_keys in [1_000, 10_000, 100_000].iter() {
+	for total_keys in &[1_000, 10_000, 100_000] {
 		// Setup helper: create datastore, then overwrite a small subset
 		// while a reader pins the old versions, then drop the reader —
 		// exactly the garbage shape only a background sweep can reclaim.
@@ -995,7 +993,7 @@ fn bench_gc_full_scan(c: &mut Criterion) {
 				let mut tx = db.transaction(true);
 				for i in 0..stale_count {
 					let key = generate_sequential_key(i);
-					let value = Bytes::from(format!("updated_{:08}", i).into_bytes());
+					let value = Bytes::from(format!("updated_{i:08}").into_bytes());
 					tx.set(key, value).unwrap();
 				}
 				tx.commit().unwrap();
@@ -1008,7 +1006,7 @@ fn bench_gc_full_scan(c: &mut Criterion) {
 		// returned from the routine so its O(n) teardown is dropped
 		// outside the timed region rather than polluting the measurement.
 		group.bench_function(
-			BenchmarkId::new("full_gc", format!("{}total_{}stale", total_keys, stale_count)),
+			BenchmarkId::new("full_gc", format!("{total_keys}total_{stale_count}stale")),
 			|b| {
 				b.iter_batched(
 					setup,
@@ -1017,14 +1015,14 @@ fn bench_gc_full_scan(c: &mut Criterion) {
 						db
 					},
 					criterion::BatchSize::LargeInput,
-				)
+				);
 			},
 		);
 
 		// Tracked sweep: visits only the keys commits tracked as holding
 		// garbage, so cost scales with the stale count, not total keys
 		group.bench_function(
-			BenchmarkId::new("tracked_gc", format!("{}total_{}stale", total_keys, stale_count)),
+			BenchmarkId::new("tracked_gc", format!("{total_keys}total_{stale_count}stale")),
 			|b| {
 				b.iter_batched(
 					setup,
@@ -1033,7 +1031,7 @@ fn bench_gc_full_scan(c: &mut Criterion) {
 						db
 					},
 					criterion::BatchSize::LargeInput,
-				)
+				);
 			},
 		);
 	}
@@ -1056,7 +1054,7 @@ fn bench_commit_inline_gc(c: &mut Criterion) {
 			let mut tx = db.transaction(true);
 			tx.set(key.clone(), value.clone()).unwrap();
 			tx.commit().unwrap();
-		})
+		});
 	});
 
 	// Wide writeset: one commit overwriting many keys
@@ -1066,11 +1064,11 @@ fn bench_commit_inline_gc(c: &mut Criterion) {
 		let value = generate_sequential_value(0, 100);
 		b.iter(|| {
 			let mut tx = db.transaction(true);
-			for key in keys.iter() {
+			for key in &keys {
 				tx.set(key.clone(), value.clone()).unwrap();
 			}
 			tx.commit().unwrap();
-		})
+		});
 	});
 
 	group.finish();
@@ -1082,10 +1080,10 @@ fn bench_commit_inline_gc(c: &mut Criterion) {
 // growth and every other commit cost.
 fn bench_watermark_scan(c: &mut Criterion) {
 	let mut group = c.benchmark_group("watermark_scan");
-	for num_readers in [0usize, 10, 100, 1_000, 10_000].iter() {
+	for num_readers in &[0usize, 10, 100, 1_000, 10_000] {
 		let scenario = WatermarkScanScenario::new(*num_readers);
 		group.bench_function(BenchmarkId::new("live_readers", num_readers), |b| {
-			b.iter(|| scenario.scan())
+			b.iter(|| scenario.scan());
 		});
 	}
 	group.finish();
@@ -1100,7 +1098,7 @@ fn bench_watermark_scan(c: &mut Criterion) {
 fn bench_readset_bloom_impact(c: &mut Criterion) {
 	let mut group = c.benchmark_group("readset_bloom_impact");
 
-	for readset_size in [100, 1_000, 10_000].iter() {
+	for readset_size in &[100, 1_000, 10_000] {
 		// Committed transaction wrote 10 keys in the high range
 		let writeset_keys: Vec<Bytes> = (90_000..90_010).map(generate_sequential_key).collect();
 		// Current transaction read keys in the low range (no overlap)
@@ -1109,22 +1107,19 @@ fn bench_readset_bloom_impact(c: &mut Criterion) {
 		let scenario = ReadsetConflictScenario::new(&writeset_keys, &readset_keys);
 
 		// With bloom filter pre-check
-		group.bench_function(
-			BenchmarkId::new("with_bloom", format!("{}reads", readset_size)),
-			|b| {
-				b.iter(|| {
-					black_box(scenario.check_with_bloom());
-				})
-			},
-		);
+		group.bench_function(BenchmarkId::new("with_bloom", format!("{readset_size}reads")), |b| {
+			b.iter(|| {
+				black_box(scenario.check_with_bloom());
+			});
+		});
 
 		// Without bloom filter (exact HashSet intersection)
 		group.bench_function(
-			BenchmarkId::new("without_bloom", format!("{}reads", readset_size)),
+			BenchmarkId::new("without_bloom", format!("{readset_size}reads")),
 			|b| {
 				b.iter(|| {
 					black_box(scenario.check_without_bloom());
-				})
+				});
 			},
 		);
 	}
@@ -1136,7 +1131,7 @@ fn bench_readset_bloom_impact(c: &mut Criterion) {
 fn bench_readset_bloom_conflict_path(c: &mut Criterion) {
 	let mut group = c.benchmark_group("readset_bloom_conflict_path");
 
-	for readset_size in [100, 1_000, 10_000].iter() {
+	for readset_size in &[100, 1_000, 10_000] {
 		// Committed transaction wrote 10 keys that overlap the readset
 		let writeset_keys: Vec<Bytes> = (0..10).map(generate_sequential_key).collect();
 		// Current transaction read keys 0..readset_size (overlap on 0..10)
@@ -1145,22 +1140,19 @@ fn bench_readset_bloom_conflict_path(c: &mut Criterion) {
 		let scenario = ReadsetConflictScenario::new(&writeset_keys, &readset_keys);
 
 		// With bloom (bloom says "maybe", falls through)
-		group.bench_function(
-			BenchmarkId::new("with_bloom", format!("{}reads", readset_size)),
-			|b| {
-				b.iter(|| {
-					black_box(scenario.check_with_bloom());
-				})
-			},
-		);
+		group.bench_function(BenchmarkId::new("with_bloom", format!("{readset_size}reads")), |b| {
+			b.iter(|| {
+				black_box(scenario.check_with_bloom());
+			});
+		});
 
 		// Without bloom (exact check directly)
 		group.bench_function(
-			BenchmarkId::new("without_bloom", format!("{}reads", readset_size)),
+			BenchmarkId::new("without_bloom", format!("{readset_size}reads")),
 			|b| {
 				b.iter(|| {
 					black_box(scenario.check_without_bloom());
-				})
+				});
 			},
 		);
 	}
@@ -1172,7 +1164,7 @@ fn bench_readset_bloom_conflict_path(c: &mut Criterion) {
 fn bench_writeset_bloom_impact(c: &mut Criterion) {
 	let mut group = c.benchmark_group("writeset_bloom_impact");
 
-	for writeset_size in [10, 100, 1_000].iter() {
+	for writeset_size in &[10, 100, 1_000] {
 		// Committed transaction wrote keys in the high range
 		let committed_keys: Vec<Bytes> =
 			(90_000..(90_000 + *writeset_size)).map(generate_sequential_key).collect();
@@ -1183,21 +1175,21 @@ fn bench_writeset_bloom_impact(c: &mut Criterion) {
 
 		// With bloom filter + min/max pre-check
 		group.bench_function(
-			BenchmarkId::new("with_bloom", format!("{}writes", writeset_size)),
+			BenchmarkId::new("with_bloom", format!("{writeset_size}writes")),
 			|b| {
 				b.iter(|| {
 					black_box(scenario.check_with_bloom());
-				})
+				});
 			},
 		);
 
 		// Without bloom (sorted merge only)
 		group.bench_function(
-			BenchmarkId::new("without_bloom", format!("{}writes", writeset_size)),
+			BenchmarkId::new("without_bloom", format!("{writeset_size}writes")),
 			|b| {
 				b.iter(|| {
 					black_box(scenario.check_without_bloom());
-				})
+				});
 			},
 		);
 	}
@@ -1208,7 +1200,7 @@ fn bench_writeset_bloom_impact(c: &mut Criterion) {
 fn bench_writeset_bloom_conflict_path(c: &mut Criterion) {
 	let mut group = c.benchmark_group("writeset_bloom_conflict_path");
 
-	for writeset_size in [10, 100, 1_000].iter() {
+	for writeset_size in &[10, 100, 1_000] {
 		// Both write to overlapping ranges
 		let committed_keys: Vec<Bytes> = (0..10).map(generate_sequential_key).collect();
 		let current_keys: Vec<Bytes> = (0..*writeset_size).map(generate_sequential_key).collect();
@@ -1217,21 +1209,21 @@ fn bench_writeset_bloom_conflict_path(c: &mut Criterion) {
 
 		// With bloom (bloom says "maybe", falls through to sorted merge)
 		group.bench_function(
-			BenchmarkId::new("with_bloom", format!("{}writes", writeset_size)),
+			BenchmarkId::new("with_bloom", format!("{writeset_size}writes")),
 			|b| {
 				b.iter(|| {
 					black_box(scenario.check_with_bloom());
-				})
+				});
 			},
 		);
 
 		// Without bloom (sorted merge only)
 		group.bench_function(
-			BenchmarkId::new("without_bloom", format!("{}writes", writeset_size)),
+			BenchmarkId::new("without_bloom", format!("{writeset_size}writes")),
 			|b| {
 				b.iter(|| {
 					black_box(scenario.check_without_bloom());
-				})
+				});
 			},
 		);
 	}
@@ -1245,10 +1237,10 @@ fn bench_writeset_bloom_conflict_path(c: &mut Criterion) {
 fn bench_bloom_concurrent_throughput(c: &mut Criterion) {
 	let mut group = c.benchmark_group("bloom_concurrent_throughput");
 	// Use a reasonable thread count
-	let cpu_cores = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+	let cpu_cores = std::thread::available_parallelism().map_or(8, std::num::NonZero::get);
 	let thread_counts = [2, 4, cpu_cores.min(8)];
 
-	for &thread_count in thread_counts.iter() {
+	for &thread_count in &thread_counts {
 		// Each thread gets a disjoint key range of 1000 keys
 		let keys_per_thread = 1000;
 		let total_keys = thread_count * keys_per_thread;
@@ -1256,7 +1248,7 @@ fn bench_bloom_concurrent_throughput(c: &mut Criterion) {
 
 		// SSI mode
 		group.throughput(Throughput::Elements(thread_count as u64));
-		group.bench_function(BenchmarkId::new("ssi", format!("{}threads", thread_count)), |b| {
+		group.bench_function(BenchmarkId::new("ssi", format!("{thread_count}threads")), |b| {
 			b.iter(|| {
 				let handles: Vec<_> = (0..thread_count)
 					.map(|t| {
@@ -1284,12 +1276,12 @@ fn bench_bloom_concurrent_throughput(c: &mut Criterion) {
 				for h in handles {
 					h.join().unwrap();
 				}
-			})
+			});
 		});
 
 		// SI baseline for comparison
 		group.bench_function(
-			BenchmarkId::new("si_baseline", format!("{}threads", thread_count)),
+			BenchmarkId::new("si_baseline", format!("{thread_count}threads")),
 			|b| {
 				b.iter(|| {
 					let handles: Vec<_> = (0..thread_count)
@@ -1317,7 +1309,7 @@ fn bench_bloom_concurrent_throughput(c: &mut Criterion) {
 					for h in handles {
 						h.join().unwrap();
 					}
-				})
+				});
 			},
 		);
 	}
@@ -1338,27 +1330,24 @@ fn bench_merge_queue_iter(c: &mut Criterion) {
 	let total_keys = 10_000;
 	let keys_per_source = 50;
 
-	for num_sources in [1, 4, 16, 64].iter() {
+	for num_sources in &[1, 4, 16, 64] {
 		let scenario = MergeQueueScenario::new(*num_sources, keys_per_source, total_keys);
 
 		// Full drain: scales with merge-queue depth × keys per source.
-		group.bench_function(BenchmarkId::new("drain", format!("{}sources", num_sources)), |b| {
+		group.bench_function(BenchmarkId::new("drain", format!("{num_sources}sources")), |b| {
 			b.iter(|| {
 				black_box(scenario.iter_forward_count());
-			})
+			});
 		});
 
 		// Early termination at 100 entries: highlights the lazy iterator's
 		// advantage over the previous eager BTreeMap materialisation, which
 		// always paid the full merge cost up front.
-		group.bench_function(
-			BenchmarkId::new("take_100", format!("{}sources", num_sources)),
-			|b| {
-				b.iter(|| {
-					black_box(scenario.iter_forward_take(100));
-				})
-			},
-		);
+		group.bench_function(BenchmarkId::new("take_100", format!("{num_sources}sources")), |b| {
+			b.iter(|| {
+				black_box(scenario.iter_forward_take(100));
+			});
+		});
 	}
 	group.finish();
 }
@@ -1373,10 +1362,10 @@ fn bench_cursor_pagination(c: &mut Criterion) {
 	let entry_count = 10_000;
 	let db = setup_database_with_sequential_data(entry_count, 100);
 
-	for page_size in [10, 100, 1000].iter() {
+	for page_size in &[10, 100, 1000] {
 		group.throughput(Throughput::Elements(*page_size as u64));
 		group.bench_with_input(
-			BenchmarkId::new("first_n", format!("page{}", page_size)),
+			BenchmarkId::new("first_n", format!("page{page_size}")),
 			page_size,
 			|b, &page| {
 				b.iter(|| {
@@ -1395,7 +1384,7 @@ fn bench_cursor_pagination(c: &mut Criterion) {
 						cursor.next();
 					}
 					black_box(count);
-				})
+				});
 			},
 		);
 	}

--- a/src/bench_internals.rs
+++ b/src/bench_internals.rs
@@ -150,7 +150,7 @@ impl MergeQueueScenario {
 				// Cheap deterministic spread; collisions across sources are
 				// expected and exercise the dedup path.
 				let key_idx = (i.wrapping_mul(31) + j.wrapping_mul(17)) % total_keys;
-				let key = Bytes::from(format!("key_{:08}", key_idx).into_bytes());
+				let key = Bytes::from(format!("key_{key_idx:08}").into_bytes());
 				ws.insert(key, Some(Bytes::from_static(b"v")));
 			}
 			sources.push(Arc::new(Merge {
@@ -159,7 +159,7 @@ impl MergeQueueScenario {
 			}));
 		}
 		let beg = Bytes::from(b"key_00000000".to_vec());
-		let end = Bytes::from(format!("key_{:08}", total_keys).into_bytes());
+		let end = Bytes::from(format!("key_{total_keys:08}").into_bytes());
 		Self {
 			sources,
 			beg,

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -85,7 +85,7 @@ impl BloomFilter {
 		// Compute the primary FNV-1a hash
 		let mut h1: u64 = 0xcbf29ce484222325;
 		for &b in key {
-			h1 ^= b as u64;
+			h1 ^= u64::from(b);
 			h1 = h1.wrapping_mul(0x100000001b3);
 		}
 		// Derive the secondary hash via multiplication and rotation
@@ -97,7 +97,7 @@ impl BloomFilter {
 	/// Compute the nth hash from the dual hash pair
 	#[inline]
 	fn nth_hash(hashes: (u64, u64), n: u32) -> u64 {
-		hashes.0.wrapping_add((n as u64).wrapping_mul(hashes.1))
+		hashes.0.wrapping_add(u64::from(n).wrapping_mul(hashes.1))
 	}
 }
 
@@ -135,7 +135,7 @@ mod tests {
 				false_positives += 1;
 			}
 		}
-		assert!(false_positives < 100, "too many false positives: {}", false_positives);
+		assert!(false_positives < 100, "too many false positives: {false_positives}");
 	}
 
 	#[test]

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -83,13 +83,13 @@ impl BloomFilter {
 	#[inline]
 	fn hash(key: &[u8]) -> (u64, u64) {
 		// Compute the primary FNV-1a hash
-		let mut h1: u64 = 0xcbf29ce484222325;
+		let mut h1: u64 = 0xcbf2_9ce4_8422_2325;
 		for &b in key {
 			h1 ^= u64::from(b);
-			h1 = h1.wrapping_mul(0x100000001b3);
+			h1 = h1.wrapping_mul(0x0100_0000_01b3);
 		}
 		// Derive the secondary hash via multiplication and rotation
-		let h2 = h1.wrapping_mul(0x9e3779b97f4a7c15).rotate_left(31);
+		let h2 = h1.wrapping_mul(0x9e37_79b9_7f4a_7c15).rotate_left(31);
 		// Return the dual hash pair
 		(h1, h2)
 	}

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -27,8 +27,8 @@ pub(crate) struct BloomFilter {
 
 impl BloomFilter {
 	/// Create a new empty bloom filter
-	pub fn new() -> Self {
-		BloomFilter {
+	pub const fn new() -> Self {
+		Self {
 			bits: [0; BLOOM_BYTES],
 			count: 0,
 		}
@@ -69,12 +69,12 @@ impl BloomFilter {
 	}
 
 	/// Check whether the filter is empty
-	pub fn is_empty(&self) -> bool {
+	pub const fn is_empty(&self) -> bool {
 		self.count == 0
 	}
 
 	/// Reset the filter to its initial empty state
-	pub fn clear(&mut self) {
+	pub const fn clear(&mut self) {
 		self.bits = [0; BLOOM_BYTES];
 		self.count = 0;
 	}

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -60,6 +60,18 @@ impl CompressedWriter {
 	}
 
 	/// Finish compression (for LZ4, this finalizes the stream)
+	///
+	/// Takes `self` by value so that the encoder is dropped, and the stream
+	/// finalized, at an explicit point chosen by the caller rather than
+	/// wherever the writer happens to go out of scope.
+	#[expect(
+		clippy::unnecessary_wraps,
+		reason = "fallible signature is part of the writer API and mirrors the io::Result of every other method here"
+	)]
+	#[expect(
+		clippy::unused_self,
+		reason = "consuming self is the point: the drop finalizes the stream"
+	)]
 	pub(crate) fn finish(self) -> io::Result<()> {
 		// The encoder will be dropped here, which finalizes the stream
 		Ok(())

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -89,7 +89,7 @@ impl<'a> Cursor<'a> {
 			.transaction_merge_queue
 			.range(..=version)
 			.rev()
-			.map(|e| e.value().clone())
+			.map(|e| Arc::clone(e.value()))
 			.collect();
 
 		Cursor {
@@ -108,7 +108,7 @@ impl<'a> Cursor<'a> {
 
 	/// Check if the cursor is positioned at a valid entry.
 	#[inline]
-	pub fn valid(&self) -> bool {
+	pub const fn valid(&self) -> bool {
 		self.current.is_some()
 	}
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -128,7 +128,7 @@ impl<'a> Cursor<'a> {
 	/// Check if the current entry exists (is not deleted).
 	#[inline]
 	pub fn exists(&self) -> bool {
-		self.current.as_ref().map(|(_, v)| v.is_some()).unwrap_or(false)
+		self.current.as_ref().is_some_and(|(_, v)| v.is_some())
 	}
 
 	/// Move the cursor to the first entry in the range.
@@ -335,7 +335,7 @@ impl<'a> KeyIterator<'a> {
 	}
 }
 
-impl<'a> Iterator for KeyIterator<'a> {
+impl Iterator for KeyIterator<'_> {
 	type Item = Bytes;
 
 	fn next(&mut self) -> Option<Self::Item> {
@@ -360,7 +360,7 @@ impl<'a> Iterator for KeyIterator<'a> {
 	}
 }
 
-impl<'a> DoubleEndedIterator for KeyIterator<'a> {
+impl DoubleEndedIterator for KeyIterator<'_> {
 	fn next_back(&mut self) -> Option<Self::Item> {
 		// When iterating from the back, we go in the opposite direction
 		let was_reverse = self.reverse;
@@ -432,7 +432,7 @@ impl<'a> ScanIterator<'a> {
 	}
 }
 
-impl<'a> Iterator for ScanIterator<'a> {
+impl Iterator for ScanIterator<'_> {
 	type Item = (Bytes, Bytes);
 
 	fn next(&mut self) -> Option<Self::Item> {
@@ -458,7 +458,7 @@ impl<'a> Iterator for ScanIterator<'a> {
 	}
 }
 
-impl<'a> DoubleEndedIterator for ScanIterator<'a> {
+impl DoubleEndedIterator for ScanIterator<'_> {
 	fn next_back(&mut self) -> Option<Self::Item> {
 		// When iterating from the back, we go in the opposite direction
 		let was_reverse = self.reverse;

--- a/src/db.rs
+++ b/src/db.rs
@@ -53,8 +53,8 @@ pub struct Database {
 impl Default for Database {
 	fn default() -> Self {
 		let inner = Arc::new(Inner::default());
-		let pool = Pool::new(inner.clone(), DEFAULT_POOL_SIZE);
-		Database {
+		let pool = Pool::new(Arc::clone(&inner), DEFAULT_POOL_SIZE);
+		Self {
 			inner,
 			pool,
 			#[cfg(not(target_arch = "wasm32"))]
@@ -92,9 +92,9 @@ impl Database {
 		//  Create a new inner database
 		let inner = Arc::new(Inner::new(&opts));
 		// Initialise a transaction pool
-		let pool = Pool::new(inner.clone(), opts.pool_size);
+		let pool = Pool::new(Arc::clone(&inner), opts.pool_size);
 		// Create the database
-		let db = Database {
+		let db = Self {
 			inner,
 			pool,
 			#[cfg(not(target_arch = "wasm32"))]
@@ -128,14 +128,14 @@ impl Database {
 		//  Create a new inner database
 		let inner = Arc::new(Inner::new(&opts));
 		// Initialise a transaction pool
-		let pool = Pool::new(inner.clone(), opts.pool_size);
+		let pool = Pool::new(Arc::clone(&inner), opts.pool_size);
 		// Create a new persistence layer with options
-		let persist = Persistence::new_with_options(persistence_opts, inner.clone())
+		let persist = Persistence::new_with_options(persistence_opts, Arc::clone(&inner))
 			.map_err(std::io::Error::other)?;
 		// Replace the persistence layer in the database
 		inner.persistence.write().replace(Arc::new(persist.clone()));
 		// Create the database
-		let db = Database {
+		let db = Self {
 			inner,
 			pool,
 			persistence: Some(persist),
@@ -160,7 +160,7 @@ impl Database {
 
 	/// Get a reference to the persistence layer if enabled
 	#[cfg(not(target_arch = "wasm32"))]
-	pub fn persistence(&self) -> Option<&Persistence> {
+	pub const fn persistence(&self) -> Option<&Persistence> {
 		self.persistence.as_ref()
 	}
 
@@ -277,7 +277,7 @@ impl Database {
 	#[cfg(not(target_arch = "wasm32"))]
 	fn initialise_cleanup_worker(&self) {
 		// Clone the underlying datastore inner
-		let db = self.inner.clone();
+		let db = Arc::clone(&self.inner);
 		// Check if a background thread is already running
 		if db.transaction_cleanup_handle.read().is_none() {
 			// Get the specified interval
@@ -305,7 +305,7 @@ impl Database {
 	#[cfg(not(target_arch = "wasm32"))]
 	fn initialise_garbage_worker(&self) {
 		// Clone the underlying datastore inner
-		let db = self.inner.clone();
+		let db = Arc::clone(&self.inner);
 		// Check if a background thread is already running
 		if db.garbage_collection_handle.read().is_none() {
 			// Get the specified interval

--- a/src/db.rs
+++ b/src/db.rs
@@ -233,16 +233,21 @@ impl Database {
 			if let Some(ref persistence) = self.persistence {
 				// Disable the persistence background workers
 				persistence.background_threads_enabled.store(false, Ordering::Release);
-				// Wait for persistence threads to exit
-				if let Some(handle) = persistence.fsync_handle.write().take() {
+				// Wait for persistence threads to exit. Each `take` is hoisted
+				// into its own statement so the write guard is released before
+				// the blocking `join`, instead of being held across it.
+				let fsync = persistence.fsync_handle.write().take();
+				if let Some(handle) = fsync {
 					handle.thread().unpark();
 					let _ = handle.join();
 				}
-				if let Some(handle) = persistence.snapshot_handle.write().take() {
+				let snapshot = persistence.snapshot_handle.write().take();
+				if let Some(handle) = snapshot {
 					handle.thread().unpark();
 					let _ = handle.join();
 				}
-				if let Some(handle) = persistence.appender_handle.write().take() {
+				let appender = persistence.appender_handle.write().take();
+				if let Some(handle) = appender {
 					handle.thread().unpark();
 					let _ = handle.join();
 				}
@@ -253,12 +258,14 @@ impl Database {
 		#[cfg(not(target_arch = "wasm32"))]
 		{
 			// Wait for the transaction cleanup thread to exit
-			if let Some(handle) = self.transaction_cleanup_handle.write().take() {
+			let cleanup = self.transaction_cleanup_handle.write().take();
+			if let Some(handle) = cleanup {
 				handle.thread().unpark();
 				let _ = handle.join();
 			}
 			// Wait for the garbage collector thread to exit
-			if let Some(handle) = self.garbage_collection_handle.write().take() {
+			let gc = self.garbage_collection_handle.write().take();
+			if let Some(handle) = gc {
 				handle.thread().unpark();
 				let _ = handle.join();
 			}
@@ -344,6 +351,10 @@ impl Database {
 }
 
 #[cfg(test)]
+#[allow(
+	clippy::significant_drop_tightening,
+	reason = "lock contention is irrelevant in single-threaded assertions"
+)]
 mod tests {
 
 	use super::*;

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -17,6 +17,8 @@
 /// The direction that the iterator should iterate
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Direction {
+	/// Iterate from the start of the range towards the end
 	Forward,
+	/// Iterate from the end of the range towards the start
 	Reverse,
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -86,6 +86,6 @@ pub enum PersistenceError {
 
 impl<T> From<PoisonError<std::sync::MutexGuard<'_, T>>> for PersistenceError {
 	fn from(error: PoisonError<std::sync::MutexGuard<'_, T>>) -> Self {
-		PersistenceError::LockFailed(error.to_string())
+		Self::LockFailed(error.to_string())
 	}
 }

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -56,9 +56,9 @@ pub(crate) const COMMIT_ABORTED: u64 = u64::MAX;
 /// transaction and is exclusively owned by it, so state transitions are
 /// plain stores — no CAS protocol is required.
 pub(crate) struct Slot {
-	/// The owner's snapshot merge version, or SLOT_PINNING
+	/// The owner's snapshot merge version, or `SLOT_PINNING`
 	pub(crate) version: AtomicU64,
-	/// The owner's snapshot commit id, or SLOT_PINNING
+	/// The owner's snapshot commit id, or `SLOT_PINNING`
 	pub(crate) commit: AtomicU64,
 }
 
@@ -218,7 +218,7 @@ impl Inner {
 	/// loaded BEFORE the fence-and-scan over the slots. This ordering is
 	/// load-bearing: a transaction missed by the scan pinned its slot
 	/// after the scan, so its subsequent commit-snapshot load is ordered
-	/// after our bound load in the SeqCst total order and (the watermark
+	/// after our bound load in the `SeqCst` total order and (the watermark
 	/// being monotonic) returns at least our bound — its conflict window
 	/// `snapshot + 1 ..` sits strictly above everything we trim. A
 	/// transaction seen by the scan bounds the trim directly, and a slot
@@ -566,7 +566,7 @@ impl Inner {
 	)]
 	pub(crate) fn run_gc_full(&self, cleanup_ts: u64) {
 		// Iterate over the entire datastore
-		for entry in self.datastore.iter() {
+		for entry in &self.datastore {
 			// Get a mutable reference to the versions list
 			let mut versions = entry.value().write();
 			// Clean up unnecessary older versions
@@ -594,7 +594,7 @@ impl Inner {
 /// holds [`SLOT_PINNING`] in that dimension.
 ///
 /// The fence pairs with the fence in the pin-then-read registration
-/// protocol: a transaction whose pin-fence precedes ours in the SeqCst
+/// protocol: a transaction whose pin-fence precedes ours in the `SeqCst`
 /// total order is visible to this scan (as a value or as the sentinel);
 /// a transaction whose pin-fence follows ours performs its snapshot
 /// loads after the caller's bound load, so its snapshot is at least the
@@ -610,7 +610,7 @@ pub(crate) fn earliest_pinned(
 ) -> Option<u64> {
 	fence(Ordering::SeqCst);
 	let mut min = fallback;
-	for entry in map.iter() {
+	for entry in map {
 		if Some(*entry.key()) == exclude {
 			continue;
 		}

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -499,6 +499,10 @@ impl Inner {
 	/// the trimmed chain still holds reclaimable versions (a reader
 	/// watermark is pinning them), the key is re-tracked for the next
 	/// sweep.
+	#[expect(
+		clippy::significant_drop_tightening,
+		reason = "the version write guard must cover entry.remove() so a committer blocked on it observes is_removed() and re-inserts"
+	)]
 	pub(crate) fn run_gc_tracked(&self, cleanup_ts: u64) {
 		// A single map guard serves the whole sweep: guard churn per
 		// candidate costs more than holding one across the pass, and the
@@ -523,7 +527,10 @@ impl Inner {
 			let Some(entry) = self.datastore.get(&key) else {
 				continue;
 			};
-			// Get a mutable reference to the versions list
+			// Get a mutable reference to the versions list. The write guard is
+			// deliberately held across `entry.remove()` below: a committer
+			// blocked on this lock must observe `is_removed()` and re-insert,
+			// rather than writing into a node we are about to unlink.
 			let mut versions = entry.value().write();
 			// A sweep or commit-time collapse unlinked this node between
 			// lookup and lock; any recreation re-tracks the key itself
@@ -553,6 +560,10 @@ impl Inner {
 	/// every key, it supersedes the candidate set: callers clear the set
 	/// before scanning (commits racing with the scan re-track their keys
 	/// as usual).
+	#[expect(
+		clippy::significant_drop_tightening,
+		reason = "the version write guard must cover entry.remove() so a committer blocked on it observes is_removed() and re-inserts"
+	)]
 	pub(crate) fn run_gc_full(&self, cleanup_ts: u64) {
 		// Iterate over the entire datastore
 		for entry in self.datastore.iter() {

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -335,9 +335,9 @@ impl Inner {
 			// past us, so reload and continue from the fresh bound. Back
 			// off on contention: a caller of this function (e.g. a
 			// cleanup sweep with no delay between iterations) can end up
-			// calling it far more often than intended, and an
-			// unconditional `continue` here would otherwise hammer this
-			// cache line against every other thread doing the same.
+			// calling it far more often than intended, and retrying here
+			// without a delay would otherwise hammer this cache line
+			// against every other thread doing the same.
 			if self
 				.transaction_commit_id
 				.compare_exchange_weak(cur, next, Ordering::SeqCst, Ordering::SeqCst)
@@ -345,7 +345,6 @@ impl Inner {
 			{
 				crate::tx::backoff(spins);
 				spins += 1;
-				continue;
 			}
 		}
 	}
@@ -380,7 +379,6 @@ impl Inner {
 			{
 				crate::tx::backoff(spins);
 				spins += 1;
-				continue;
 			}
 		}
 	}

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -64,7 +64,7 @@ pub(crate) struct Slot {
 
 impl Slot {
 	/// Create a new slot in the pinning state
-	pub(crate) fn pinning() -> Self {
+	pub(crate) const fn pinning() -> Self {
 		Self {
 			version: AtomicU64::new(SLOT_PINNING),
 			commit: AtomicU64::new(SLOT_PINNING),

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 
 /// Owned range bounds for the skip list range iterator.
 /// Using owned Bytes avoids lifetime coupling between range bounds
-/// and the MergeIterator, enabling persistent storage (e.g., in a Cursor).
+/// and the `MergeIterator`, enabling persistent storage (e.g., in a Cursor).
 pub(crate) type SkipBounds = (Bound<Bytes>, Bound<Bytes>);
 
 /// Lazy k-way merge iterator over committed merge-queue writesets.
@@ -40,7 +40,7 @@ pub(crate) type SkipBounds = (Bound<Bytes>, Bound<Bytes>);
 ///
 /// Holds an `Arc<Merge>` per source to keep the underlying `Arc<BTreeMap>`
 /// alive without storing any borrows from it; advancement re-seeks the
-/// BTreeMap each step (O(log n) per advance).
+/// `BTreeMap` each step (O(log n) per advance).
 pub(crate) struct MergeQueueIter {
 	sources: Vec<Arc<Merge>>,
 	heads: Vec<Option<(Bytes, Option<Bytes>)>>,
@@ -132,7 +132,7 @@ impl Iterator for MergeQueueIter {
 		let (out_key, out_val) = self.heads[winner].take().unwrap();
 		// Discard older duplicates at the same key, re-seeking past it.
 		for i in (winner + 1)..self.heads.len() {
-			let same = self.heads[i].as_ref().map(|(k, _)| k == &out_key).unwrap_or(false);
+			let same = self.heads[i].as_ref().is_some_and(|(k, _)| k == &out_key);
 			if same {
 				let new = seek_in_writeset(
 					&self.sources[i],
@@ -524,7 +524,7 @@ impl<'a> MergeIterator<'a> {
 	}
 }
 
-impl<'a> Iterator for MergeIterator<'a> {
+impl Iterator for MergeIterator<'_> {
 	type Item = (Bytes, Option<Bytes>);
 
 	fn next(&mut self) -> Option<Self::Item> {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -102,6 +102,18 @@ fn seek_in_writeset(
 	entry.map(|(k, v)| (k.clone(), v.clone()))
 }
 
+/// Panic message for the merge-queue head accessors.
+///
+/// `winner` is only ever assigned from an index whose head matched
+/// `Some((k, _))`, so re-reading that head cannot observe `None`.
+const WINNER_HEAD: &str = "winner index is only set for a Some head";
+
+/// Panic message for the three-way merge accessors below.
+///
+/// `next_source` is assigned only inside an `if let Some(..)` on the
+/// corresponding head, so the matching arm's head is always `Some`.
+const SELECTED_HEAD: &str = "next_source is only set when the matching head is Some";
+
 impl Iterator for MergeQueueIter {
 	type Item = (Bytes, Option<Bytes>);
 
@@ -117,7 +129,7 @@ impl Iterator for MergeQueueIter {
 			match winner {
 				None => winner = Some(i),
 				Some(wi) => {
-					let (wk, _) = self.heads[wi].as_ref().unwrap();
+					let (wk, _) = self.heads[wi].as_ref().expect(WINNER_HEAD);
 					let take = match self.direction {
 						Direction::Forward => k < wk,
 						Direction::Reverse => k > wk,
@@ -129,7 +141,7 @@ impl Iterator for MergeQueueIter {
 			}
 		}
 		let winner = winner?;
-		let (out_key, out_val) = self.heads[winner].take().unwrap();
+		let (out_key, out_val) = self.heads[winner].take().expect(WINNER_HEAD);
 		// Discard older duplicates at the same key, re-seeking past it.
 		for i in (winner + 1)..self.heads.len() {
 			let same = self.heads[i].as_ref().is_some_and(|(k, _)| k == &out_key);
@@ -277,7 +289,7 @@ impl<'a> MergeIterator<'a> {
 			// Process the selected source
 			let exists = match next_source {
 				KeySource::Transaction => {
-					let (sk, sv) = self.self_next.unwrap();
+					let (sk, sv) = self.self_next.expect(SELECTED_HEAD);
 					let exists = sv.is_some();
 
 					// Advance self iterator
@@ -304,7 +316,7 @@ impl<'a> MergeIterator<'a> {
 					exists
 				}
 				KeySource::Committed => {
-					let exists = self.join_next.as_ref().unwrap().1.is_some();
+					let exists = self.join_next.as_ref().expect(SELECTED_HEAD).1.is_some();
 
 					// Check if we need to skip same key in tree before advancing join
 					let should_skip_tree = if let Some(t_entry) = &self.tree_next {
@@ -331,7 +343,7 @@ impl<'a> MergeIterator<'a> {
 					exists
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
+					let t_entry = self.tree_next.as_ref().expect(SELECTED_HEAD);
 					let tv = match t_entry.value().try_read() {
 						Some(guard) => guard,
 						None => t_entry.value().read(),
@@ -405,7 +417,7 @@ impl<'a> MergeIterator<'a> {
 			// Process the selected source - first determine if entry exists
 			match next_source {
 				KeySource::Transaction => {
-					let (sk, sv) = self.self_next.unwrap();
+					let (sk, sv) = self.self_next.expect(SELECTED_HEAD);
 					let exists = sv.is_some();
 
 					// Store key reference for later cloning if needed
@@ -442,7 +454,7 @@ impl<'a> MergeIterator<'a> {
 					return Some((key_ref.clone(), exists));
 				}
 				KeySource::Committed => {
-					let (jk, jv) = self.join_next.as_ref().unwrap();
+					let (jk, jv) = self.join_next.as_ref().expect(SELECTED_HEAD);
 
 					// Check if we should skip (only skip existing entries)
 					if jv.is_some() && self.skip_remaining > 0 {
@@ -488,7 +500,7 @@ impl<'a> MergeIterator<'a> {
 					return Some((key, exists));
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
+					let t_entry = self.tree_next.as_ref().expect(SELECTED_HEAD);
 					let tv = match t_entry.value().try_read() {
 						Some(guard) => guard,
 						None => t_entry.value().read(),
@@ -571,7 +583,7 @@ impl Iterator for MergeIterator<'_> {
 			// Process the selected source
 			match next_source {
 				KeySource::Transaction => {
-					let (sk, sv) = self.self_next.unwrap();
+					let (sk, sv) = self.self_next.expect(SELECTED_HEAD);
 					let exists = sv.is_some();
 
 					// Store key reference for deferred cloning
@@ -608,7 +620,7 @@ impl Iterator for MergeIterator<'_> {
 					return Some((key_ref.clone(), sv.clone()));
 				}
 				KeySource::Committed => {
-					let (jk, jv) = self.join_next.as_ref().unwrap();
+					let (jk, jv) = self.join_next.as_ref().expect(SELECTED_HEAD);
 
 					// Check if we should skip (only skip existing entries)
 					if jv.is_some() && self.skip_remaining > 0 {
@@ -654,7 +666,7 @@ impl Iterator for MergeIterator<'_> {
 					return Some((key, value_opt));
 				}
 				KeySource::Datastore => {
-					let t_entry = self.tree_next.as_ref().unwrap();
+					let t_entry = self.tree_next.as_ref().expect(SELECTED_HEAD);
 					let tv = match t_entry.value().try_read() {
 						Some(guard) => guard,
 						None => t_entry.value().read(),

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -130,7 +130,7 @@ impl IntoBytes for Box<[u8]> {
 	}
 }
 
-impl<'a> IntoBytes for Cow<'a, [u8]> {
+impl IntoBytes for Cow<'_, [u8]> {
 	fn as_slice(&self) -> &[u8] {
 		// Get the bytes reference
 		self.as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! An embedded, in-memory, lock-free, transaction-based, key-value database
+//! engine.
+//!
+//! A [`Database`] holds versioned keys and hands out [`Transaction`] values
+//! from a pool. Transactions read a consistent snapshot and are committed
+//! under one of the [`IsolationLevel`] variants, with conflicting commits
+//! rejected rather than serialised. Reads and writes never block on a global
+//! lock: the datastore is a lock-free skip list, and version visibility is
+//! resolved against a logical clock.
+//!
+//! On non-wasm targets the engine can additionally be backed by persistence
+//! (an append-only log plus periodic snapshots); see [`PersistenceOptions`].
+
 /// Tracing target for transaction conflict diagnostics
 pub const LOG_TARGET_CONFLICTS: &str = "surrealmx::conflicts";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(clippy::bool_comparison)]
-
 /// Tracing target for transaction conflict diagnostics
 pub const LOG_TARGET_CONFLICTS: &str = "surrealmx::conflicts";
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -119,7 +119,7 @@ impl DatabaseOptions {
 	/// latency for minimal background CPU.
 	pub fn with_low_resource(mut self) -> Self {
 		self.pool_size /= 2;
-		self.gc_interval = Duration::from_secs(60);
+		self.gc_interval = Duration::from_mins(1);
 		self.cleanup_interval = Duration::from_millis(500);
 		self.reset_threshold /= 2;
 		self

--- a/src/options.rs
+++ b/src/options.rs
@@ -59,43 +59,43 @@ impl DatabaseOptions {
 	}
 
 	/// Set the maximum number of transactions kept in the pool.
-	pub fn with_pool_size(mut self, pool_size: usize) -> Self {
+	pub const fn with_pool_size(mut self, pool_size: usize) -> Self {
 		self.pool_size = pool_size;
 		self
 	}
 
 	/// Set whether the garbage collector thread is started automatically.
-	pub fn with_enable_gc(mut self, enable: bool) -> Self {
+	pub const fn with_enable_gc(mut self, enable: bool) -> Self {
 		self.enable_gc = enable;
 		self
 	}
 
 	/// Set the interval at which the garbage collector wakes up.
-	pub fn with_gc_interval(mut self, interval: Duration) -> Self {
+	pub const fn with_gc_interval(mut self, interval: Duration) -> Self {
 		self.gc_interval = interval;
 		self
 	}
 
 	/// Set whether the cleanup worker thread is started automatically.
-	pub fn with_enable_cleanup(mut self, enable: bool) -> Self {
+	pub const fn with_enable_cleanup(mut self, enable: bool) -> Self {
 		self.enable_cleanup = enable;
 		self
 	}
 
 	/// Set the interval at which the cleanup worker wakes up.
-	pub fn with_cleanup_interval(mut self, interval: Duration) -> Self {
+	pub const fn with_cleanup_interval(mut self, interval: Duration) -> Self {
 		self.cleanup_interval = interval;
 		self
 	}
 
 	/// Set the threshold after which transaction state maps are reset.
-	pub fn with_reset_threshold(mut self, threshold: usize) -> Self {
+	pub const fn with_reset_threshold(mut self, threshold: usize) -> Self {
 		self.reset_threshold = threshold;
 		self
 	}
 
 	/// Disable all background worker threads (gc and cleanup).
-	pub fn with_all_workers_disabled(mut self) -> Self {
+	pub const fn with_all_workers_disabled(mut self) -> Self {
 		self.enable_gc = false;
 		self.enable_cleanup = false;
 		self
@@ -106,7 +106,7 @@ impl DatabaseOptions {
 	/// throughput: more dropped transactions are kept for reuse, and
 	/// reader-pinned garbage waits longer for its tracked sweep —
 	/// steady-state reclamation happens inline at commit time either way.
-	pub fn with_high_performance(mut self) -> Self {
+	pub const fn with_high_performance(mut self) -> Self {
 		self.pool_size *= 2;
 		self.gc_interval = Duration::from_secs(30);
 		self.cleanup_interval = Duration::from_millis(100);
@@ -117,7 +117,7 @@ impl DatabaseOptions {
 	/// Configure for low-CPU scenarios (embedded / battery-powered)
 	/// with slower background workers. Trades memory and reclamation
 	/// latency for minimal background CPU.
-	pub fn with_low_resource(mut self) -> Self {
+	pub const fn with_low_resource(mut self) -> Self {
 		self.pool_size /= 2;
 		self.gc_interval = Duration::from_mins(1);
 		self.cleanup_interval = Duration::from_millis(500);
@@ -131,7 +131,7 @@ impl DatabaseOptions {
 	/// transactions are kept around for reuse. Since a sweep visits only
 	/// the tracked candidate keys, the extra ticks cost little CPU even
 	/// on large datasets.
-	pub fn with_reduced_memory(mut self) -> Self {
+	pub const fn with_reduced_memory(mut self) -> Self {
 		self.pool_size /= 2;
 		self.gc_interval = Duration::from_secs(5);
 		self.cleanup_interval = Duration::from_millis(100);

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -242,7 +242,9 @@ impl Persistence {
 			base_path.join("snapshot.bin")
 		};
 		// Initialize AOL components if enabled
-		let aol = if !matches!(options.aol_mode, AolMode::Never) {
+		let aol = if matches!(options.aol_mode, AolMode::Never) {
+			None
+		} else {
 			// Ensure parent directories exist for AOL path
 			if let Some(parent) = aol_path.parent() {
 				fs::create_dir_all(parent)?;
@@ -250,8 +252,6 @@ impl Persistence {
 			// Open the AOL file with append mode
 			let file = OpenOptions::new().create(true).append(true).read(true).open(&aol_path)?;
 			Some(Arc::new(Mutex::new(file)))
-		} else {
-			None
 		};
 		// Ensure parent directories exist for snapshot path
 		if let Some(parent) = snapshot_path.parent() {
@@ -314,7 +314,7 @@ impl Persistence {
 				0
 			};
 			// Stream write each key-value pair to reduce memory usage
-			for entry in self.inner.datastore.iter() {
+			for entry in &self.inner.datastore {
 				// Persist only the latest committed version of each key. Keys
 				// whose newest entry is a delete tombstone are omitted: on
 				// reload the key is simply absent, which is the same
@@ -706,7 +706,7 @@ impl Persistence {
 							0
 						};
 						// Stream write each entry to reduce memory usage
-						for entry in db.datastore.iter() {
+						for entry in &db.datastore {
 							// Persist only the latest committed version of
 							// each key, omitting keys whose newest entry is
 							// a delete tombstone. See `snapshot()` above.

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -321,7 +321,11 @@ impl Persistence {
 				// observable state. The encoded element type is unchanged, so
 				// snapshot files remain readable across releases in both
 				// directions.
-				if let Some((version, value)) = entry.value().read().latest() {
+				// `latest` returns owned values, so the per-key version read guard is
+				// released at the end of this statement rather than being held across
+				// the encode and write below.
+				let latest = entry.value().read().latest();
+				if let Some((version, value)) = latest {
 					// Serialize and write this single entry
 					bincode::serde::encode_into_std_write(
 						&(entry.key().clone(), vec![(version, Some(value))]),
@@ -538,6 +542,10 @@ impl Persistence {
 
 	/// Truncate the AOL file up to the specified position, preserving any data
 	/// after.
+	#[expect(
+		clippy::significant_drop_tightening,
+		reason = "the file guard must cover the pending_syncs store, or a concurrent append's increment is silently discarded along with its required fsync"
+	)]
 	fn truncate(
 		aol: &Option<Arc<Mutex<File>>>,
 		position: u64,
@@ -545,7 +553,8 @@ impl Persistence {
 	) -> Result<(), PersistenceError> {
 		// Check that we have a AOL file handle
 		if let Some(ref aol) = aol {
-			// Lock the AOL file
+			// Lock the AOL file. The mutex is deliberately held past its last
+			// file use so that it still covers the `pending_syncs` store below.
 			let mut file = aol.lock()?;
 			// Get the current file length
 			let file_len = file.metadata()?.len();
@@ -701,7 +710,11 @@ impl Persistence {
 							// Persist only the latest committed version of
 							// each key, omitting keys whose newest entry is
 							// a delete tombstone. See `snapshot()` above.
-							if let Some((version, value)) = entry.value().read().latest() {
+							// `latest` returns owned values, so the per-key version read guard is
+							// released at the end of this statement rather than being held across
+							// the encode and write below.
+							let latest = entry.value().read().latest();
+							if let Some((version, value)) = latest {
 								// Serialize and write this single entry
 								bincode::serde::encode_into_std_write(
 									&(entry.key().clone(), vec![(version, Some(value))]),
@@ -890,6 +903,10 @@ impl Persistence {
 	///
 	/// # Returns
 	/// * `Result<(), PersistenceError>` - Success or an error
+	#[expect(
+		clippy::significant_drop_tightening,
+		reason = "the file guard must cover the pending_syncs store, or a concurrent append's increment is silently discarded along with its required fsync"
+	)]
 	pub(crate) fn append(
 		&self,
 		version: u64,
@@ -914,7 +931,9 @@ impl Persistence {
 				}
 			}
 			if self.aol_mode == AolMode::SynchronousOnCommit {
-				// Lock the AOL file for writing
+				// Lock the AOL file for writing. The mutex is deliberately held
+				// past its last file use so that it still covers the
+				// `pending_syncs` store below.
 				let mut file = aol.lock()?;
 				// Create a new buffer for the AOL file
 				let mut writer = BufWriter::new(&mut *file);
@@ -983,18 +1002,23 @@ impl Drop for Persistence {
 	fn drop(&mut self) {
 		// Signal shutdown to the worker threads
 		self.background_threads_enabled.store(false, Ordering::Release);
-		// Stop the fsync worker if it exists
-		if let Some(handle) = self.fsync_handle.write().take() {
+		// Stop the fsync worker if it exists. The `take` is hoisted into its
+		// own statement so the write guard is released before the blocking
+		// `join`, instead of being held across it.
+		let fsync = self.fsync_handle.write().take();
+		if let Some(handle) = fsync {
 			handle.thread().unpark();
 			let _ = handle.join();
 		}
 		// Stop the snapshot worker if it exists
-		if let Some(handle) = self.snapshot_handle.write().take() {
+		let snapshot = self.snapshot_handle.write().take();
+		if let Some(handle) = snapshot {
 			handle.thread().unpark();
 			let _ = handle.join();
 		}
 		// Stop the async append worker if it exists
-		if let Some(handle) = self.appender_handle.write().take() {
+		let appender = self.appender_handle.write().take();
+		if let Some(handle) = appender {
 			handle.thread().unpark();
 			let _ = handle.join();
 		}

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -346,7 +346,7 @@ impl Persistence {
 				final_file.sync_all()?;
 			}
 			// Truncate AOL only up to the cutoff position
-			Self::truncate(&self.aol, aol_cutoff_position, &self.pending_syncs)?;
+			Self::truncate(self.aol.as_ref(), aol_cutoff_position, &self.pending_syncs)?;
 			// All ok
 			Ok(())
 		})();
@@ -365,6 +365,9 @@ impl Persistence {
 	/// 1. Loads the latest snapshot if it exists
 	/// 2. Applies any changes from the append-only log
 	fn load(&self) -> Result<(), PersistenceError> {
+		// Decoded record shapes, one per file format
+		type SnapshotEntry = (Bytes, Vec<(u64, Option<Bytes>)>);
+		type AolEntry = (Bytes, u64, Option<Bytes>);
 		// Track the maximum version seen across EVERY decoded record —
 		// snapshot entries (including keys skipped as tombstone-topped)
 		// and every append-only log record (including deletes). The
@@ -393,10 +396,8 @@ impl Persistence {
 					count += 1;
 					// Trace the loading of the snapshot entry
 					tracing::trace!("Loading snapshot entry: {count}");
-					// Type alias for the entry
-					type Entry = (Bytes, Vec<(u64, Option<Bytes>)>);
 					// Attempt to decode the next entry, handling EOF gracefully
-					let result: Result<Entry, _> =
+					let result: Result<SnapshotEntry, _> =
 						bincode::serde::decode_from_std_read(&mut reader, config::standard());
 					// Detech any end of file errors
 					match result {
@@ -459,10 +460,8 @@ impl Persistence {
 					count += 1;
 					// Trace the loading of the append-only entry
 					tracing::trace!("Loading AOL entry: {count}");
-					// Type alias for the entry
-					type Entry = (Bytes, u64, Option<Bytes>);
 					// Explicitly type the result to help type inference
-					let result: Result<Entry, _> =
+					let result: Result<AolEntry, _> =
 						bincode::serde::decode_from_std_read(&mut reader, config::standard());
 					// Detech any end of file errors
 					match result {
@@ -547,12 +546,12 @@ impl Persistence {
 		reason = "the file guard must cover the pending_syncs store, or a concurrent append's increment is silently discarded along with its required fsync"
 	)]
 	fn truncate(
-		aol: &Option<Arc<Mutex<File>>>,
+		aol: Option<&Arc<Mutex<File>>>,
 		position: u64,
 		pending_syncs: &Arc<AtomicU64>,
 	) -> Result<(), PersistenceError> {
 		// Check that we have a AOL file handle
-		if let Some(ref aol) = aol {
+		if let Some(aol) = aol {
 			// Lock the AOL file. The mutex is deliberately held past its last
 			// file use so that it still covers the `pending_syncs` store below.
 			let mut file = aol.lock()?;
@@ -735,7 +734,7 @@ impl Persistence {
 							final_file.sync_all()?;
 						}
 						// Truncate AOL to the cutoff position
-						Self::truncate(&aol, aol_cutoff_position, &pending_syncs)?;
+						Self::truncate(aol.as_ref(), aol_cutoff_position, &pending_syncs)?;
 						// All ok
 						Ok(())
 					})();
@@ -795,7 +794,6 @@ impl Persistence {
 							match injector.steal() {
 								Steal::Retry => {
 									std::thread::yield_now();
-									continue;
 								}
 								Steal::Success(op) => {
 									batch.push(op);

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -127,19 +127,19 @@ impl PersistenceOptions {
 	}
 
 	/// Set the AOL (append-only log) behavior mode
-	pub fn with_aol_mode(mut self, mode: AolMode) -> Self {
+	pub const fn with_aol_mode(mut self, mode: AolMode) -> Self {
 		self.aol_mode = mode;
 		self
 	}
 
 	/// Set the snapshot behavior mode
-	pub fn with_snapshot_mode(mut self, mode: SnapshotMode) -> Self {
+	pub const fn with_snapshot_mode(mut self, mode: SnapshotMode) -> Self {
 		self.snapshot_mode = mode;
 		self
 	}
 
 	/// Set the fsync mode
-	pub fn with_fsync_mode(mut self, mode: FsyncMode) -> Self {
+	pub const fn with_fsync_mode(mut self, mode: FsyncMode) -> Self {
 		self.fsync_mode = mode;
 		self
 	}
@@ -157,7 +157,7 @@ impl PersistenceOptions {
 	}
 
 	/// Set the compression mode for snapshots
-	pub fn with_compression(mut self, mode: CompressionMode) -> Self {
+	pub const fn with_compression(mut self, mode: CompressionMode) -> Self {
 		self.compression_mode = mode;
 		self
 	}
@@ -623,9 +623,9 @@ impl Persistence {
 			// Check if a background thread is already running
 			if self.fsync_handle.read().is_none() {
 				// Clone necessary fields for the worker thread
-				let aol = aol.clone();
-				let pending_syncs = self.pending_syncs.clone();
-				let enabled = self.background_threads_enabled.clone();
+				let aol = Arc::clone(aol);
+				let pending_syncs = Arc::clone(&self.pending_syncs);
+				let enabled = Arc::clone(&self.background_threads_enabled);
 				// Spawn the background worker thread
 				let handle = thread::spawn(move || {
 					// Check whether the persistence process is enabled
@@ -673,11 +673,11 @@ impl Persistence {
 		// Check if a background thread is already running
 		if self.snapshot_handle.read().is_none() {
 			// Clone necessary fields for the worker thread
-			let db = self.inner.clone();
+			let db = Arc::clone(&self.inner);
 			let aol = self.aol.clone();
 			let snapshot_path = self.snapshot_path.clone();
-			let pending_syncs = self.pending_syncs.clone();
-			let enabled = self.background_threads_enabled.clone();
+			let pending_syncs = Arc::clone(&self.pending_syncs);
+			let enabled = Arc::clone(&self.background_threads_enabled);
 			let compression = self.compression_mode;
 			// Spawn the background worker thread
 			let handle = thread::spawn(move || {
@@ -764,12 +764,12 @@ impl Persistence {
 			// Check if a background thread is already running
 			if self.appender_handle.read().is_none() {
 				// Clone necessary fields for the worker thread
-				let injector = self.async_append_injector.clone();
-				let aol = aol.clone();
+				let injector = Arc::clone(&self.async_append_injector);
+				let aol = Arc::clone(aol);
 				let fsync_mode = self.fsync_mode;
-				let enabled = self.background_threads_enabled.clone();
-				let pending_syncs = self.pending_syncs.clone();
-				let last_fsync = self.last_fsync.clone();
+				let enabled = Arc::clone(&self.background_threads_enabled);
+				let pending_syncs = Arc::clone(&self.pending_syncs);
+				let last_fsync = Arc::clone(&self.last_fsync);
 				// Spawn the background worker thread
 				let handle = thread::spawn(move || {
 					// Set the batch size and timeout

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -52,7 +52,7 @@ impl Pool {
 			tx.reset(write);
 			tx
 		} else {
-			TransactionInner::new(self.inner.clone(), write)
+			TransactionInner::new(Arc::clone(&self.inner), write)
 		};
 		// Return a new enclosing transaction
 		Transaction {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -15,12 +15,14 @@
 //! This module stores the transaction commit and merge queues.
 
 use crate::bloom::BloomFilter;
+#[cfg(debug_assertions)]
 use crate::LOG_TARGET_CONFLICTS;
 use bytes::Bytes;
 use papaya::HashSet;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
+#[cfg(debug_assertions)]
 use tracing::debug;
 
 /// A transaction entry in the transaction commit queue

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -111,7 +111,7 @@ impl Commit {
 			// Choose iteration direction based on size to minimize iterations
 			if other.len() < self.keys.len() {
 				// Check if any key in readset exists in the writeset
-				for key in other.iter() {
+				for key in &other {
 					if self.contains_key(key) {
 						// Log the error for debug purposes
 						#[cfg(debug_assertions)]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -138,7 +138,7 @@ impl Commit {
 	/// Returns true if self has no elements in common with other.
 	/// Uses bloom filters and key bounds for fast pre-checks before the
 	/// exact sorted merge.
-	pub fn is_disjoint_writeset_bloom(&self, other: &Arc<Commit>) -> bool {
+	pub fn is_disjoint_writeset_bloom(&self, other: &Arc<Self>) -> bool {
 		// Fast path: check if the key ranges overlap at all
 		match (self.min_key(), self.max_key(), other.min_key(), other.max_key()) {
 			(Some(self_min), Some(self_max), Some(other_min), Some(other_max)) => {
@@ -178,7 +178,7 @@ impl Commit {
 	}
 
 	/// Returns true if self has no elements in common with other
-	pub fn is_disjoint_writeset(&self, other: &Arc<Commit>) -> bool {
+	pub fn is_disjoint_writeset(&self, other: &Arc<Self>) -> bool {
 		// Create a key iterator for each writeset
 		let mut a = self.keys.iter();
 		let mut b = other.keys.iter();

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -60,7 +60,7 @@ pub struct Transaction {
 // Transaction must be Send + Sync so downstream callers can place it
 // behind shared locks like `tokio::sync::RwLock<Transaction>`.
 const _: fn() = || {
-	fn assert_send_sync<T: Send + Sync>() {}
+	const fn assert_send_sync<T: Send + Sync>() {}
 	assert_send_sync::<Transaction>();
 };
 
@@ -81,14 +81,14 @@ impl Drop for Transaction {
 
 impl Transaction {
 	/// Ensure this transaction is committed with snapshot isolation guarantees
-	pub fn with_snapshot_isolation(mut self) -> Self {
+	pub const fn with_snapshot_isolation(mut self) -> Self {
 		self.inner.as_mut().unwrap().mode = IsolationLevel::SnapshotIsolation;
 		self
 	}
 
 	/// Ensure this transaction is committed with serializable snapshot
 	/// isolation guarantees
-	pub fn with_serializable_snapshot_isolation(mut self) -> Self {
+	pub const fn with_serializable_snapshot_isolation(mut self) -> Self {
 		self.inner.as_mut().unwrap().mode = IsolationLevel::SerializableSnapshotIsolation;
 		self
 	}
@@ -109,12 +109,12 @@ impl Transaction {
 	}
 
 	/// Get the starting sequence number of this transaction
-	pub fn version(&self) -> u64 {
+	pub const fn version(&self) -> u64 {
 		self.inner.as_ref().unwrap().version()
 	}
 
 	/// Check if the transaction is closed
-	pub fn closed(&self) -> bool {
+	pub const fn closed(&self) -> bool {
 		self.inner.as_ref().unwrap().closed()
 	}
 
@@ -488,7 +488,7 @@ fn pin_slot(db: &Inner, slot: &Arc<Slot>) -> (u64, u64, u64) {
 	slot.commit.store(SLOT_PINNING, Ordering::SeqCst);
 	// Insert the slot into the readers map under a fresh id
 	let slot_id = db.reader_slot_id.fetch_add(1, Ordering::Relaxed) + 1;
-	db.readers.insert(slot_id, slot.clone());
+	db.readers.insert(slot_id, Arc::clone(slot));
 	// Pair with the fence in every watermark scan
 	fence(Ordering::SeqCst);
 	// Load the commit snapshot, then the version snapshot
@@ -565,12 +565,12 @@ impl TransactionInner {
 	}
 
 	/// Get the starting sequence number of this transaction
-	pub fn version(&self) -> u64 {
+	pub const fn version(&self) -> u64 {
 		self.version
 	}
 
 	/// Check if the transaction is closed
-	pub fn closed(&self) -> bool {
+	pub const fn closed(&self) -> bool {
 		self.done
 	}
 
@@ -718,8 +718,8 @@ impl TransactionInner {
 		let mut commit_guard = OnUnwind {
 			armed: true,
 			action: {
-				let database = self.database.clone();
-				let entry = commit_entry.clone();
+				let database = Arc::clone(&self.database);
+				let entry = Arc::clone(&commit_entry);
 				move || {
 					entry.merge_version.store(COMMIT_ABORTED, Ordering::SeqCst);
 					database.advance_commit_watermark();
@@ -856,8 +856,8 @@ impl TransactionInner {
 		let mut merge_guard = OnUnwind {
 			armed: true,
 			action: {
-				let database = self.database.clone();
-				let entry = entry.clone();
+				let database = Arc::clone(&self.database);
+				let entry = Arc::clone(&entry);
 				move || {
 					entry.applied.store(true, Ordering::SeqCst);
 					database.advance_merge_retirement();
@@ -1756,7 +1756,7 @@ impl TransactionInner {
 			.transaction_merge_queue
 			.range(..=version)
 			.rev()
-			.map(|e| e.value().clone())
+			.map(|e| Arc::clone(e.value()))
 			.collect()
 	}
 
@@ -2272,7 +2272,7 @@ impl TransactionInner {
 			// bound already having reached our slot as success.
 			let cur = self.database.transaction_commit_id.load(Ordering::SeqCst);
 			if cur >= slot {
-				return (slot, entry.value().clone());
+				return (slot, Arc::clone(entry.value()));
 			}
 			if cur == slot - 1
 				&& self
@@ -2281,7 +2281,7 @@ impl TransactionInner {
 					.compare_exchange_weak(cur, slot, Ordering::SeqCst, Ordering::Acquire)
 					.is_ok()
 			{
-				return (slot, entry.value().clone());
+				return (slot, Arc::clone(entry.value()));
 			}
 			// Ensure the thread backs off when under contention
 			backoff(spins);
@@ -2298,7 +2298,7 @@ impl TransactionInner {
 		// Store the commit in an Arc
 		let updates = Arc::new(updates);
 		// Get the database logical clock
-		let oracle = self.database.oracle.clone();
+		let oracle = Arc::clone(&self.database.oracle);
 		// Get the database transaction merge queue
 		let queue = &self.database.transaction_merge_queue;
 		// Claim a unique merge version from the allocation counter. See
@@ -2315,7 +2315,7 @@ impl TransactionInner {
 		loop {
 			let cur = oracle.timestamp.load(Ordering::SeqCst);
 			if cur >= version {
-				return (version, entry.value().clone());
+				return (version, Arc::clone(entry.value()));
 			}
 			if cur == version - 1
 				&& oracle
@@ -2323,7 +2323,7 @@ impl TransactionInner {
 					.compare_exchange_weak(cur, version, Ordering::SeqCst, Ordering::Acquire)
 					.is_ok()
 			{
-				return (version, entry.value().clone());
+				return (version, Arc::clone(entry.value()));
 			}
 			// Ensure the thread backs off when under contention
 			backoff(spins);
@@ -4668,9 +4668,9 @@ mod tests {
 			Arc::new(std::sync::Mutex::new(std::collections::BTreeSet::new()));
 		let mut handles = Vec::new();
 		for tid in 0..THREADS {
-			let db = db.clone();
-			let barrier = barrier.clone();
-			let written = written.clone();
+			let db = Arc::clone(&db);
+			let barrier = Arc::clone(&barrier);
+			let written = Arc::clone(&written);
 			handles.push(thread::spawn(move || {
 				barrier.wait();
 				for i in 0..PER_THREAD {

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -576,7 +576,7 @@ impl TransactionInner {
 	/// Cancel the transaction and rollback any changes
 	pub fn cancel(&mut self) -> Result<(), Error> {
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Mark this transaction as done
@@ -598,11 +598,11 @@ impl TransactionInner {
 	/// This method is stackable and can be called multiple times
 	pub fn set_savepoint(&mut self) -> Result<(), Error> {
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check to see if transaction is writable
-		if self.write == false {
+		if !self.write {
 			return Err(Error::TxNotWritable);
 		}
 		// Create a new readset for the savepoint
@@ -638,11 +638,11 @@ impl TransactionInner {
 	/// Pops the latest savepoint from the stack and restores transaction state
 	pub fn rollback_to_savepoint(&mut self) -> Result<(), Error> {
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check to see if transaction is writable
-		if self.write == false {
+		if !self.write {
 			return Err(Error::TxNotWritable);
 		}
 		// Pop the most recent savepoint from the stack
@@ -672,7 +672,7 @@ impl TransactionInner {
 	/// Commit the transaction and store all changes
 	pub fn commit(&mut self) -> Result<(), Error> {
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Mark this transaction as done
@@ -1015,7 +1015,7 @@ impl TransactionInner {
 		// Get the key reference
 		let lookup = key.as_slice();
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check the transaction type
@@ -1052,7 +1052,7 @@ impl TransactionInner {
 		// Get the key reference
 		let lookup = key.as_slice();
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check the transaction type
@@ -1090,7 +1090,7 @@ impl TransactionInner {
 		K: IntoBytes,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Prepare result vector with the same capacity
@@ -1146,11 +1146,11 @@ impl TransactionInner {
 		V: IntoBytes,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check to see if transaction is writable
-		if self.write == false {
+		if !self.write {
 			return Err(Error::TxNotWritable);
 		}
 		// Set the key
@@ -1168,11 +1168,11 @@ impl TransactionInner {
 		// Get the key reference
 		let lookup = key.as_slice();
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check to see if transaction is writable
-		if self.write == false {
+		if !self.write {
 			return Err(Error::TxNotWritable);
 		}
 		// Set the key
@@ -1201,11 +1201,11 @@ impl TransactionInner {
 		// Get the key reference
 		let lookup = key.as_slice();
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check to see if transaction is writable
-		if self.write == false {
+		if !self.write {
 			return Err(Error::TxNotWritable);
 		}
 		// Set the key
@@ -1240,11 +1240,11 @@ impl TransactionInner {
 		K: IntoBytes,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check to see if transaction is writable
-		if self.write == false {
+		if !self.write {
 			return Err(Error::TxNotWritable);
 		}
 		// Remove the key
@@ -1262,11 +1262,11 @@ impl TransactionInner {
 		// Get the key reference
 		let lookup = key.as_slice();
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Check to see if transaction is writable
-		if self.write == false {
+		if !self.write {
 			return Err(Error::TxNotWritable);
 		}
 		// Remove the key
@@ -1373,7 +1373,7 @@ impl TransactionInner {
 		F: FnMut(&Bytes, &Bytes) -> bool,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Initialise the entry counter
@@ -1472,7 +1472,7 @@ impl TransactionInner {
 		F: FnMut(&Bytes) -> bool,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Initialise the entry counter
@@ -1571,7 +1571,7 @@ impl TransactionInner {
 		// Clear the output buffer, reusing its capacity
 		buf.clear();
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Compute the range
@@ -1662,7 +1662,7 @@ impl TransactionInner {
 		// Clear the output buffer, reusing its capacity
 		buf.clear();
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Compute the range
@@ -1786,7 +1786,7 @@ impl TransactionInner {
 		K: IntoBytes,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Prepare result count
@@ -1888,7 +1888,7 @@ impl TransactionInner {
 		K: IntoBytes,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Prepare result vector
@@ -1992,7 +1992,7 @@ impl TransactionInner {
 		K: IntoBytes,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Prepare result vector
@@ -2095,7 +2095,7 @@ impl TransactionInner {
 		K: IntoBytes,
 	{
 		// Check to see if transaction is closed
-		if self.done == true {
+		if self.done {
 			return Err(Error::TxClosed);
 		}
 		// Compute the range

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -956,9 +956,13 @@ impl TransactionInner {
 				candidates.insert(key);
 			}
 		}
-		// Append the transaction to the persistence layer
+		// Append the transaction to the persistence layer. Clone the `Arc` out
+		// first so the `persistence` read guard is not held across `append`,
+		// which performs file I/O and may fsync.
 		#[cfg(not(target_arch = "wasm32"))]
-		if let Some(p) = self.database.persistence.read().clone() {
+		let persistence = self.database.persistence.read().clone();
+		#[cfg(not(target_arch = "wasm32"))]
+		if let Some(p) = persistence {
 			if let Err(e) = p.append(version, entry.writeset.as_ref()) {
 				// Do NOT remove the entry here: the merge clock's
 				// insertion-order advance is opportunistic (see
@@ -2386,6 +2390,10 @@ impl<F: FnMut()> Drop for OnUnwind<F> {
 }
 
 #[cfg(test)]
+#[allow(
+	clippy::significant_drop_tightening,
+	reason = "lock contention is irrelevant in single-threaded assertions"
+)]
 mod tests {
 
 	use crate::err::Error;

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -57,6 +57,14 @@ pub struct Transaction {
 	pub(crate) inner: Option<TransactionInner>,
 }
 
+/// Panic message for the `Transaction::inner` accessors below.
+///
+/// `inner` is only an `Option` so that `Drop` can move the inner transaction
+/// out and return it to the pool. It is `Some` for the entire lifetime of a
+/// `Transaction`, and the only `take` is in `Drop`, so no method on a live
+/// `Transaction` can observe `None`.
+const INNER_TAKEN: &str = "Transaction::inner is only taken in Drop";
+
 // Transaction must be Send + Sync so downstream callers can place it
 // behind shared locks like `tokio::sync::RwLock<Transaction>`.
 const _: fn() = || {
@@ -82,14 +90,15 @@ impl Drop for Transaction {
 impl Transaction {
 	/// Ensure this transaction is committed with snapshot isolation guarantees
 	pub const fn with_snapshot_isolation(mut self) -> Self {
-		self.inner.as_mut().unwrap().mode = IsolationLevel::SnapshotIsolation;
+		self.inner.as_mut().expect(INNER_TAKEN).mode = IsolationLevel::SnapshotIsolation;
 		self
 	}
 
 	/// Ensure this transaction is committed with serializable snapshot
 	/// isolation guarantees
 	pub const fn with_serializable_snapshot_isolation(mut self) -> Self {
-		self.inner.as_mut().unwrap().mode = IsolationLevel::SerializableSnapshotIsolation;
+		self.inner.as_mut().expect(INNER_TAKEN).mode =
+			IsolationLevel::SerializableSnapshotIsolation;
 		self
 	}
 
@@ -97,7 +106,7 @@ impl Transaction {
 	/// This method is stackable and can be called multiple times with
 	/// corresponding calls to `rollback_to_savepoint`
 	pub fn set_savepoint(&mut self) -> Result<(), Error> {
-		self.inner.as_mut().unwrap().set_savepoint()
+		self.inner.as_mut().expect(INNER_TAKEN).set_savepoint()
 	}
 
 	/// Rollback the transaction to the most recently set savepoint
@@ -105,27 +114,27 @@ impl Transaction {
 	/// transaction can be rolled back by calling `rollback_to_savepoint`
 	/// again if there are more savepoints in the stack
 	pub fn rollback_to_savepoint(&mut self) -> Result<(), Error> {
-		self.inner.as_mut().unwrap().rollback_to_savepoint()
+		self.inner.as_mut().expect(INNER_TAKEN).rollback_to_savepoint()
 	}
 
 	/// Get the starting sequence number of this transaction
 	pub const fn version(&self) -> u64 {
-		self.inner.as_ref().unwrap().version()
+		self.inner.as_ref().expect(INNER_TAKEN).version()
 	}
 
 	/// Check if the transaction is closed
 	pub const fn closed(&self) -> bool {
-		self.inner.as_ref().unwrap().closed()
+		self.inner.as_ref().expect(INNER_TAKEN).closed()
 	}
 
 	/// Cancel the transaction and rollback any changes
 	pub fn cancel(&mut self) -> Result<(), Error> {
-		self.inner.as_mut().unwrap().cancel()
+		self.inner.as_mut().expect(INNER_TAKEN).cancel()
 	}
 
 	/// Commit the transaction and store all changes
 	pub fn commit(&mut self) -> Result<(), Error> {
-		self.inner.as_mut().unwrap().commit()
+		self.inner.as_mut().expect(INNER_TAKEN).commit()
 	}
 
 	/// Check if a key exists in the database
@@ -133,7 +142,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().exists(key)
+		self.inner.as_ref().expect(INNER_TAKEN).exists(key)
 	}
 
 	/// Fetch a key from the database
@@ -141,7 +150,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().get(key)
+		self.inner.as_ref().expect(INNER_TAKEN).get(key)
 	}
 
 	/// Fetch multiple keys from the database
@@ -149,7 +158,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().getm(keys)
+		self.inner.as_ref().expect(INNER_TAKEN).getm(keys)
 	}
 
 	/// Insert or update a key in the database
@@ -158,7 +167,7 @@ impl Transaction {
 		K: IntoBytes,
 		V: IntoBytes,
 	{
-		self.inner.as_mut().unwrap().set(key, val)
+		self.inner.as_mut().expect(INNER_TAKEN).set(key, val)
 	}
 
 	/// Insert a key if it doesn't exist in the database
@@ -167,7 +176,7 @@ impl Transaction {
 		K: IntoBytes,
 		V: IntoBytes,
 	{
-		self.inner.as_mut().unwrap().put(key, val)
+		self.inner.as_mut().expect(INNER_TAKEN).put(key, val)
 	}
 
 	/// Insert a key if it matches a value
@@ -177,7 +186,7 @@ impl Transaction {
 		V: IntoBytes,
 		C: IntoBytes,
 	{
-		self.inner.as_mut().unwrap().putc(key, val, chk)
+		self.inner.as_mut().expect(INNER_TAKEN).putc(key, val, chk)
 	}
 
 	/// Delete a key from the database
@@ -185,7 +194,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_mut().unwrap().del(key)
+		self.inner.as_mut().expect(INNER_TAKEN).del(key)
 	}
 
 	/// Delete a key if it matches a value
@@ -194,7 +203,7 @@ impl Transaction {
 		K: IntoBytes,
 		C: IntoBytes,
 	{
-		self.inner.as_mut().unwrap().delc(key, chk)
+		self.inner.as_mut().expect(INNER_TAKEN).delc(key, chk)
 	}
 
 	/// Retrieve a count of keys from the database
@@ -207,7 +216,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().total(rng, skip, limit)
+		self.inner.as_ref().expect(INNER_TAKEN).total(rng, skip, limit)
 	}
 
 	/// Retrieve a range of keys from the database
@@ -220,7 +229,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().keys(rng, skip, limit)
+		self.inner.as_ref().expect(INNER_TAKEN).keys(rng, skip, limit)
 	}
 
 	/// Retrieve a range of keys from the database, in reverse order
@@ -233,7 +242,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().keys_reverse(rng, skip, limit)
+		self.inner.as_ref().expect(INNER_TAKEN).keys_reverse(rng, skip, limit)
 	}
 
 	/// Retrieve a range of keys and values from the database
@@ -246,7 +255,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().scan(rng, skip, limit)
+		self.inner.as_ref().expect(INNER_TAKEN).scan(rng, skip, limit)
 	}
 
 	/// Retrieve a range of keys and values from the database in reverse order
@@ -259,7 +268,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().scan_reverse(rng, skip, limit)
+		self.inner.as_ref().expect(INNER_TAKEN).scan_reverse(rng, skip, limit)
 	}
 
 	// --------------------------------------------------
@@ -279,7 +288,7 @@ impl Transaction {
 		K: IntoBytes,
 		F: FnMut(&Bytes, &Bytes) -> bool,
 	{
-		self.inner.as_ref().unwrap().scan_for_each(rng, skip, limit, f)
+		self.inner.as_ref().expect(INNER_TAKEN).scan_for_each(rng, skip, limit, f)
 	}
 
 	/// Call a closure for each key in a range, avoiding intermediate Vec
@@ -295,7 +304,7 @@ impl Transaction {
 		K: IntoBytes,
 		F: FnMut(&Bytes) -> bool,
 	{
-		self.inner.as_ref().unwrap().keys_for_each(rng, skip, limit, f)
+		self.inner.as_ref().expect(INNER_TAKEN).keys_for_each(rng, skip, limit, f)
 	}
 
 	/// Scan key-value pairs into a caller-provided Vec, reusing its capacity.
@@ -309,7 +318,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().scan_into(rng, skip, limit, buf)
+		self.inner.as_ref().expect(INNER_TAKEN).scan_into(rng, skip, limit, buf)
 	}
 
 	/// Scan keys into a caller-provided Vec, reusing its capacity.
@@ -323,7 +332,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().keys_into(rng, skip, limit, buf)
+		self.inner.as_ref().expect(INNER_TAKEN).keys_into(rng, skip, limit, buf)
 	}
 
 	// --------------------------------------------------
@@ -350,7 +359,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().cursor(rng)
+		self.inner.as_ref().expect(INNER_TAKEN).cursor(rng)
 	}
 
 	/// Iterate over keys in a range.
@@ -369,7 +378,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().keys_iter(rng)
+		self.inner.as_ref().expect(INNER_TAKEN).keys_iter(rng)
 	}
 
 	/// Iterate over keys in a range, in reverse order.
@@ -377,7 +386,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().keys_iter_reverse(rng)
+		self.inner.as_ref().expect(INNER_TAKEN).keys_iter_reverse(rng)
 	}
 
 	/// Iterate over key-value pairs in a range.
@@ -396,7 +405,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().scan_iter(rng)
+		self.inner.as_ref().expect(INNER_TAKEN).scan_iter(rng)
 	}
 
 	/// Iterate over key-value pairs in a range, in reverse order.
@@ -404,7 +413,7 @@ impl Transaction {
 	where
 		K: IntoBytes,
 	{
-		self.inner.as_ref().unwrap().scan_iter_reverse(rng)
+		self.inner.as_ref().expect(INNER_TAKEN).scan_iter_reverse(rng)
 	}
 }
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -465,7 +465,7 @@ pub(crate) struct TransactionInner {
 /// after our insert either sees the pinning sentinel (and skips
 /// reclamation for that pass) or sees our final snapshot values (and is
 /// bounded by them). A scan computed before our insert loaded its
-/// bounds before our snapshot loads in the SeqCst total order, so our
+/// bounds before our snapshot loads in the `SeqCst` total order, so our
 /// snapshot is at or above every bound it used — and reclamation always
 /// retains the entry visible at its watermark. This closes the historic
 /// load-then-register race structurally, with no validate/rollback
@@ -547,10 +547,11 @@ impl TransactionInner {
 		// Clear the readset bloom filter
 		self.readset_bloom.lock().clear();
 		// Clear or completely reset the allocated writeset
-		match self.writeset.len() > threshold {
-			true => self.writeset = BTreeMap::new(),
-			false => self.writeset.clear(),
-		};
+		if self.writeset.len() > threshold {
+			self.writeset = BTreeMap::new()
+		} else {
+			self.writeset.clear()
+		}
 		// Clear or completely reset the allocated savepoints
 		if self.savepoint_stack.len() > threshold {
 			self.savepoint_stack = Vec::new();
@@ -612,14 +613,14 @@ impl TransactionInner {
 			// Pin the readset for access
 			let pin = readset.pin();
 			// Clone the readset for the savepoint
-			for key in self.readset.pin().iter() {
+			for key in &self.readset.pin() {
 				pin.insert(key.clone());
 			}
 		};
 		// Create a new scanset for the savepoint
 		let scanset = SkipMap::new();
 		// Clone the scanset for the savepoint
-		for entry in self.scanset.iter() {
+		for entry in &self.scanset {
 			// Load the Arc from ArcSwap and clone it for the new savepoint
 			let value = Arc::clone(&entry.value().load());
 			scanset.insert(entry.key().clone(), ArcSwap::new(value));
@@ -652,13 +653,13 @@ impl TransactionInner {
 		// Clear the readset
 		readset.clear();
 		// Clone the readset from the savepoint
-		for key in savepoint.readset.pin().iter() {
+		for key in &savepoint.readset.pin() {
 			readset.insert(key.clone());
 		}
 		// Restore the scanset to the savepoint
 		self.scanset.clear();
 		// Clone the scanset from the savepoint
-		for entry in savepoint.scanset.iter() {
+		for entry in &savepoint.scanset {
 			// Load the Arc from ArcSwap and clone it for the restored scanset
 			let value = Arc::clone(&entry.value().load());
 			self.scanset.insert(entry.key().clone(), ArcSwap::new(value));
@@ -1023,9 +1024,8 @@ impl TransactionInner {
 			return Err(Error::TxClosed);
 		}
 		// Check the transaction type
-		let res = match self.write {
-			// This is a writeable transaction
-			true => match self.writeset.get(lookup) {
+		let res = if self.write {
+			match self.writeset.get(lookup) {
 				// The key exists in the writeset
 				Some(_) => true,
 				// Check for the key in the tree
@@ -1040,9 +1040,9 @@ impl TransactionInner {
 					// Return the result
 					res
 				}
-			},
-			// This is a readonly transaction
-			false => self.exists_in_datastore(lookup, self.version),
+			}
+		} else {
+			self.exists_in_datastore(lookup, self.version)
 		};
 		// Return result
 		Ok(res)
@@ -1060,9 +1060,8 @@ impl TransactionInner {
 			return Err(Error::TxClosed);
 		}
 		// Check the transaction type
-		let res = match self.write {
-			// This is a writeable transaction
-			true => match self.writeset.get(lookup) {
+		let res = if self.write {
+			match self.writeset.get(lookup) {
 				// The key exists in the writeset
 				Some(v) => v.clone(),
 				// Check for the key in the tree
@@ -1080,9 +1079,9 @@ impl TransactionInner {
 					// Return the result
 					res
 				}
-			},
-			// This is a readonly transaction
-			false => self.fetch_in_datastore(lookup, self.version),
+			}
+		} else {
+			self.fetch_in_datastore(lookup, self.version)
 		};
 		// Return result
 		Ok(res)
@@ -1100,43 +1099,38 @@ impl TransactionInner {
 		// Prepare result vector with the same capacity
 		let mut results = Vec::with_capacity(keys.len());
 		// Check the transaction type
-		match self.write {
-			// This is a writeable transaction
-			true => {
-				for key in keys {
-					// Get the key reference
-					let lookup = key.as_slice();
-					// Check the writeset first
-					let res = match self.writeset.get(lookup) {
-						// The key exists in the writeset
-						Some(v) => v.clone(),
-						// Check for the key in the tree
-						None => {
-							// Fetch for the key from the datastore
-							let res = self.fetch_in_datastore(lookup, self.version);
-							// Check whether we should track key reads
-							if self.mode >= IsolationLevel::SerializableSnapshotIsolation
-								&& !self.readset.pin().contains(lookup)
-							{
-								self.readset_bloom.lock().insert(lookup);
-								self.readset.pin().insert(key.into_bytes());
-							}
-							// Return the result
-							res
+		if self.write {
+			for key in keys {
+				// Get the key reference
+				let lookup = key.as_slice();
+				// Check the writeset first
+				let res = match self.writeset.get(lookup) {
+					// The key exists in the writeset
+					Some(v) => v.clone(),
+					// Check for the key in the tree
+					None => {
+						// Fetch for the key from the datastore
+						let res = self.fetch_in_datastore(lookup, self.version);
+						// Check whether we should track key reads
+						if self.mode >= IsolationLevel::SerializableSnapshotIsolation
+							&& !self.readset.pin().contains(lookup)
+						{
+							self.readset_bloom.lock().insert(lookup);
+							self.readset.pin().insert(key.into_bytes());
 						}
-					};
-					results.push(res);
-				}
+						// Return the result
+						res
+					}
+				};
+				results.push(res);
 			}
-			// This is a readonly transaction
-			false => {
-				for key in keys {
-					// Get the key reference
-					let lookup = key.as_slice();
-					// Fetch from datastore
-					let res = self.fetch_in_datastore(lookup, self.version);
-					results.push(res);
-				}
+		} else {
+			for key in keys {
+				// Get the key reference
+				let lookup = key.as_slice();
+				// Fetch from datastore
+				let res = self.fetch_in_datastore(lookup, self.version);
+				results.push(res);
 			}
 		}
 		// Return results
@@ -1184,12 +1178,13 @@ impl TransactionInner {
 			// The key exists in the writeset
 			Some(_) => return Err(Error::KeyAlreadyExists),
 			// Check for the key in the tree
-			None => match self.exists_in_datastore(lookup, self.version) {
-				// The key does not exist in the datastore
-				false => self.writeset.insert(key.into_bytes(), Some(val.into_bytes())),
-				// The key exists in the datastore
-				true => return Err(Error::KeyAlreadyExists),
-			},
+			None => {
+				if self.exists_in_datastore(lookup, self.version) {
+					return Err(Error::KeyAlreadyExists);
+				} else {
+					self.writeset.insert(key.into_bytes(), Some(val.into_bytes()))
+				}
+			}
 		};
 		// Return result
 		Ok(())
@@ -1225,15 +1220,14 @@ impl TransactionInner {
 			// The key exists in the writeset, but does not match
 			(_, Some(_)) => return Err(Error::ValNotExpectedValue),
 			// Check for the key in the tree
-			_ => match self.equals_in_datastore(lookup, chk, self.version) {
-				// The key does not exist in the datastore
-				true => {
+			_ => {
+				if self.equals_in_datastore(lookup, chk, self.version) {
 					self.writeset.insert(key.into_bytes(), Some(val.into_bytes()));
+				} else {
+					return Err(Error::ValNotExpectedValue);
 				}
-				// The key exists in the datastore
-				_ => return Err(Error::ValNotExpectedValue),
-			},
-		};
+			}
+		}
 		// Return result
 		Ok(())
 	}
@@ -1286,15 +1280,14 @@ impl TransactionInner {
 			// The key exists in the writeset, but does not match
 			(_, Some(_)) => return Err(Error::ValNotExpectedValue),
 			// Check for the key in the tree
-			_ => match self.equals_in_datastore(lookup, chk, self.version) {
-				// The key does not exist in the datastore
-				true => {
+			_ => {
+				if self.equals_in_datastore(lookup, chk, self.version) {
 					self.writeset.insert(key.into_bytes(), None);
+				} else {
+					return Err(Error::ValNotExpectedValue);
 				}
-				// The key exists in the datastore
-				_ => return Err(Error::ValNotExpectedValue),
-			},
-		};
+			}
+		}
 		// Return result
 		Ok(())
 	}
@@ -3472,22 +3465,19 @@ mod tests {
 
 				for i in 0..commits_per_thread {
 					let mut tx = db.transaction(true);
-					tx.set(format!("key_{}", i), format!("value_{}", i)).unwrap();
+					tx.set(format!("key_{i}"), format!("value_{i}")).unwrap();
 
 					// Force the commit to generate a transaction queue ID
-					match tx.commit() {
-						Ok(_) => {
-							// Successfully committed
-						}
-						Err(_) => {
-							// May fail due to conflicts, which is fine for this
-							// test
-						}
+					if let Ok(()) = tx.commit() {
+						// Successfully committed
+					} else {
+						// May fail due to conflicts, which is fine for this
+						// test
 					}
 
 					// Also test merge queue ID generation
 					let mut tx2 = db.transaction(true);
-					tx2.set(format!("merge_key_{}", i), format!("merge_value_{}", i)).unwrap();
+					tx2.set(format!("merge_key_{i}"), format!("merge_value_{i}")).unwrap();
 					let _ = tx2.commit();
 				}
 			});
@@ -3542,8 +3532,8 @@ mod tests {
 				// Each thread tries to commit multiple transactions
 				for i in 0..10 {
 					let mut tx = db.transaction(true);
-					let key = format!("thread_{}_key_{}", thread_id, i);
-					let value = format!("thread_{}_value_{}", thread_id, i);
+					let key = format!("thread_{thread_id}_key_{i}");
+					let value = format!("thread_{thread_id}_value_{i}");
 
 					tx.set(key.clone(), value.clone()).unwrap();
 
@@ -3569,7 +3559,7 @@ mod tests {
 		let tx = db.transaction(false);
 		let mut count = 0;
 		// Use a very wide range to scan all keys
-		for _ in tx.scan("".to_string().."~".to_string(), None, None).unwrap() {
+		for _ in tx.scan(String::new().."~".to_string(), None, None).unwrap() {
 			count += 1;
 		}
 
@@ -3715,7 +3705,7 @@ mod tests {
 
 		// Set multiple nested savepoints
 		for i in 0..3 {
-			let key = format!("key{}", i);
+			let key = format!("key{i}");
 			tx_stack.set(key, "value").unwrap();
 			tx_stack.set_savepoint().unwrap();
 		}
@@ -3763,8 +3753,7 @@ mod tests {
 		let result = tx2.rollback_to_savepoint();
 		assert!(
 			matches!(result, Err(Error::NoSavepoint)),
-			"Should get NoSavepoint error on fresh transaction, got: {:?}",
-			result
+			"Should get NoSavepoint error on fresh transaction, got: {result:?}"
 		);
 
 		tx2.cancel().unwrap();
@@ -3840,8 +3829,7 @@ mod tests {
 		let result = tx1.commit();
 		assert!(
 			matches!(result, Err(Error::KeyReadConflict)),
-			"Should detect scan conflict even with savepoint, got: {:?}",
-			result
+			"Should detect scan conflict even with savepoint, got: {result:?}"
 		);
 	}
 
@@ -3898,8 +3886,7 @@ mod tests {
 		let result = tx.commit();
 		assert!(
 			matches!(result, Err(Error::KeyReadConflict)),
-			"Should detect conflict from scan before savepoint, got: {:?}",
-			result
+			"Should detect conflict from scan before savepoint, got: {result:?}"
 		);
 	}
 
@@ -3912,8 +3899,8 @@ mod tests {
 
 		// Insert 10,000 keys one-by-one
 		for i in 0..10_000 {
-			let key = format!("key_{:08}", i).into_bytes();
-			let value = format!("value_{:08}", i).into_bytes();
+			let key = format!("key_{i:08}").into_bytes();
+			let value = format!("value_{i:08}").into_bytes();
 
 			let mut tx = db.transaction(true);
 			tx.put(key, value).unwrap();
@@ -3922,8 +3909,8 @@ mod tests {
 
 		// Read each key one-by-one
 		for i in 0..10_000 {
-			let key = format!("key_{:08}", i).into_bytes();
-			let expected_value = format!("value_{:08}", i).into_bytes();
+			let key = format!("key_{i:08}").into_bytes();
+			let expected_value = format!("value_{i:08}").into_bytes();
 
 			let mut tx = db.transaction(false);
 			let result = tx.get(key.clone());
@@ -3931,8 +3918,7 @@ mod tests {
 			let value = result.unwrap();
 			assert!(
 				value.is_some(),
-				"Key at index {} was not found (version was garbage collected too early)",
-				i
+				"Key at index {i} was not found (version was garbage collected too early)"
 			);
 			assert_eq!(value.unwrap(), expected_value, "Value mismatch at index {i}");
 			tx.cancel().unwrap();
@@ -3951,8 +3937,8 @@ mod tests {
 		{
 			let mut tx = db.transaction(true);
 			for i in 0..1000 {
-				let key = format!("key_{:08}", i).into_bytes();
-				let value = format!("value_{:08}", i).into_bytes();
+				let key = format!("key_{i:08}").into_bytes();
+				let value = format!("value_{i:08}").into_bytes();
 				tx.put(key, value).unwrap();
 			}
 			tx.commit().unwrap();
@@ -3968,7 +3954,7 @@ mod tests {
 			let handle = thread::spawn(move || {
 				// Each thread reads all keys
 				for i in 0..1000 {
-					let key = format!("key_{:08}", i).into_bytes();
+					let key = format!("key_{i:08}").into_bytes();
 					let mut tx = db.transaction(false);
 					let result = tx.get(key.clone());
 					assert!(
@@ -4070,8 +4056,8 @@ mod tests {
 
 		// Run multiple iterations to increase chance of hitting the race
 		for iteration in 0..100 {
-			let key = format!("race_test_key_{}", iteration).into_bytes();
-			let value = format!("race_test_value_{}", iteration).into_bytes();
+			let key = format!("race_test_key_{iteration}").into_bytes();
+			let value = format!("race_test_value_{iteration}").into_bytes();
 
 			let db_writer = Arc::clone(&db);
 			let key_writer = key.clone();
@@ -4120,14 +4106,12 @@ mod tests {
 			tx.cancel().unwrap();
 			assert!(
 				result.is_some(),
-				"Key must be visible after writer completes (iteration {})",
-				iteration
+				"Key must be visible after writer completes (iteration {iteration})"
 			);
 			assert_eq!(
 				result.unwrap(),
 				value,
-				"Value mismatch after writer completes (iteration {})",
-				iteration
+				"Value mismatch after writer completes (iteration {iteration})"
 			);
 		}
 	}
@@ -4140,7 +4124,7 @@ mod tests {
 		let db = Database::new();
 		let db = Arc::new(db);
 
-		let num_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(8);
+		let num_threads = std::thread::available_parallelism().map_or(8, std::num::NonZero::get);
 		let operations_per_thread = 50;
 
 		let mut handles = vec![];
@@ -4150,8 +4134,8 @@ mod tests {
 			let db = Arc::clone(&db);
 			let handle = thread::spawn(move || {
 				for op_id in 0..operations_per_thread {
-					let key = format!("thread_{}_key_{}", thread_id, op_id).into_bytes();
-					let value = format!("thread_{}_value_{}", thread_id, op_id).into_bytes();
+					let key = format!("thread_{thread_id}_key_{op_id}").into_bytes();
+					let value = format!("thread_{thread_id}_value_{op_id}").into_bytes();
 
 					let mut tx = db.transaction(true);
 					tx.set(key, value).unwrap();
@@ -4168,9 +4152,9 @@ mod tests {
 				// Read keys from different writers
 				for writer_id in 0..num_threads {
 					for op_id in 0..operations_per_thread {
-						let key = format!("thread_{}_key_{}", writer_id, op_id).into_bytes();
+						let key = format!("thread_{writer_id}_key_{op_id}").into_bytes();
 						let expected_value =
-							format!("thread_{}_value_{}", writer_id, op_id).into_bytes();
+							format!("thread_{writer_id}_value_{op_id}").into_bytes();
 
 						// Try reading multiple times
 						for _ in 0..5 {
@@ -4179,8 +4163,7 @@ mod tests {
 								// If we see a value, it must be correct
 								assert_eq!(
 									value, expected_value,
-									"Reader {} saw wrong value for writer {} op {}",
-									reader_id, writer_id, op_id
+									"Reader {reader_id} saw wrong value for writer {writer_id} op {op_id}"
 								);
 							}
 							tx.cancel().unwrap();
@@ -4200,8 +4183,8 @@ mod tests {
 		// Final verification: all keys must be visible
 		for thread_id in 0..num_threads {
 			for op_id in 0..operations_per_thread {
-				let key = format!("thread_{}_key_{}", thread_id, op_id).into_bytes();
-				let expected_value = format!("thread_{}_value_{}", thread_id, op_id).into_bytes();
+				let key = format!("thread_{thread_id}_key_{op_id}").into_bytes();
+				let expected_value = format!("thread_{thread_id}_value_{op_id}").into_bytes();
 
 				let mut tx = db.transaction(false);
 				let result = tx.get(key.clone()).unwrap();
@@ -4209,16 +4192,12 @@ mod tests {
 
 				assert!(
 					result.is_some(),
-					"Key from thread {} op {} not found after all threads complete",
-					thread_id,
-					op_id
+					"Key from thread {thread_id} op {op_id} not found after all threads complete"
 				);
 				assert_eq!(
 					result.unwrap(),
 					expected_value,
-					"Wrong value for thread {} op {} after all threads complete",
-					thread_id,
-					op_id
+					"Wrong value for thread {thread_id} op {op_id} after all threads complete"
 				);
 			}
 		}
@@ -4532,7 +4511,7 @@ mod tests {
 		// Set up initial data
 		let mut tx = db.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("key{}", i), format!("value{}", i)).unwrap();
+			tx.set(format!("key{i}"), format!("value{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 
@@ -4542,17 +4521,15 @@ mod tests {
 			let db_clone = Arc::clone(&db);
 			let handle = thread::spawn(move || {
 				let tx = db_clone.transaction(false);
-				let keys: Vec<String> = (0..100).map(|i| format!("key{}", i)).collect();
+				let keys: Vec<String> = (0..100).map(|i| format!("key{i}")).collect();
 				let results = tx.getm(keys).unwrap();
 
 				// Verify all results
 				for (i, result) in results.iter().enumerate() {
 					assert_eq!(
 						result.as_deref(),
-						Some(format!("value{}", i).as_bytes()),
-						"Thread {} failed at index {}",
-						thread_id,
-						i
+						Some(format!("value{i}").as_bytes()),
+						"Thread {thread_id} failed at index {i}"
 					);
 				}
 			});

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -25,6 +25,7 @@ use crate::pool::Pool;
 use crate::queue::{Commit, Merge};
 use crate::version::Version;
 use crate::versions::Versions;
+#[cfg(debug_assertions)]
 use crate::LOG_TARGET_CONFLICTS;
 use arc_swap::ArcSwap;
 use bytes::Bytes;
@@ -36,12 +37,17 @@ use std::ops::Bound;
 use std::ops::Range;
 use std::sync::atomic::{fence, AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+#[cfg(debug_assertions)]
 use tracing::debug;
 
 /// The isolation level of a database transaction
 #[derive(PartialEq, PartialOrd)]
 pub enum IsolationLevel {
+	/// Reads see a consistent snapshot, and commits conflict only on
+	/// write-write overlap
 	SnapshotIsolation,
+	/// As snapshot isolation, and additionally tracks the read set so that
+	/// read-write conflicts are detected at commit time
 	SerializableSnapshotIsolation,
 }
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -548,9 +548,9 @@ impl TransactionInner {
 		self.readset_bloom.lock().clear();
 		// Clear or completely reset the allocated writeset
 		if self.writeset.len() > threshold {
-			self.writeset = BTreeMap::new()
+			self.writeset = BTreeMap::new();
 		} else {
-			self.writeset.clear()
+			self.writeset.clear();
 		}
 		// Clear or completely reset the allocated savepoints
 		if self.savepoint_stack.len() > threshold {
@@ -1025,21 +1025,20 @@ impl TransactionInner {
 		}
 		// Check the transaction type
 		let res = if self.write {
-			match self.writeset.get(lookup) {
-				// The key exists in the writeset
-				Some(_) => true,
+			// The key exists in the writeset
+			if self.writeset.contains_key(lookup) {
+				true
+			} else {
 				// Check for the key in the tree
-				None => {
-					// Fetch for the key from the datastore
-					let res = self.exists_in_datastore(lookup, self.version);
-					// Check whether we should track key reads
-					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
-						self.readset_bloom.lock().insert(lookup);
-						self.readset.pin().insert(key.into_bytes());
-					}
-					// Return the result
-					res
+				// Fetch for the key from the datastore
+				let res = self.exists_in_datastore(lookup, self.version);
+				// Check whether we should track key reads
+				if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+					self.readset_bloom.lock().insert(lookup);
+					self.readset.pin().insert(key.into_bytes());
 				}
+				// Return the result
+				res
 			}
 		} else {
 			self.exists_in_datastore(lookup, self.version)
@@ -1061,24 +1060,23 @@ impl TransactionInner {
 		}
 		// Check the transaction type
 		let res = if self.write {
-			match self.writeset.get(lookup) {
-				// The key exists in the writeset
-				Some(v) => v.clone(),
+			// The key exists in the writeset
+			if let Some(v) = self.writeset.get(lookup) {
+				v.clone()
+			} else {
 				// Check for the key in the tree
-				None => {
-					// Fetch for the key from the datastore
-					let res = self.fetch_in_datastore(lookup, self.version);
-					// Check whether we should track key reads
-					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
-						let guard = self.readset.pin();
-						if !guard.contains(lookup) {
-							self.readset_bloom.lock().insert(lookup);
-							guard.insert(key.into_bytes());
-						}
+				// Fetch for the key from the datastore
+				let res = self.fetch_in_datastore(lookup, self.version);
+				// Check whether we should track key reads
+				if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+					let guard = self.readset.pin();
+					if !guard.contains(lookup) {
+						self.readset_bloom.lock().insert(lookup);
+						guard.insert(key.into_bytes());
 					}
-					// Return the result
-					res
 				}
+				// Return the result
+				res
 			}
 		} else {
 			self.fetch_in_datastore(lookup, self.version)
@@ -1104,23 +1102,22 @@ impl TransactionInner {
 				// Get the key reference
 				let lookup = key.as_slice();
 				// Check the writeset first
-				let res = match self.writeset.get(lookup) {
-					// The key exists in the writeset
-					Some(v) => v.clone(),
+				// The key exists in the writeset
+				let res = if let Some(v) = self.writeset.get(lookup) {
+					v.clone()
+				} else {
 					// Check for the key in the tree
-					None => {
-						// Fetch for the key from the datastore
-						let res = self.fetch_in_datastore(lookup, self.version);
-						// Check whether we should track key reads
-						if self.mode >= IsolationLevel::SerializableSnapshotIsolation
-							&& !self.readset.pin().contains(lookup)
-						{
-							self.readset_bloom.lock().insert(lookup);
-							self.readset.pin().insert(key.into_bytes());
-						}
-						// Return the result
-						res
+					// Fetch for the key from the datastore
+					let res = self.fetch_in_datastore(lookup, self.version);
+					// Check whether we should track key reads
+					if self.mode >= IsolationLevel::SerializableSnapshotIsolation
+						&& !self.readset.pin().contains(lookup)
+					{
+						self.readset_bloom.lock().insert(lookup);
+						self.readset.pin().insert(key.into_bytes());
 					}
+					// Return the result
+					res
 				};
 				results.push(res);
 			}
@@ -1173,19 +1170,12 @@ impl TransactionInner {
 		if !self.write {
 			return Err(Error::TxNotWritable);
 		}
-		// Set the key
-		match self.writeset.get(lookup) {
-			// The key exists in the writeset
-			Some(_) => return Err(Error::KeyAlreadyExists),
-			// Check for the key in the tree
-			None => {
-				if self.exists_in_datastore(lookup, self.version) {
-					return Err(Error::KeyAlreadyExists);
-				} else {
-					self.writeset.insert(key.into_bytes(), Some(val.into_bytes()))
-				}
-			}
-		};
+		// Set the key. The key must not already exist, either in the
+		// writeset or in the tree.
+		if self.writeset.contains_key(lookup) || self.exists_in_datastore(lookup, self.version) {
+			return Err(Error::KeyAlreadyExists);
+		}
+		self.writeset.insert(key.into_bytes(), Some(val.into_bytes()));
 		// Return result
 		Ok(())
 	}

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -21,7 +21,7 @@ pub(crate) enum IndexOrUpdate<'a> {
 /// for the steady state keeps every cold key at ~a third of the memory
 /// a four-slot buffer costs, which dominates total datastore footprint
 /// by key count. Keys that do grow a chain under a pinned reader spill
-/// to a small heap buffer once (SmallVec retains it thereafter), and
+/// to a small heap buffer once (`SmallVec` retains it thereafter), and
 /// even a spilled two-entry chain occupies no more total memory than
 /// the old four-slot inline layout.
 pub struct Versions {
@@ -111,13 +111,13 @@ impl Versions {
 	/// existing entry.
 	///
 	/// This function works in the following way:
-	/// - Return IndexOrUpdate::Ignore if:
+	/// - Return `IndexOrUpdate::Ignore` if:
 	///   - There is no entry with a version <= value.version and the new
 	///     value is a delete (an absent prefix already reads as `None`)
-	/// - Return IndexOrUpdate::Update(version) if:
+	/// - Return `IndexOrUpdate::Update(version)` if:
 	///   - The new value version is the same as an existing version and we
 	///     should update the entry
-	/// - Return IndexOrUpdate::Index(index) if:
+	/// - Return `IndexOrUpdate::Index(index)` if:
 	///   - The entry belongs at any other sorted position
 	#[inline]
 	pub(crate) fn fetch_index_or_update(&mut self, value: &Version) -> IndexOrUpdate<'_> {
@@ -899,7 +899,7 @@ mod tests {
 		let mut versions = Versions::new();
 		// Push many versions in order (all fast path appends)
 		for i in 0..100 {
-			let value = format!("v{}", i);
+			let value = format!("v{i}");
 			versions.push(make_version(i * 10, Some(&value)));
 		}
 		assert_eq!(versions.inner.len(), 100);
@@ -913,7 +913,7 @@ mod tests {
 		versions.push(make_version(10, Some("v1")));
 		// Update the same version many times (all fast path updates)
 		for i in 0..100 {
-			let value = format!("v{}", i);
+			let value = format!("v{i}");
 			versions.push(make_version(10, Some(&value)));
 		}
 		assert_eq!(versions.inner.len(), 1);

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -32,7 +32,7 @@ impl From<Version> for Versions {
 	fn from(value: Version) -> Self {
 		let mut inner = SmallVec::new();
 		inner.push(value);
-		Versions {
+		Self {
 			inner,
 		}
 	}
@@ -44,7 +44,7 @@ impl Versions {
 	#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 	#[inline]
 	pub(crate) fn new() -> Self {
-		Versions {
+		Self {
 			inner: SmallVec::new(),
 		}
 	}

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Batch operation tests for SurrealMX.
+//! Batch operation tests for `SurrealMX`.
 //!
 //! Tests `getm()` for multi-key operations.
 
@@ -77,7 +77,7 @@ fn getm_handles_all_missing_keys() {
 	let results = tx.getm(keys).unwrap();
 
 	assert_eq!(results.len(), 3);
-	assert!(results.iter().all(|r| r.is_none()), "All results should be None");
+	assert!(results.iter().all(std::option::Option::is_none), "All results should be None");
 }
 
 #[test]
@@ -158,18 +158,18 @@ fn getm_large_batch() {
 	let count = 1000;
 	let mut tx = db.transaction(true);
 	for i in 0..count {
-		tx.set(format!("key_{:04}", i), format!("value_{}", i)).unwrap();
+		tx.set(format!("key_{i:04}"), format!("value_{i}")).unwrap();
 	}
 	tx.commit().unwrap();
 
 	// Get all keys
 	let tx = db.transaction(false);
-	let keys: Vec<String> = (0..count).map(|i| format!("key_{:04}", i)).collect();
+	let keys: Vec<String> = (0..count).map(|i| format!("key_{i:04}")).collect();
 	let results = tx.getm(keys).unwrap();
 
 	assert_eq!(results.len(), count);
 	for (i, result) in results.iter().enumerate() {
-		assert_eq!(*result, Some(Bytes::from(format!("value_{}", i))));
+		assert_eq!(*result, Some(Bytes::from(format!("value_{i}"))));
 	}
 }
 

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Compression tests for SurrealMX.
+//! Compression tests for `SurrealMX`.
 //!
 //! Tests LZ4 compression for snapshots and compression round-trips.
 
@@ -44,7 +44,7 @@ fn lz4_snapshot_round_trip() {
 
 		let mut tx = db.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("key_{:04}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("key_{i:04}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 
@@ -69,9 +69,9 @@ fn lz4_snapshot_round_trip() {
 
 		let mut tx = db.transaction(false);
 		for i in 0..100 {
-			let expected = Bytes::from(format!("value_{}", i));
-			let actual = tx.get(format!("key_{:04}", i)).unwrap();
-			assert_eq!(actual, Some(expected), "Key {} should be recovered", i);
+			let expected = Bytes::from(format!("value_{i}"));
+			let actual = tx.get(format!("key_{i:04}")).unwrap();
+			assert_eq!(actual, Some(expected), "Key {i} should be recovered");
 		}
 		tx.cancel().unwrap();
 	}
@@ -94,7 +94,7 @@ fn uncompressed_snapshot_round_trip() {
 
 		let mut tx = db.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("key_{:04}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("key_{i:04}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 
@@ -121,8 +121,8 @@ fn uncompressed_snapshot_round_trip() {
 
 		let mut tx = db.transaction(false);
 		for i in 0..100 {
-			let expected = Bytes::from(format!("value_{}", i));
-			let actual = tx.get(format!("key_{:04}", i)).unwrap();
+			let expected = Bytes::from(format!("value_{i}"));
+			let actual = tx.get(format!("key_{i:04}")).unwrap();
 			assert_eq!(actual, Some(expected));
 		}
 		tx.cancel().unwrap();
@@ -153,7 +153,7 @@ fn lz4_compression_with_large_values() {
 
 		let mut tx = db.transaction(true);
 		for i in 0..50 {
-			tx.set(format!("key_{}", i), large_value.clone()).unwrap();
+			tx.set(format!("key_{i}"), large_value.clone()).unwrap();
 		}
 		tx.commit().unwrap();
 
@@ -168,11 +168,10 @@ fn lz4_compression_with_large_values() {
 
 	// Uncompressed would be at least 50 * 10000 = 500,000 bytes
 	// LZ4 should compress repeated data significantly
-	println!("Snapshot size with LZ4: {} bytes", snapshot_size);
+	println!("Snapshot size with LZ4: {snapshot_size} bytes");
 	assert!(
 		snapshot_size < 300_000,
-		"LZ4 should compress repeated data well, got {} bytes",
-		snapshot_size
+		"LZ4 should compress repeated data well, got {snapshot_size} bytes"
 	);
 
 	// Verify recovery
@@ -181,7 +180,7 @@ fn lz4_compression_with_large_values() {
 
 		let mut tx = db.transaction(false);
 		for i in 0..50 {
-			let actual = tx.get(format!("key_{}", i)).unwrap();
+			let actual = tx.get(format!("key_{i}")).unwrap();
 			assert_eq!(actual, Some(Bytes::from(large_value.clone())));
 		}
 		tx.cancel().unwrap();
@@ -212,7 +211,7 @@ fn lz4_compression_with_random_data() {
 			let mut val = random_value.clone();
 			val[0] = (i % 256) as u8;
 			val[1] = ((i / 256) % 256) as u8;
-			tx.set(format!("key_{:04}", i), val).unwrap();
+			tx.set(format!("key_{i:04}"), val).unwrap();
 		}
 		tx.commit().unwrap();
 
@@ -231,7 +230,7 @@ fn lz4_compression_with_random_data() {
 			expected[0] = (i % 256) as u8;
 			expected[1] = ((i / 256) % 256) as u8;
 
-			let actual = tx.get(format!("key_{:04}", i)).unwrap();
+			let actual = tx.get(format!("key_{i:04}")).unwrap();
 			assert_eq!(actual, Some(Bytes::from(expected)));
 		}
 		tx.cancel().unwrap();

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -255,8 +255,7 @@ fn auto_detect_lz4_compressed_snapshot() {
 		.with_compression(CompressionMode::Lz4);
 
 	{
-		let db =
-			Database::new_with_persistence(db_opts.clone(), persistence_opts_lz4.clone()).unwrap();
+		let db = Database::new_with_persistence(db_opts.clone(), persistence_opts_lz4).unwrap();
 
 		let mut tx = db.transaction(true);
 		tx.set("key", "compressed_value").unwrap();
@@ -302,8 +301,7 @@ fn auto_detect_uncompressed_snapshot() {
 		.with_compression(CompressionMode::None);
 
 	{
-		let db =
-			Database::new_with_persistence(db_opts.clone(), persistence_opts_none.clone()).unwrap();
+		let db = Database::new_with_persistence(db_opts.clone(), persistence_opts_none).unwrap();
 
 		let mut tx = db.transaction(true);
 		tx.set("key", "uncompressed_value").unwrap();

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -480,7 +480,7 @@ fn high_contention_counter() {
 	// The maximum possible value is num_threads * increments_per_thread
 	let max_possible = num_threads * increments_per_thread;
 	assert!(
-		final_val <= max_possible as i32,
+		final_val <= i32::try_from(max_possible).unwrap(),
 		"Counter should not exceed maximum possible increments"
 	);
 }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Concurrency tests for SurrealMX.
+//! Concurrency tests for `SurrealMX`.
 //!
 //! Tests concurrent operations, GC with active readers, and multi-writer
 //! scenarios.
@@ -51,7 +51,7 @@ fn gc_does_not_remove_versions_needed_by_active_readers() {
 	// Update the key multiple times
 	for i in 2..10 {
 		let mut tx = db.transaction(true);
-		tx.set("key", format!("v{}", i)).unwrap();
+		tx.set("key", format!("v{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -92,7 +92,7 @@ fn gc_cleans_up_after_readers_complete() {
 	// Update multiple times
 	for i in 2..20 {
 		let mut tx = db.transaction(true);
-		tx.set("key", format!("v{}", i)).unwrap();
+		tx.set("key", format!("v{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -126,8 +126,8 @@ fn multiple_writers_disjoint_keys() {
 				barrier.wait();
 
 				for op_id in 0..ops_per_writer {
-					let key = format!("writer_{}_key_{}", writer_id, op_id);
-					let value = format!("value_{}_{}", writer_id, op_id);
+					let key = format!("writer_{writer_id}_key_{op_id}");
+					let value = format!("value_{writer_id}_{op_id}");
 
 					let mut tx = db.transaction(true);
 					tx.set(key, value).unwrap();
@@ -145,10 +145,10 @@ fn multiple_writers_disjoint_keys() {
 	let mut tx = db.transaction(false);
 	for writer_id in 0..num_writers {
 		for op_id in 0..ops_per_writer {
-			let key = format!("writer_{}_key_{}", writer_id, op_id);
-			let expected = format!("value_{}_{}", writer_id, op_id);
+			let key = format!("writer_{writer_id}_key_{op_id}");
+			let expected = format!("value_{writer_id}_{op_id}");
 			let actual = tx.get(&key).unwrap();
-			assert_eq!(actual, Some(Bytes::from(expected)), "Key {} missing", key);
+			assert_eq!(actual, Some(Bytes::from(expected)), "Key {key} missing");
 		}
 	}
 	tx.cancel().unwrap();
@@ -173,7 +173,7 @@ fn multiple_writers_overlapping_keys_conflict() {
 				let mut tx = db.transaction(true).with_serializable_snapshot_isolation();
 				// Read first to establish dependency
 				let _ = tx.get("shared_key");
-				tx.set("shared_key", format!("writer_{}", writer_id)).unwrap();
+				tx.set("shared_key", format!("writer_{writer_id}")).unwrap();
 				tx.commit()
 			})
 		})
@@ -207,7 +207,7 @@ fn concurrent_readers_and_writers() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("key_{:04}", i), format!("initial_{}", i)).unwrap();
+			tx.set(format!("key_{i:04}"), format!("initial_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -248,7 +248,7 @@ fn concurrent_readers_and_writers() {
 				barrier.wait();
 
 				for op in 0..20 {
-					let key = format!("writer_{}_op_{}", writer_id, op);
+					let key = format!("writer_{writer_id}_op_{op}");
 					let mut tx = db.transaction(true);
 					tx.set(key, "written").unwrap();
 					let _ = tx.commit();
@@ -269,9 +269,9 @@ fn concurrent_readers_and_writers() {
 	// Verify original data still intact
 	let mut tx = db.transaction(false);
 	for i in 0..100 {
-		let val = tx.get(format!("key_{:04}", i)).unwrap();
+		let val = tx.get(format!("key_{i:04}")).unwrap();
 		// Value should either be initial or have been updated
-		assert!(val.is_some(), "Key {} should exist", i);
+		assert!(val.is_some(), "Key {i} should exist");
 	}
 	tx.cancel().unwrap();
 }
@@ -320,7 +320,7 @@ fn transaction_pool_recycling() {
 		let mut tx = db.transaction(i % 2 == 0);
 
 		if i % 2 == 0 {
-			tx.set(format!("key_{}", i), "value").unwrap();
+			tx.set(format!("key_{i}"), "value").unwrap();
 			let _ = tx.commit();
 		} else {
 			let _ = tx.get("any_key");
@@ -332,7 +332,7 @@ fn transaction_pool_recycling() {
 	let mut tx = db.transaction(false);
 	// Only even numbered keys should exist
 	for i in (0..1000).step_by(2) {
-		assert!(tx.exists(format!("key_{}", i)).unwrap());
+		assert!(tx.exists(format!("key_{i}")).unwrap());
 	}
 	tx.cancel().unwrap();
 }
@@ -360,7 +360,7 @@ fn concurrent_writes_during_snapshot() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("key_{}", i), "initial").unwrap();
+			tx.set(format!("key_{i}"), "initial").unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -388,7 +388,7 @@ fn concurrent_writes_during_snapshot() {
 
 				for op in 0..50 {
 					let mut tx = db.transaction(true);
-					tx.set(format!("concurrent_{}_{}", writer_id, op), "value").unwrap();
+					tx.set(format!("concurrent_{writer_id}_{op}"), "value").unwrap();
 					let _ = tx.commit();
 				}
 			})
@@ -403,7 +403,7 @@ fn concurrent_writes_during_snapshot() {
 	// Verify data integrity
 	let mut tx = db.transaction(false);
 	for i in 0..100 {
-		assert!(tx.get(format!("key_{}", i)).unwrap().is_some());
+		assert!(tx.get(format!("key_{i}")).unwrap().is_some());
 	}
 	tx.cancel().unwrap();
 }
@@ -493,7 +493,7 @@ fn concurrent_scan_operations() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..1000 {
-			tx.set(format!("key_{:06}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("key_{i:06}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}

--- a/tests/concurrent_deletes.rs
+++ b/tests/concurrent_deletes.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Concurrent delete tests for SurrealMX.
+//! Concurrent delete tests for `SurrealMX`.
 //!
 //! Tests delete operations under concurrent access, including racing
 //! deletes, delete vs update conflicts, and phantom delete detection.
@@ -131,7 +131,7 @@ fn delete_during_range_scan() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..10 {
-			tx.set(format!("key{:02}", i), format!("value{}", i)).unwrap();
+			tx.set(format!("key{i:02}"), format!("value{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -318,7 +318,7 @@ fn ssi_delete_read_conflict() {
 ///
 /// Note: the specific remove-vs-reinsert window is extremely narrow and this
 /// test is not a deterministic reproducer of it (it did not fail even with the
-/// guard removed under ThreadSanitizer); it is a sanity/stress guard over the
+/// guard removed under `ThreadSanitizer`); it is a sanity/stress guard over the
 /// delete-recreate-under-GC pattern. A side thread hammers `run_gc()`.
 #[test]
 fn delete_then_recreate_under_gc_keeps_value() {

--- a/tests/concurrent_deletes.rs
+++ b/tests/concurrent_deletes.rs
@@ -345,8 +345,8 @@ fn delete_then_recreate_under_gc_keeps_value() {
 	// Hammer GC to maximise the chance of a remove landing next to a recreate.
 	let stop = Arc::new(AtomicBool::new(false));
 	let gc = {
-		let db = db.clone();
-		let stop = stop.clone();
+		let db = Arc::clone(&db);
+		let stop = Arc::clone(&stop);
 		thread::spawn(move || {
 			while !stop.load(Ordering::Relaxed) {
 				db.run_gc();
@@ -357,7 +357,7 @@ fn delete_then_recreate_under_gc_keeps_value() {
 	let mut handles = Vec::new();
 	for w in 0..WRITERS {
 		// Each writer owns a disjoint key set, so commits never conflict.
-		let db = db.clone();
+		let db = Arc::clone(&db);
 		handles.push(thread::spawn(move || {
 			for round in 0..ROUNDS {
 				for k in 0..KEYS_PER_WRITER {

--- a/tests/concurrent_ranges.rs
+++ b/tests/concurrent_ranges.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Concurrent range operation tests for SurrealMX.
+//! Concurrent range operation tests for `SurrealMX`.
 //!
 //! Tests range scans under concurrent modifications including inserts,
 //! deletes, and updates within scanned ranges.
@@ -86,7 +86,7 @@ fn delete_from_scanned_range() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..5 {
-			tx.set(format!("key_{}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("key_{i}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -133,7 +133,7 @@ fn update_within_scanned_range() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..5 {
-			tx.set(format!("key_{}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("key_{i}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -189,7 +189,7 @@ fn concurrent_range_scans() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..20 {
-			tx.set(format!("key_{:02}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("key_{i:02}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -214,7 +214,7 @@ fn concurrent_range_scans() {
 
 	// All scanners should see the same count (consistent snapshot)
 	for (scanner_id, count) in &results {
-		assert_eq!(*count, 20, "Scanner {} should see all 20 keys, got {}", scanner_id, count);
+		assert_eq!(*count, 20, "Scanner {scanner_id} should see all 20 keys, got {count}");
 	}
 }
 
@@ -226,7 +226,7 @@ fn scan_while_bulk_insert() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..10 {
-			tx.set(format!("existing_{:02}", i), "initial").unwrap();
+			tx.set(format!("existing_{i:02}"), "initial").unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -250,7 +250,7 @@ fn scan_while_bulk_insert() {
 		barrier2.wait();
 		let mut tx = db2.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("new_{:03}", i), "bulk").unwrap();
+			tx.set(format!("new_{i:03}"), "bulk").unwrap();
 		}
 		tx.commit()
 	});
@@ -278,7 +278,7 @@ fn range_scan_consistency() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..10 {
-			tx.set(format!("data_{:02}", i), format!("v{}", i)).unwrap();
+			tx.set(format!("data_{i:02}"), format!("v{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}

--- a/tests/conditional.rs
+++ b/tests/conditional.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Conditional operation tests for SurrealMX.
+//! Conditional operation tests for `SurrealMX`.
 //!
 //! Tests `put()`, `putc()`, and `delc()` behavior for conditional
 //! insert, update, and delete operations.

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Error handling tests for SurrealMX.
+//! Error handling tests for `SurrealMX`.
 //!
 //! Tests error conditions and proper error handling behavior.
 

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Garbage collection tests for SurrealMX.
+//! Garbage collection tests for `SurrealMX`.
 //!
 //! Tests manual `run_gc()` and background GC behavior.
 
@@ -30,14 +30,14 @@ use surrealmx::{Database, DatabaseOptions};
 fn manual_gc_removes_stale_versions() {
 	let db = Database::new_with_options(
 		DatabaseOptions::default()
-			.with_gc_interval(Duration::from_secs(3600)) // Disable background GC
-			.with_cleanup_interval(Duration::from_secs(3600)),
+			.with_gc_interval(Duration::from_hours(1)) // Disable background GC
+			.with_cleanup_interval(Duration::from_hours(1)),
 	);
 
 	// Create multiple versions
 	for i in 0..10 {
 		let mut tx = db.transaction(true);
-		tx.set("key", format!("v{}", i)).unwrap();
+		tx.set("key", format!("v{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -56,8 +56,8 @@ fn manual_gc_removes_stale_versions() {
 fn manual_gc_respects_active_transactions() {
 	let db = Database::new_with_options(
 		DatabaseOptions::default()
-			.with_gc_interval(Duration::from_secs(3600))
-			.with_cleanup_interval(Duration::from_secs(3600)),
+			.with_gc_interval(Duration::from_hours(1))
+			.with_cleanup_interval(Duration::from_hours(1)),
 	);
 
 	// Create initial version
@@ -73,7 +73,7 @@ fn manual_gc_respects_active_transactions() {
 	// Update multiple times
 	for i in 2..10 {
 		let mut tx = db.transaction(true);
-		tx.set("key", format!("v{}", i)).unwrap();
+		tx.set("key", format!("v{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -93,8 +93,8 @@ fn manual_gc_respects_active_transactions() {
 fn manual_gc_removes_deleted_keys() {
 	let db = Database::new_with_options(
 		DatabaseOptions::default()
-			.with_gc_interval(Duration::from_secs(3600))
-			.with_cleanup_interval(Duration::from_secs(3600)),
+			.with_gc_interval(Duration::from_hours(1))
+			.with_cleanup_interval(Duration::from_hours(1)),
 	);
 
 	// Create and delete key
@@ -133,7 +133,7 @@ fn background_gc_runs_automatically() {
 	// Create many versions quickly
 	for i in 0..20 {
 		let mut tx = db.transaction(true);
-		tx.set("gc_key", format!("value_{}", i)).unwrap();
+		tx.set("gc_key", format!("value_{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -163,7 +163,7 @@ fn gc_handles_multiple_keys() {
 	for key_id in 0..10 {
 		for version in 0..5 {
 			let mut tx = db.transaction(true);
-			tx.set(format!("key_{}", key_id), format!("v{}", version)).unwrap();
+			tx.set(format!("key_{key_id}"), format!("v{version}")).unwrap();
 			tx.commit().unwrap();
 		}
 	}
@@ -174,8 +174,8 @@ fn gc_handles_multiple_keys() {
 	// All keys should still have their latest values
 	let mut tx = db.transaction(false);
 	for key_id in 0..10 {
-		let val = tx.get(format!("key_{}", key_id)).unwrap();
-		assert_eq!(val, Some(Bytes::from("v4")), "Key {} should have latest value", key_id);
+		let val = tx.get(format!("key_{key_id}")).unwrap();
+		assert_eq!(val, Some(Bytes::from("v4")), "Key {key_id} should have latest value");
 	}
 	tx.cancel().unwrap();
 }
@@ -222,14 +222,14 @@ fn gc_with_mixed_deletes() {
 fn transaction_cleanup_runs_automatically() {
 	let db = Database::new_with_options(
 		DatabaseOptions::default()
-			.with_gc_interval(Duration::from_secs(3600))
+			.with_gc_interval(Duration::from_hours(1))
 			.with_cleanup_interval(Duration::from_millis(100)),
 	);
 
 	// Create and complete many transactions
 	for i in 0..50 {
 		let mut tx = db.transaction(true);
-		tx.set(format!("key_{}", i), "value").unwrap();
+		tx.set(format!("key_{i}"), "value").unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -239,7 +239,7 @@ fn transaction_cleanup_runs_automatically() {
 	// New transactions should work fine
 	let mut tx = db.transaction(false);
 	for i in 0..50 {
-		assert!(tx.exists(format!("key_{}", i)).unwrap());
+		assert!(tx.exists(format!("key_{i}")).unwrap());
 	}
 	tx.cancel().unwrap();
 }
@@ -248,14 +248,14 @@ fn transaction_cleanup_runs_automatically() {
 fn manual_cleanup() {
 	let db = Database::new_with_options(
 		DatabaseOptions::default()
-			.with_gc_interval(Duration::from_secs(3600))
-			.with_cleanup_interval(Duration::from_secs(3600)), // Disable auto cleanup
+			.with_gc_interval(Duration::from_hours(1))
+			.with_cleanup_interval(Duration::from_hours(1)), // Disable auto cleanup
 	);
 
 	// Create transactions
 	for i in 0..20 {
 		let mut tx = db.transaction(true);
-		tx.set(format!("key_{}", i), "value").unwrap();
+		tx.set(format!("key_{i}"), "value").unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -265,7 +265,7 @@ fn manual_cleanup() {
 	// Should still work
 	let mut tx = db.transaction(false);
 	for i in 0..20 {
-		assert!(tx.exists(format!("key_{}", i)).unwrap());
+		assert!(tx.exists(format!("key_{i}")).unwrap());
 	}
 	tx.cancel().unwrap();
 }
@@ -295,7 +295,7 @@ fn concurrent_gc_and_transactions() {
 
 					// Write
 					let mut tx = db.transaction(true);
-					tx.set(&key, format!("value_{}_{}", thread_id, op)).unwrap();
+					tx.set(&key, format!("value_{thread_id}_{op}")).unwrap();
 					let _ = tx.commit();
 
 					// Read
@@ -314,9 +314,9 @@ fn concurrent_gc_and_transactions() {
 	let mut tx = db.transaction(false);
 	for thread_id in 0..num_threads {
 		for key_id in 0..10 {
-			let key = format!("thread_{}_key_{}", thread_id, key_id);
+			let key = format!("thread_{thread_id}_key_{key_id}");
 			let val = tx.get(&key).unwrap();
-			assert!(val.is_some(), "Key {} should exist", key);
+			assert!(val.is_some(), "Key {key} should exist");
 		}
 	}
 	tx.cancel().unwrap();
@@ -337,13 +337,13 @@ fn gc_with_only_deleted_keys() {
 	// Create and immediately delete
 	let mut tx = db.transaction(true);
 	for i in 0..10 {
-		tx.set(format!("temp_{}", i), "value").unwrap();
+		tx.set(format!("temp_{i}"), "value").unwrap();
 	}
 	tx.commit().unwrap();
 
 	let mut tx = db.transaction(true);
 	for i in 0..10 {
-		tx.del(format!("temp_{}", i)).unwrap();
+		tx.del(format!("temp_{i}")).unwrap();
 	}
 	tx.commit().unwrap();
 
@@ -353,7 +353,7 @@ fn gc_with_only_deleted_keys() {
 	// All should be gone
 	let mut tx = db.transaction(false);
 	for i in 0..10 {
-		assert!(tx.get(format!("temp_{}", i)).unwrap().is_none());
+		assert!(tx.get(format!("temp_{i}")).unwrap().is_none());
 	}
 	tx.cancel().unwrap();
 }

--- a/tests/isolation.rs
+++ b/tests/isolation.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Transaction isolation tests for SurrealMX.
+//! Transaction isolation tests for `SurrealMX`.
 //!
 //! Tests SSI (Serializable Snapshot Isolation) conflict detection
 //! and Snapshot Isolation behavior.

--- a/tests/iteration_edge.rs
+++ b/tests/iteration_edge.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Iteration edge case tests for SurrealMX.
+//! Iteration edge case tests for `SurrealMX`.
 //!
 //! Tests iterator and cursor behavior under edge conditions including
 //! modifications during iteration, transaction lifecycle, and concurrent
@@ -206,7 +206,7 @@ fn concurrent_iteration_same_range() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..20 {
-			tx.set(format!("data_{:02}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("data_{i:02}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -233,6 +233,6 @@ fn concurrent_iteration_same_range() {
 
 	// All threads should see the same count
 	for (thread_id, count) in &results {
-		assert_eq!(*count, 20, "Thread {} should see all 20 items, got {}", thread_id, count);
+		assert_eq!(*count, 20, "Thread {thread_id} should see all 20 items, got {count}");
 	}
 }

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Iterator and cursor edge case tests for SurrealMX.
+//! Iterator and cursor edge case tests for `SurrealMX`.
 //!
-//! Tests cursor, KeyIterator, and ScanIterator behavior including
+//! Tests cursor, `KeyIterator`, and `ScanIterator` behavior including
 //! direction switching, empty ranges, and edge cases.
 
 use bytes::Bytes;
@@ -430,7 +430,7 @@ fn scan_with_skip_and_limit() {
 
 	let mut tx = db.transaction(true);
 	for i in 0..10 {
-		tx.set(format!("key_{:02}", i), format!("value_{}", i)).unwrap();
+		tx.set(format!("key_{i:02}"), format!("value_{i}")).unwrap();
 	}
 	tx.commit().unwrap();
 

--- a/tests/key_boundaries.rs
+++ b/tests/key_boundaries.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Key and value boundary tests for SurrealMX.
+//! Key and value boundary tests for `SurrealMX`.
 //!
 //! Tests boundary conditions including empty values, null bytes,
 //! byte boundaries, and key ordering.
@@ -154,7 +154,7 @@ fn single_byte_keys() {
 	// Single byte keys covering the byte range
 	for byte in [0x00u8, 0x01, 0x7F, 0x80, 0xFE, 0xFF] {
 		let key = vec![byte];
-		let value = format!("value_{:02X}", byte);
+		let value = format!("value_{byte:02X}");
 		tx.set(&key, value).unwrap();
 	}
 	tx.commit().unwrap();
@@ -163,12 +163,11 @@ fn single_byte_keys() {
 	let tx = db.transaction(false);
 	for byte in [0x00u8, 0x01, 0x7F, 0x80, 0xFE, 0xFF] {
 		let key = vec![byte];
-		let expected = format!("value_{:02X}", byte);
+		let expected = format!("value_{byte:02X}");
 		assert_eq!(
 			tx.get(&key).unwrap(),
 			Some(Bytes::from(expected)),
-			"Single byte key 0x{:02X}",
-			byte
+			"Single byte key 0x{byte:02X}"
 		);
 	}
 }
@@ -195,15 +194,15 @@ fn unicode_keys() {
 	];
 
 	for (i, key) in keys.iter().enumerate() {
-		tx.set(*key, format!("value_{}", i)).unwrap();
+		tx.set(*key, format!("value_{i}")).unwrap();
 	}
 	tx.commit().unwrap();
 
 	// Verify all Unicode keys
 	let tx = db.transaction(false);
 	for (i, key) in keys.iter().enumerate() {
-		let expected = format!("value_{}", i);
-		assert_eq!(tx.get(*key).unwrap(), Some(Bytes::from(expected)), "Unicode key: {}", key);
+		let expected = format!("value_{i}");
+		assert_eq!(tx.get(*key).unwrap(), Some(Bytes::from(expected)), "Unicode key: {key}");
 	}
 
 	// Verify we can retrieve all keys using a wide scan
@@ -253,9 +252,7 @@ fn binary_key_ordering() {
 		if let Some(p) = prev {
 			assert!(
 				key.as_ref() > p.as_ref(),
-				"Keys should be in ascending byte order: {:?} should be after {:?}",
-				key,
-				p
+				"Keys should be in ascending byte order: {key:?} should be after {p:?}"
 			);
 		}
 		prev = Some(key);

--- a/tests/large_transactions.rs
+++ b/tests/large_transactions.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Large transaction stress tests for SurrealMX.
+//! Large transaction stress tests for `SurrealMX`.
 //!
 //! Tests high-volume transaction scenarios including many keys,
 //! large values, and sustained write pressure.
@@ -37,8 +37,8 @@ fn transaction_with_thousands_of_keys() {
 	// Write many keys in a single transaction
 	let mut tx = db.transaction(true);
 	for i in 0..num_keys {
-		let key = format!("key_{:06}", i);
-		let value = format!("value_{}", i);
+		let key = format!("key_{i:06}");
+		let value = format!("value_{i}");
 		tx.set(key, value).unwrap();
 	}
 	tx.commit().unwrap();
@@ -46,7 +46,7 @@ fn transaction_with_thousands_of_keys() {
 	// Verify all keys are present
 	let tx = db.transaction(false);
 	let results = tx.scan("key_".."key_z", None, None).unwrap();
-	assert_eq!(results.len(), num_keys, "All {} keys should be present", num_keys);
+	assert_eq!(results.len(), num_keys, "All {num_keys} keys should be present");
 
 	// Spot check some values
 	assert_eq!(tx.get("key_000000").unwrap(), Some(Bytes::from("value_0")));
@@ -64,7 +64,7 @@ fn large_value_handling() {
 
 	let mut tx = db.transaction(true);
 	for (i, size) in sizes.iter().enumerate() {
-		let key = format!("large_key_{}", i);
+		let key = format!("large_key_{i}");
 		// Create a value of the specified size
 		let value = vec![b'x'; *size];
 		tx.set(key, value).unwrap();
@@ -74,9 +74,9 @@ fn large_value_handling() {
 	// Verify all values are retrievable and correct size
 	let tx = db.transaction(false);
 	for (i, expected_size) in sizes.iter().enumerate() {
-		let key = format!("large_key_{}", i);
+		let key = format!("large_key_{i}");
 		let value = tx.get(&key).unwrap().expect("Value should exist");
-		assert_eq!(value.len(), *expected_size, "Value {} should be {} bytes", i, expected_size);
+		assert_eq!(value.len(), *expected_size, "Value {i} should be {expected_size} bytes");
 		// Verify content
 		assert!(value.iter().all(|&b| b == b'x'), "All bytes should be 'x'");
 	}
@@ -94,7 +94,7 @@ fn many_small_writes() {
 	for tx_num in 0..num_transactions {
 		let mut tx = db.transaction(true);
 		for key_num in 0..keys_per_tx {
-			let key = format!("tx{:04}_key{:02}", tx_num, key_num);
+			let key = format!("tx{tx_num:04}_key{key_num:02}");
 			tx.set(key, "value").unwrap();
 		}
 		tx.commit().unwrap();
@@ -122,8 +122,8 @@ fn large_scan_results() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..num_keys {
-			let key = format!("scan_key_{:05}", i);
-			let value = format!("value_for_{}", i);
+			let key = format!("scan_key_{i:05}");
+			let value = format!("value_for_{i}");
 			tx.set(key, value).unwrap();
 		}
 		tx.commit().unwrap();
@@ -162,7 +162,7 @@ fn memory_under_write_pressure() {
 		let mut tx = db.transaction(true);
 		for key_num in 0..keys_per_iteration {
 			// Reuse key names to simulate updates (overwriting existing data)
-			let key = format!("pressure_key_{:03}", key_num);
+			let key = format!("pressure_key_{key_num:03}");
 			let value = vec![(iter % 256) as u8; value_size];
 			tx.set(key, value).unwrap();
 		}
@@ -172,7 +172,7 @@ fn memory_under_write_pressure() {
 	// Verify final state
 	let tx = db.transaction(false);
 	let results = tx.scan("pressure_key_".."pressure_key_z", None, None).unwrap();
-	assert_eq!(results.len(), keys_per_iteration, "Should have {} unique keys", keys_per_iteration);
+	assert_eq!(results.len(), keys_per_iteration, "Should have {keys_per_iteration} unique keys");
 
 	// Verify values have the content from the last iteration
 	let expected_byte = ((iterations - 1) % 256) as u8;
@@ -196,8 +196,8 @@ fn large_batch_getm() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..num_keys {
-			let key = format!("batch_key_{:04}", i);
-			let value = format!("batch_value_{}", i);
+			let key = format!("batch_key_{i:04}");
+			let value = format!("batch_value_{i}");
 			tx.set(key, value).unwrap();
 		}
 		tx.commit().unwrap();
@@ -205,16 +205,16 @@ fn large_batch_getm() {
 
 	// Perform a large batch get
 	let tx = db.transaction(false);
-	let keys: Vec<String> = (0..num_keys).map(|i| format!("batch_key_{:04}", i)).collect();
-	let key_refs: Vec<&str> = keys.iter().map(|s| s.as_str()).collect();
+	let keys: Vec<String> = (0..num_keys).map(|i| format!("batch_key_{i:04}")).collect();
+	let key_refs: Vec<&str> = keys.iter().map(std::string::String::as_str).collect();
 
 	let results = tx.getm(key_refs).unwrap();
 	assert_eq!(results.len(), num_keys);
 
 	// All values should be present
 	for (i, result) in results.iter().enumerate() {
-		assert!(result.is_some(), "Key {} should have a value", i);
-		let expected = format!("batch_value_{}", i);
+		assert!(result.is_some(), "Key {i} should have a value");
+		let expected = format!("batch_value_{i}");
 		assert_eq!(result.as_ref().unwrap(), &Bytes::from(expected));
 	}
 
@@ -222,13 +222,13 @@ fn large_batch_getm() {
 	let mixed_keys: Vec<String> = (0..100)
 		.map(|i| {
 			if i % 2 == 0 {
-				format!("batch_key_{:04}", i)
+				format!("batch_key_{i:04}")
 			} else {
-				format!("nonexistent_{:04}", i)
+				format!("nonexistent_{i:04}")
 			}
 		})
 		.collect();
-	let mixed_refs: Vec<&str> = mixed_keys.iter().map(|s| s.as_str()).collect();
+	let mixed_refs: Vec<&str> = mixed_keys.iter().map(std::string::String::as_str).collect();
 
 	let mixed_results = tx.getm(mixed_refs).unwrap();
 	assert_eq!(mixed_results.len(), 100);
@@ -236,9 +236,9 @@ fn large_batch_getm() {
 	// Every other result should be Some/None
 	for (i, result) in mixed_results.iter().enumerate() {
 		if i % 2 == 0 {
-			assert!(result.is_some(), "Even index {} should have value", i);
+			assert!(result.is_some(), "Even index {i} should have value");
 		} else {
-			assert!(result.is_none(), "Odd index {} should be None", i);
+			assert!(result.is_none(), "Odd index {i} should be None");
 		}
 	}
 }

--- a/tests/memory_test.rs
+++ b/tests/memory_test.rs
@@ -18,24 +18,24 @@ fn test_version_cleanup_with_updates() {
 	let num_keys = 1000;
 	let num_updates = 10;
 
-	println!("Creating {} keys...", num_keys);
+	println!("Creating {num_keys} keys...");
 
 	// Create initial keys
 	for i in 0..num_keys {
 		let mut tx = db.transaction(true);
-		let key = format!("key_{:06}", i);
+		let key = format!("key_{i:06}");
 		let value = vec![0u8; 100];
 		tx.set(key, value).unwrap();
 		tx.commit().unwrap();
 	}
 
-	println!("Updating each key {} times...", num_updates);
+	println!("Updating each key {num_updates} times...");
 
 	// Update each key multiple times
 	for update_round in 0..num_updates {
 		for i in 0..num_keys {
 			let mut tx = db.transaction(true);
-			let key = format!("key_{:06}", i);
+			let key = format!("key_{i:06}");
 			let value = vec![update_round as u8; 100];
 			tx.set(key, value).unwrap();
 			tx.commit().unwrap();
@@ -53,9 +53,9 @@ fn test_version_cleanup_with_updates() {
 	// Verify all keys exist and have the latest value
 	let mut tx = db.transaction(false);
 	for i in 0..num_keys {
-		let key = format!("key_{:06}", i);
+		let key = format!("key_{i:06}");
 		let value = tx.get(key).unwrap();
-		assert!(value.is_some(), "Key {} should exist", i);
+		assert!(value.is_some(), "Key {i} should exist");
 		assert_eq!(value.unwrap(), Bytes::from(vec![(num_updates - 1) as u8; 100]));
 	}
 	tx.cancel().unwrap();
@@ -71,12 +71,12 @@ fn test_version_cleanup_with_deletes() {
 
 	let num_keys = 500;
 
-	println!("Creating {} keys...", num_keys);
+	println!("Creating {num_keys} keys...");
 
 	// Create keys
 	for i in 0..num_keys {
 		let mut tx = db.transaction(true);
-		let key = format!("key_{:06}", i);
+		let key = format!("key_{i:06}");
 		let value = vec![1u8; 100];
 		tx.set(key, value).unwrap();
 		tx.commit().unwrap();
@@ -87,7 +87,7 @@ fn test_version_cleanup_with_deletes() {
 	// Update all keys
 	for i in 0..num_keys {
 		let mut tx = db.transaction(true);
-		let key = format!("key_{:06}", i);
+		let key = format!("key_{i:06}");
 		let value = vec![2u8; 100];
 		tx.set(key, value).unwrap();
 		tx.commit().unwrap();
@@ -98,7 +98,7 @@ fn test_version_cleanup_with_deletes() {
 	// Delete all keys
 	for i in 0..num_keys {
 		let mut tx = db.transaction(true);
-		let key = format!("key_{:06}", i);
+		let key = format!("key_{i:06}");
 		tx.del(key).unwrap();
 		tx.commit().unwrap();
 	}
@@ -111,15 +111,15 @@ fn test_version_cleanup_with_deletes() {
 	// Verify all keys are gone
 	let mut tx = db.transaction(false);
 	for i in 0..num_keys {
-		let key = format!("key_{:06}", i);
+		let key = format!("key_{i:06}");
 		let value = tx.get(key).unwrap();
-		assert!(value.is_none(), "Key {} should be deleted", i);
+		assert!(value.is_none(), "Key {i} should be deleted");
 	}
 	tx.cancel().unwrap();
 
 	println!("Test passed! All keys are properly deleted.");
 	println!("\nNote: With the fix, delete operations should remove all old versions,");
-	println!("freeing memory for {} keys with their full version history.", num_keys);
+	println!("freeing memory for {num_keys} keys with their full version history.");
 }
 
 #[test]
@@ -131,13 +131,13 @@ fn test_memory_with_batch_operations() {
 	let num_batches = 10;
 	let batch_size = 100;
 
-	println!("Running {} batches of {} operations...", num_batches, batch_size);
+	println!("Running {num_batches} batches of {batch_size} operations...");
 
 	for batch_num in 0..num_batches {
 		// Create a batch
 		let mut tx = db.transaction(true);
 		for i in 0..batch_size {
-			let key = format!("batch_{}_{:04}", batch_num, i);
+			let key = format!("batch_{batch_num}_{i:04}");
 			let value = vec![batch_num as u8; 100];
 			tx.set(key, value).unwrap();
 		}
@@ -148,7 +148,7 @@ fn test_memory_with_batch_operations() {
 		// Update the same batch
 		let mut tx = db.transaction(true);
 		for i in 0..batch_size {
-			let key = format!("batch_{}_{:04}", batch_num, i);
+			let key = format!("batch_{batch_num}_{i:04}");
 			let value = vec![(batch_num + 100) as u8; 100];
 			tx.set(key, value).unwrap();
 		}
@@ -169,7 +169,7 @@ fn test_memory_with_batch_operations() {
 	let mut count = 0;
 	for batch_num in 0..num_batches {
 		for i in 0..batch_size {
-			let key = format!("batch_{}_{:04}", batch_num, i);
+			let key = format!("batch_{batch_num}_{i:04}");
 			let value = tx.get(&key).unwrap();
 			assert!(value.is_some());
 			assert_eq!(value.unwrap(), Bytes::from(vec![(batch_num + 100) as u8; 100]));
@@ -178,7 +178,7 @@ fn test_memory_with_batch_operations() {
 	}
 	tx.cancel().unwrap();
 
-	println!("Test passed! Verified {} entries.", count);
+	println!("Test passed! Verified {count} entries.");
 	println!(
 		"\nWith the fix, {} create + {} update operations should use",
 		num_batches * batch_size,

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -282,7 +282,7 @@ fn test_snapshot_only_persistence_basic() {
 	// Configure snapshot-only persistence (no AOL)
 	let persistence_opts = PersistenceOptions::new(temp_path)
 		.with_aol_mode(AolMode::Never)
-		.with_snapshot_mode(SnapshotMode::Interval(Duration::from_secs(60)));
+		.with_snapshot_mode(SnapshotMode::Interval(Duration::from_mins(1)));
 
 	// Create persistent database with snapshot-only mode
 	let db = Database::new_with_persistence(db_opts, persistence_opts).unwrap();
@@ -536,7 +536,7 @@ fn test_aol_snapshot_with_truncation() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..10 {
-			tx.set(format!("key_{}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("key_{i}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -571,8 +571,8 @@ fn test_aol_snapshot_with_truncation() {
 		let mut tx = db.transaction(false);
 		for i in 0..10 {
 			assert_eq!(
-				tx.get(format!("key_{}", i)).unwrap(),
-				Some(Bytes::from(format!("value_{}", i)))
+				tx.get(format!("key_{i}")).unwrap(),
+				Some(Bytes::from(format!("value_{i}")))
 			);
 		}
 		assert_eq!(tx.get("post_snapshot_key").unwrap(), Some(Bytes::from("post_snapshot_value")));

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -876,6 +876,7 @@ fn test_loads_multiversion_snapshot_files() {
 	// tombstone. Loading must surface only the newest value of the first
 	// key, and treat the second as absent.
 	{
+		use std::io::Write as _;
 		let file = std::fs::File::create(temp_path.join("snapshot.bin")).unwrap();
 		let mut writer = std::io::BufWriter::new(file);
 		let multi: (Bytes, Vec<(u64, Option<Bytes>)>) = (
@@ -892,7 +893,6 @@ fn test_loads_multiversion_snapshot_files() {
 			.unwrap();
 		bincode::serde::encode_into_std_write(&gone, &mut writer, bincode::config::standard())
 			.unwrap();
-		use std::io::Write;
 		writer.flush().unwrap();
 	}
 

--- a/tests/persistence_edge.rs
+++ b/tests/persistence_edge.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Persistence edge case tests for SurrealMX.
+//! Persistence edge case tests for `SurrealMX`.
 //!
 //! Tests recovery scenarios, edge cases, and persistence behavior.
 
@@ -334,7 +334,7 @@ fn fsync_interval_mode() {
 	// Write multiple transactions
 	for i in 0..5 {
 		let mut tx = db.transaction(true);
-		tx.set(format!("key_{}", i), format!("value_{}", i)).unwrap();
+		tx.set(format!("key_{i}"), format!("value_{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -505,7 +505,7 @@ fn snapshot_truncates_aol() {
 	// Add lots of data to AOL
 	for i in 0..100 {
 		let mut tx = db.transaction(true);
-		tx.set(format!("key_{:04}", i), format!("value_{}", i)).unwrap();
+		tx.set(format!("key_{i:04}"), format!("value_{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -521,8 +521,6 @@ fn snapshot_truncates_aol() {
 
 	assert!(
 		aol_size_after < aol_size_before,
-		"AOL should be truncated after snapshot ({} < {})",
-		aol_size_after,
-		aol_size_before
+		"AOL should be truncated after snapshot ({aol_size_after} < {aol_size_before})"
 	);
 }

--- a/tests/prefix_concurrency.rs
+++ b/tests/prefix_concurrency.rs
@@ -167,7 +167,7 @@ fn concurrent_writers_compete_for_same_keys() {
 						tx.set(key.clone(), val.clone()).unwrap();
 						match tx.commit() {
 							Ok(()) => break,
-							Err(Error::KeyWriteConflict) | Err(Error::KeyReadConflict) => {
+							Err(Error::KeyWriteConflict | Error::KeyReadConflict) => {
 								conflicts.fetch_add(1, Ordering::Relaxed);
 								continue;
 							}
@@ -243,7 +243,7 @@ fn ssi_increment_counter_under_contention() {
 							successes.fetch_add(1, Ordering::Relaxed);
 							break;
 						}
-						Err(Error::KeyReadConflict) | Err(Error::KeyWriteConflict) => {
+						Err(Error::KeyReadConflict | Error::KeyWriteConflict) => {
 							conflicts.fetch_add(1, Ordering::Relaxed);
 							continue;
 						}
@@ -546,7 +546,11 @@ fn sustained_mixed_workload_prefix_keys() {
 	for (k, v) in &scanned {
 		// scan and get must agree
 		let g = tx.get(k.as_ref()).unwrap();
-		assert_eq!(g.as_ref().map(|b| b.as_ref()), Some(v.as_ref()), "scan/get disagree");
+		assert_eq!(
+			g.as_ref().map(std::convert::AsRef::as_ref),
+			Some(v.as_ref()),
+			"scan/get disagree"
+		);
 		// And the value must be one some thread actually wrote
 		assert!(
 			values.contains(v.as_ref()),

--- a/tests/prefix_concurrency.rs
+++ b/tests/prefix_concurrency.rs
@@ -169,7 +169,6 @@ fn concurrent_writers_compete_for_same_keys() {
 							Ok(()) => break,
 							Err(Error::KeyWriteConflict | Error::KeyReadConflict) => {
 								conflicts.fetch_add(1, Ordering::Relaxed);
-								continue;
 							}
 							Err(e) => panic!("unexpected commit error: {e:?}"),
 						}
@@ -245,7 +244,6 @@ fn ssi_increment_counter_under_contention() {
 						}
 						Err(Error::KeyReadConflict | Error::KeyWriteConflict) => {
 							conflicts.fetch_add(1, Ordering::Relaxed);
-							continue;
 						}
 						Err(other) => panic!("unexpected error: {other:?}"),
 					}
@@ -500,10 +498,11 @@ fn sustained_mixed_workload_prefix_keys() {
 		handles.push(thread::spawn(move || {
 			barrier.wait();
 			let start = Instant::now();
-			let mut local_seed = tid as u64 * 0xdeadbeef;
+			let mut local_seed = tid as u64 * 0xdead_beef;
 			while start.elapsed() < DURATION {
-				local_seed =
-					local_seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+				local_seed = local_seed
+					.wrapping_mul(6_364_136_223_846_793_005)
+					.wrapping_add(1_442_695_040_888_963_407);
 				let op = (local_seed >> 56) % 4;
 				let k = (local_seed >> 32) as u32 % KEY_SPACE;
 				let key = Bytes::from(pkey("workload", k as usize));

--- a/tests/prefix_concurrency.rs
+++ b/tests/prefix_concurrency.rs
@@ -57,8 +57,8 @@ fn concurrent_writers_disjoint_prefix_groups() {
 
 	let mut handles = Vec::new();
 	for tid in 0..THREADS {
-		let db = db.clone();
-		let barrier = barrier.clone();
+		let db = Arc::clone(&db);
+		let barrier = Arc::clone(&barrier);
 		handles.push(thread::spawn(move || {
 			barrier.wait();
 			for i in 0..PER_THREAD {
@@ -101,8 +101,8 @@ fn concurrent_writers_same_prefix_group_disjoint_keys() {
 
 	let mut handles = Vec::new();
 	for tid in 0..THREADS {
-		let db = db.clone();
-		let barrier = barrier.clone();
+		let db = Arc::clone(&db);
+		let barrier = Arc::clone(&barrier);
 		handles.push(thread::spawn(move || {
 			barrier.wait();
 			for i in 0..PER_THREAD {
@@ -153,9 +153,9 @@ fn concurrent_writers_compete_for_same_keys() {
 	let conflicts = Arc::new(AtomicU64::new(0));
 	let mut handles = Vec::new();
 	for tid in 0..THREADS {
-		let db = db.clone();
-		let barrier = barrier.clone();
-		let conflicts = conflicts.clone();
+		let db = Arc::clone(&db);
+		let barrier = Arc::clone(&barrier);
+		let conflicts = Arc::clone(&conflicts);
 		handles.push(thread::spawn(move || {
 			barrier.wait();
 			for round in 0..ROUNDS {
@@ -218,10 +218,10 @@ fn ssi_increment_counter_under_contention() {
 	let conflicts = Arc::new(AtomicU64::new(0));
 	let mut handles = Vec::new();
 	for _ in 0..THREADS {
-		let db = db.clone();
-		let barrier = barrier.clone();
-		let conflicts = conflicts.clone();
-		let successes = successes.clone();
+		let db = Arc::clone(&db);
+		let barrier = Arc::clone(&barrier);
+		let conflicts = Arc::clone(&conflicts);
+		let successes = Arc::clone(&successes);
 		handles.push(thread::spawn(move || {
 			barrier.wait();
 			for _ in 0..ROUNDS {
@@ -298,8 +298,8 @@ fn snapshot_reader_sees_consistent_value_for_pinned_key() {
 	let read_tx = db.transaction(false).with_snapshot_isolation();
 
 	let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
-	let writer_db = db.clone();
-	let writer_stop = stop.clone();
+	let writer_db = Arc::clone(&db);
+	let writer_stop = Arc::clone(&stop);
 	let writer = thread::spawn(move || {
 		let mut rev = 0u32;
 		while !writer_stop.load(Ordering::Relaxed) {
@@ -353,8 +353,8 @@ fn many_readers_during_inserts() {
 
 	let mut reader_handles = Vec::new();
 	for _ in 0..READERS {
-		let db = db.clone();
-		let stop = stop.clone();
+		let db = Arc::clone(&db);
+		let stop = Arc::clone(&stop);
 		reader_handles.push(thread::spawn(move || {
 			for _ in 0..READER_OPS {
 				if stop.load(Ordering::Relaxed) {
@@ -369,7 +369,7 @@ fn many_readers_during_inserts() {
 		}));
 	}
 
-	let writer_db = db.clone();
+	let writer_db = Arc::clone(&db);
 	let writer = thread::spawn(move || {
 		for i in 0..WRITER_KEYS {
 			let mut tx = writer_db.transaction(true);
@@ -409,8 +409,8 @@ fn concurrent_deletes_no_phantom_within_snapshot() {
 	}
 
 	let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
-	let deleter_db = db.clone();
-	let deleter_stop = stop.clone();
+	let deleter_db = Arc::clone(&db);
+	let deleter_stop = Arc::clone(&stop);
 	let deleter = thread::spawn(move || {
 		// Delete keys gradually
 		for i in 0..TOTAL_KEYS {
@@ -429,7 +429,7 @@ fn concurrent_deletes_no_phantom_within_snapshot() {
 	// Readers verify that within their snapshot, observed keys stay observed.
 	let mut reader_handles = Vec::new();
 	for _ in 0..4 {
-		let db = db.clone();
+		let db = Arc::clone(&db);
 		reader_handles.push(thread::spawn(move || {
 			for _ in 0..30 {
 				let mut tx = db.transaction(false);
@@ -492,9 +492,9 @@ fn sustained_mixed_workload_prefix_keys() {
 
 	let mut handles = Vec::new();
 	for tid in 0..THREADS {
-		let db = db.clone();
-		let seen_values = seen_values.clone();
-		let barrier = barrier.clone();
+		let db = Arc::clone(&db);
+		let seen_values = Arc::clone(&seen_values);
+		let barrier = Arc::clone(&barrier);
 		handles.push(thread::spawn(move || {
 			barrier.wait();
 			let start = Instant::now();
@@ -583,9 +583,9 @@ fn hot_key_concurrent_writers_converge() {
 		Arc::new(std::sync::Mutex::new(BTreeSet::new()));
 	let mut handles = Vec::new();
 	for tid in 0..THREADS {
-		let db = db.clone();
-		let barrier = barrier.clone();
-		let written = written.clone();
+		let db = Arc::clone(&db);
+		let barrier = Arc::clone(&barrier);
+		let written = Arc::clone(&written);
 		handles.push(thread::spawn(move || {
 			barrier.wait();
 			for i in 0..PER_THREAD {

--- a/tests/prefix_concurrency.rs
+++ b/tests/prefix_concurrency.rs
@@ -603,6 +603,6 @@ fn hot_key_concurrent_writers_converge() {
 	let mut tx = db.transaction(false);
 	let val = tx.get(b"hotkey".to_vec()).unwrap().expect("hotkey must exist");
 	tx.cancel().unwrap();
-	let expected = written.lock().unwrap();
-	assert!(expected.contains(val.as_ref()), "latest value is not one of the committed writes");
+	let is_committed = written.lock().unwrap().contains(val.as_ref());
+	assert!(is_committed, "latest value is not one of the committed writes");
 }

--- a/tests/prefix_keys.rs
+++ b/tests/prefix_keys.rs
@@ -68,7 +68,7 @@ fn sequential_inserts_with_shared_prefix() {
 #[test]
 fn random_order_insert_with_shared_prefix() {
 	// Deterministic shuffle so failures are reproducible
-	let mut rng = rand::rngs::StdRng::seed_from_u64(0xfeedface);
+	let mut rng = rand::rngs::StdRng::seed_from_u64(0xfeed_face);
 	let mut indices: Vec<usize> = (0..LARGE).collect();
 	indices.shuffle(&mut rng);
 

--- a/tests/read_modify_write.rs
+++ b/tests/read_modify_write.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Read-modify-write pattern tests for SurrealMX.
+//! Read-modify-write pattern tests for `SurrealMX`.
 //!
 //! Tests common transactional patterns including increment, compare-and-swap,
 //! conditional updates, and retry-on-conflict logic.
@@ -129,7 +129,7 @@ fn conditional_update_chain() {
 		let mut tx = db.transaction(true);
 		// Use putc to ensure atomic state transition
 		let result = tx.putc("state", new_state, Some::<&str>(expected));
-		assert!(result.is_ok(), "Transition from {} to {} should succeed", expected, new_state);
+		assert!(result.is_ok(), "Transition from {expected} to {new_state} should succeed");
 		tx.commit().unwrap();
 	}
 
@@ -229,15 +229,12 @@ fn retry_on_conflict() {
 			tx.set("retry_counter", (current_val + 1).to_string()).unwrap();
 
 			// Try to commit
-			match tx.commit() {
-				Ok(_) => break,
-				Err(_) => {
-					retries += 1;
-					total_retries += 1;
-					if retries >= max_retries {
-						panic!("Exceeded max retries");
-					}
-				}
+			if let Ok(()) = tx.commit() {
+				break;
+			} else {
+				retries += 1;
+				total_retries += 1;
+				assert!(retries < max_retries, "Exceeded max retries");
 			}
 		}
 	}

--- a/tests/read_modify_write.rs
+++ b/tests/read_modify_write.rs
@@ -231,11 +231,10 @@ fn retry_on_conflict() {
 			// Try to commit
 			if let Ok(()) = tx.commit() {
 				break;
-			} else {
-				retries += 1;
-				total_retries += 1;
-				assert!(retries < max_retries, "Exceeded max retries");
 			}
+			retries += 1;
+			total_retries += 1;
+			assert!(retries < max_retries, "Exceeded max retries");
 		}
 	}
 

--- a/tests/recovery_edge.rs
+++ b/tests/recovery_edge.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Recovery edge case tests for SurrealMX.
+//! Recovery edge case tests for `SurrealMX`.
 //!
 //! Tests crash recovery scenarios including partial writes, corruption,
 //! and concurrent recovery attempts.
@@ -63,19 +63,16 @@ fn recovery_after_partial_aol_write() {
 	// The database should either:
 	// 1. Successfully recover, ignoring the garbage, OR
 	// 2. Return an error indicating corruption
-	match result {
-		Ok(db) => {
-			// If recovery succeeds, valid data should be present
-			let tx = db.transaction(false);
-			let value = tx.get("valid_key").unwrap();
-			// Value might be present (if garbage was ignored/truncated)
-			// or might not be (if recovery stopped before valid data)
-			// Just verify the database is operational
-			drop(value);
-		}
-		Err(_) => {
-			// Error is acceptable - it indicates corruption was detected
-		}
+	if let Ok(db) = result {
+		// If recovery succeeds, valid data should be present
+		let tx = db.transaction(false);
+		let value = tx.get("valid_key").unwrap();
+		// Value might be present (if garbage was ignored/truncated)
+		// or might not be (if recovery stopped before valid data)
+		// Just verify the database is operational
+		drop(value);
+	} else {
+		// Error is acceptable - it indicates corruption was detected
 	}
 }
 
@@ -110,7 +107,7 @@ fn recovery_with_corrupted_snapshot() {
 	for entry in fs::read_dir(temp_path).unwrap() {
 		let entry = entry.unwrap();
 		let path = entry.path();
-		if path.extension().map(|e| e == "snap").unwrap_or(false) {
+		if path.extension().is_some_and(|e| e == "snap") {
 			// Overwrite snapshot with garbage
 			fs::write(&path, b"CORRUPTED_SNAPSHOT_DATA").unwrap();
 		}
@@ -121,16 +118,13 @@ fn recovery_with_corrupted_snapshot() {
 	// 2. Return an error
 	let result = Database::new_with_persistence(db_opts, persistence_opts);
 
-	match result {
-		Ok(db) => {
-			// If recovery succeeds via AOL, data might still be present
-			let tx = db.transaction(false);
-			// Database is operational, that's what matters
-			let _ = tx.get("key1");
-		}
-		Err(_) => {
-			// Error is acceptable for corrupted snapshot
-		}
+	if let Ok(db) = result {
+		// If recovery succeeds via AOL, data might still be present
+		let tx = db.transaction(false);
+		// Database is operational, that's what matters
+		let _ = tx.get("key1");
+	} else {
+		// Error is acceptable for corrupted snapshot
 	}
 }
 

--- a/tests/recovery_edge.rs
+++ b/tests/recovery_edge.rs
@@ -245,7 +245,7 @@ fn concurrent_recovery_attempts() {
 
 	// Create initial data
 	{
-		let db = Database::new_with_persistence(db_opts.clone(), persistence_opts.clone()).unwrap();
+		let db = Database::new_with_persistence(db_opts.clone(), persistence_opts).unwrap();
 
 		let mut tx = db.transaction(true);
 		tx.set("shared_key", "shared_value").unwrap();

--- a/tests/savepoints.rs
+++ b/tests/savepoints.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Savepoint functionality tests for SurrealMX.
+//! Savepoint functionality tests for `SurrealMX`.
 //!
 //! Tests `set_savepoint()` and `rollback_to_savepoint()` behavior
 //! including nested savepoints and edge cases.
@@ -399,12 +399,12 @@ fn savepoint_stress_many_savepoints() {
 	// Create many nested savepoints
 	for i in 0..num_savepoints {
 		tx.set_savepoint().unwrap();
-		tx.set(format!("key_{}", i), format!("value_{}", i)).unwrap();
+		tx.set(format!("key_{i}"), format!("value_{i}")).unwrap();
 	}
 
 	// Verify all keys exist
 	for i in 0..num_savepoints {
-		assert!(tx.get(format!("key_{}", i)).unwrap().is_some());
+		assert!(tx.get(format!("key_{i}")).unwrap().is_some());
 	}
 
 	// Rollback half of them
@@ -414,12 +414,12 @@ fn savepoint_stress_many_savepoints() {
 
 	// First half should still exist
 	for i in 0..(num_savepoints / 2) {
-		assert!(tx.get(format!("key_{}", i)).unwrap().is_some(), "key_{} should exist", i);
+		assert!(tx.get(format!("key_{i}")).unwrap().is_some(), "key_{i} should exist");
 	}
 
 	// Second half should not exist
 	for i in (num_savepoints / 2)..num_savepoints {
-		assert!(tx.get(format!("key_{}", i)).unwrap().is_none(), "key_{} should not exist", i);
+		assert!(tx.get(format!("key_{i}")).unwrap().is_none(), "key_{i} should not exist");
 	}
 
 	tx.commit().unwrap();

--- a/tests/scan_out_of_range.rs
+++ b/tests/scan_out_of_range.rs
@@ -146,9 +146,8 @@ fn run_once(budget: Duration) -> (usize, usize, usize) {
 				let tx = db.transaction(false).with_snapshot_isolation();
 				let beg_b = Bytes::copy_from_slice(&beg);
 				let end_b = Bytes::copy_from_slice(&end);
-				let res = match tx.scan(beg_b..end_b, None, None) {
-					Ok(r) => r,
-					Err(_) => continue,
+				let Ok(res) = tx.scan(beg_b..end_b, None, None) else {
+					continue;
 				};
 				scans_done.fetch_add(1, Ordering::Relaxed);
 				for (k, v) in res {
@@ -193,9 +192,10 @@ fn run_once(budget: Duration) -> (usize, usize, usize) {
 }
 
 fn hex(b: &[u8]) -> String {
+	use std::fmt::Write as _;
 	let mut s = String::with_capacity(b.len() * 2);
 	for c in b {
-		s.push_str(&format!("{c:02x}"));
+		let _ = write!(s, "{c:02x}");
 	}
 	s
 }

--- a/tests/scan_out_of_range.rs
+++ b/tests/scan_out_of_range.rs
@@ -4,7 +4,7 @@
 //!
 //! Symptom (in the parent project): a range scan against
 //! `[/*0*0*aaa+ix!dc\0 , /*0*0*aaa+ix!dc\xff*40)` would occasionally
-//! return keys with a *different* IndexId (different bytes inside the
+//! return keys with a *different* `IndexId` (different bytes inside the
 //! shared prefix) and a *different* category byte (`!tt`, `!dl`, …).
 //! The decode of the value as `DocLengthAndCount` then failed with
 //! either "Invalid revision 0" (8-byte u64 doc-length value) or
@@ -32,7 +32,7 @@ use std::time::{Duration, Instant};
 
 use surrealmx::Database;
 
-/// Build a key shaped like SurrealDB's index keys:
+/// Build a key shaped like `SurrealDB`'s index keys:
 ///   `/ * 00 00 00 00 * 00 00 00 00 * aaa \0 + <ix:4 BE> ! <kind:2> <doc:8 BE> <nid:16> <uid:16>`
 /// `nid`/`uid` are filled with a counter so writers don't collide on the same
 /// key — every put is a fresh delta-style key, like the full-text index does.
@@ -95,7 +95,7 @@ fn run_once(budget: Duration) -> (usize, usize, usize) {
 		let stop = Arc::clone(&stop);
 		let writes_done = Arc::clone(&writes_done);
 		writers.push(thread::spawn(move || {
-			let mut counter: u128 = (ix as u128 + 1) << 96;
+			let mut counter: u128 = (u128::from(ix) + 1) << 96;
 			let mut doc: u64 = 0;
 			while !stop.load(Ordering::Relaxed) {
 				for &kind in KINDS {
@@ -195,7 +195,7 @@ fn run_once(budget: Duration) -> (usize, usize, usize) {
 fn hex(b: &[u8]) -> String {
 	let mut s = String::with_capacity(b.len() * 2);
 	for c in b {
-		s.push_str(&format!("{:02x}", c));
+		s.push_str(&format!("{c:02x}"));
 	}
 	s
 }

--- a/tests/scan_out_of_range.rs
+++ b/tests/scan_out_of_range.rs
@@ -72,14 +72,13 @@ fn make_range(ix: u32, kind: [u8; 2]) -> (Vec<u8>, Vec<u8>) {
 fn run_once(budget: Duration) -> (usize, usize, usize) {
 	const N_INDEXES: u32 = 5;
 	const SCAN_IX: u32 = 3;
-	const SCAN_KIND: [u8; 2] = [b'd', b'c'];
+	const SCAN_KIND: [u8; 2] = *b"dc";
 
 	// All the (ix, kind) combinations that the writers will hit. The mix
 	// matters: full-text writes `!dc`, `!dl`, `!td`, `!tt`, `!ii`, `!tv`,
 	// etc., spread over `N_INDEXES` indexes. We just pick the same letter
 	// pairs from the real code.
-	const KINDS: &[[u8; 2]] =
-		&[[b'd', b'c'], [b'd', b'l'], [b't', b'd'], [b't', b't'], [b'i', b'i'], [b't', b'v']];
+	const KINDS: &[[u8; 2]] = &[*b"dc", *b"dl", *b"td", *b"tt", *b"ii", *b"tv"];
 
 	let db = Arc::new(Database::new());
 	let stop = Arc::new(AtomicBool::new(false));
@@ -106,10 +105,10 @@ fn run_once(budget: Duration) -> (usize, usize, usize) {
 					let key = make_key(ix, kind, doc, counter);
 					counter = counter.wrapping_add(1);
 					doc = doc.wrapping_add(1);
-					let value: Vec<u8> = if kind == [b'd', b'l'] {
+					let value: Vec<u8> = if kind == *b"dl" {
 						// DocLength-style value: 8 bytes, starts with zero.
 						doc.to_be_bytes().to_vec()
-					} else if kind == [b't', b't'] {
+					} else if kind == *b"tt" {
 						// Tt-style value: empty.
 						Vec::new()
 					} else {

--- a/tests/snapshot_concurrent.rs
+++ b/tests/snapshot_concurrent.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Concurrent snapshot operation tests for SurrealMX.
+//! Concurrent snapshot operation tests for `SurrealMX`.
 //!
 //! Tests snapshot behavior under concurrent access including writes during
 //! snapshot, multiple concurrent snapshots, and reads during snapshot.
@@ -44,7 +44,7 @@ fn snapshot_during_writes() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..50 {
-			tx.set(format!("initial_{:03}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("initial_{i:03}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -70,7 +70,7 @@ fn snapshot_during_writes() {
 		barrier2.wait();
 		for i in 0..50 {
 			let mut tx = db2.transaction(true);
-			tx.set(format!("concurrent_{:03}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("concurrent_{i:03}"), format!("value_{i}")).unwrap();
 			tx.commit().unwrap();
 		}
 	});
@@ -111,7 +111,7 @@ fn multiple_concurrent_snapshots() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("key_{:04}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("key_{i:04}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -167,7 +167,7 @@ fn read_during_snapshot() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("read_key_{:04}", i), format!("value_{}", i)).unwrap();
+			tx.set(format!("read_key_{i:04}"), format!("value_{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -194,7 +194,7 @@ fn read_during_snapshot() {
 		let mut read_count = 0;
 		for i in 0..100 {
 			let tx = db2.transaction(false);
-			let key = format!("read_key_{:04}", i);
+			let key = format!("read_key_{i:04}");
 			if tx.get(&key).unwrap().is_some() {
 				read_count += 1;
 			}
@@ -233,7 +233,7 @@ fn recovery_from_concurrent_snapshot() {
 		{
 			let mut tx = db.transaction(true);
 			for i in 0..50 {
-				tx.set(format!("before_snap_{:03}", i), "before").unwrap();
+				tx.set(format!("before_snap_{i:03}"), "before").unwrap();
 			}
 			tx.commit().unwrap();
 		}
@@ -247,7 +247,7 @@ fn recovery_from_concurrent_snapshot() {
 		{
 			let mut tx = db.transaction(true);
 			for i in 0..50 {
-				tx.set(format!("after_snap_{:03}", i), "after").unwrap();
+				tx.set(format!("after_snap_{i:03}"), "after").unwrap();
 			}
 			tx.commit().unwrap();
 		}

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -25,9 +25,9 @@ fn concurrent_random_transactions() {
 	// Spin up a number of threads
 	for _ in 0..THREADS {
 		// Clone the database
-		let db = db.clone();
+		let db = Arc::clone(&db);
 		// Clone the expected modifications
-		let expected = expected.clone();
+		let expected = Arc::clone(&expected);
 		// Store the reference to the thread
 		handles.push(thread::spawn(move || {
 			let mut rng = rand::rng();

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -75,7 +75,7 @@ fn concurrent_random_transactions() {
 		let key = Bytes::from(key_num.to_be_bytes().to_vec());
 		let val = tx.get(&key).unwrap();
 		let expected_val = snapshot.get(&key).cloned().unwrap_or(None);
-		assert_eq!(val, expected_val, "mismatch for key {}", key_num);
+		assert_eq!(val, expected_val, "mismatch for key {key_num}");
 	}
 	tx.cancel().unwrap();
 }

--- a/tests/transaction_lifecycle.rs
+++ b/tests/transaction_lifecycle.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Transaction lifecycle tests for SurrealMX.
+//! Transaction lifecycle tests for `SurrealMX`.
 //!
 //! Tests transaction management edge cases including long-lived transactions,
 //! transaction drop behavior, and high transaction counts.
@@ -51,7 +51,7 @@ fn long_lived_read_transaction() {
 	// Perform many updates while read transaction is open
 	for i in 2..20 {
 		let mut tx = db.transaction(true);
-		tx.set("key", format!("v{}", i)).unwrap();
+		tx.set("key", format!("v{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -124,7 +124,7 @@ fn many_concurrent_transactions() {
 
 			thread::spawn(move || {
 				for tx_num in 0..transactions_per_thread {
-					let key = format!("t{}_{}", thread_id, tx_num);
+					let key = format!("t{thread_id}_{tx_num}");
 
 					// Write transaction
 					{
@@ -137,7 +137,7 @@ fn many_concurrent_transactions() {
 					{
 						let tx = db.transaction(false);
 						let value = tx.get(&key).unwrap();
-						assert!(value.is_some(), "Key {} should exist", key);
+						assert!(value.is_some(), "Key {key} should exist");
 					}
 				}
 			})
@@ -182,7 +182,7 @@ fn transaction_after_gc() {
 	// Update multiple times to create versions
 	for i in 2..10 {
 		let mut tx = db.transaction(true);
-		tx.set("gc_test_key", format!("v{}", i)).unwrap();
+		tx.set("gc_test_key", format!("v{i}")).unwrap();
 		tx.commit().unwrap();
 	}
 
@@ -218,7 +218,7 @@ fn read_transaction_longevity() {
 	{
 		let mut tx = db.transaction(true);
 		for i in 0..100 {
-			tx.set(format!("longevity_{:03}", i), format!("v{}", i)).unwrap();
+			tx.set(format!("longevity_{i:03}"), format!("v{i}")).unwrap();
 		}
 		tx.commit().unwrap();
 	}
@@ -240,7 +240,7 @@ fn read_transaction_longevity() {
 				for i in 0..20 {
 					let mut tx = db.transaction(true);
 					let key = format!("longevity_{:03}", (thread_id * 20 + i) % 100);
-					tx.set(&key, format!("modified_by_{}", thread_id)).unwrap();
+					tx.set(&key, format!("modified_by_{thread_id}")).unwrap();
 					tx.commit().unwrap();
 				}
 			})


### PR DESCRIPTION
Makes clippy strict. Eight commits, each one green on its own, ordered so the code is fixed before the config that requires it is turned on.

## Why not just pick a preset

There is no good off-the-shelf strict preset. Clippy ships four groups (`pedantic`, `nursery`, `restriction`, `cargo`) and no curated bundle; `restriction` is explicitly not meant to be enabled wholesale. So this does two things at once:

- Adopts the lint set from `surrealdb/surrealdb`'s `[workspace.lints.clippy]`, so the two repos agree on house style.
- Adds the whole `pedantic` group on top, which that repo cannot afford. `pedantic` over ~300k LOC is not tractable; surrealmx is ~12k LOC of library code and can take the entire group. Every opt-out carries its reason inline in `Cargo.toml`.

Config lives in a `[lints]` table rather than `#![deny]` in `lib.rs`, so it covers tests and benchmarks too.

## The starting point

- **The Clippy CI job was already red** on the current stable toolchain: 9 `byte_char_slices` warnings against `-D warnings`.
- **`#![allow(clippy::bool_comparison)]` in `lib.rs`** was suppressing the `if x == true` lint, and 27 sites in `tx.rs` had grown under it. That allow was also a divergence from surrealdb's own set, which does not allow it.
- No `[lints]` table and no `clippy.toml`. The entire lint policy was that one `allow`.

## What the stricter lints actually found

**Locks held across blocking joins.** `significant_drop_in_scrutinee` flagged eight shutdown paths shaped like:

```rust
if let Some(handle) = persistence.fsync_handle.write().take() {
    let _ = handle.join();   // write guard still held here
}
```

The guard lives to the end of the `if let`, so shutdown held the lock for the whole join, while `Persistence::append` takes that same lock on the commit path to unpark the appender. Three more sites held a per-key version guard or the persistence guard across file I/O and fsync.

**41 unwraps in the library**, all provably infallible and all silent about why. Now `expect` against a named invariant, so a broken assumption identifies itself: `Transaction::inner` (30 sites, an `Option` only so `Drop` can return it to the pool) and the merge iterator heads (11 sites, safe only because `winner`/`next_source` was derived from the very head being unwrapped — exactly what a reordering would break).

**Zero `unsafe` in the whole repo**, so `unsafe_code = "forbid"` is free and now locked in.

## Four places the lint was wrong

Worth reviewing, because following clippy here would have introduced bugs:

- `Inner::run_gc_tracked` / `run_gc_full` — the version write guard must cover `entry.remove()`, so a committer blocked on it sees `is_removed()` and re-inserts instead of writing into a node about to be unlinked. `#[expect]` with the invariant.
- `Persistence::append` / `truncate` — the AOL file guard must cover the `pending_syncs` store, or a concurrent append's increment is discarded along with its required fsync. `#[expect]`.
- `needless_collect` — all three findings were the spawn-then-join pattern in the concurrency tests, and the suggested fix fuses the two iterator chains. Iterators being lazy, that spawns thread *i*, joins it, then spawns *i+1*, serialising the threads and silently gutting the tests. Set to `allow` with that written down so nobody "fixes" it later.
- `indexing_slicing` — all 11 findings are internally derived and provably in bounds (a slice guarded by a `len()` check one line above, `enumerate()` indices into the vector being enumerated, bloom bits masked to the filter width). `.get(i).expect(..)` panics identically and reads worse. Left off.

Same reasoning applied to `needless_pass_by_value` and `similar_names`: 8 findings between them, all this crate's deliberate conventions, both allowed with the rationale recorded.

## CI

The existing job stays as-is. A second, stricter pass runs over `--lib` only, denying `unwrap_used`, `get_unwrap`, `panic`, `missing_docs`, and the three cast lints. These matter in the engine but are noise in tests and benchmarks, which unwrap and cast freely and correctly, and Cargo's `[lints]` table cannot be scoped per-target. The library is clean on all of them today, so it is a ratchet, not a cleanup.

## Two pre-existing bugs found, neither fixed here

Both are out of scope for a lint pass and want their own PR:

1. **`tests/stress.rs::concurrent_random_transactions` is flaky** — fails on a visibility mismatch (a committed key reads as `None`) at roughly 5/40 runs on the untouched v0.23.0 release commit `be20bb8`. This branch measures 3/40, so it is neither introduced nor worsened here, but it looks like a real MVCC bug rather than a flaky assertion.

2. **`exists` and `put` ignore same-transaction delete tombstones.** `del` records `writeset[key] = None`, but both check only for key presence:

   ```rust
   tx.del(k);
   tx.get(k)    // -> None                  correct
   tx.exists(k) // -> true                   wrong
   tx.put(k, v) // -> Err(KeyAlreadyExists)  wrong
   ```

   `get` reads through the tombstone correctly; `exists` and `put` do not, so you cannot delete then re-put a key within one transaction. Confirmed identical on `be20bb8`, so the refactor here did not introduce it.

## Verification

Every commit was checked against all five CI gates: both clippy passes, `cargo fmt --check`, the `wasm32-unknown-unknown` check, `cargo bench --no-run`, and the full test suite (27 suites). Also fixed a pre-existing release-only warning surfaced while verifying the bench job: `LOG_TARGET_CONFLICTS` and `tracing::debug` are only used inside `#[cfg(debug_assertions)]` blocks, so both imports were unused in release and bench builds.

The behaviour-preserving claims worth spot-checking: `contains_key` is exactly the old `Some(_)` match arm, and the `||` in `put` short-circuits in the same order the nested `if` did.
